### PR TITLE
Fix UB left shift in zigzag encoding

### DIFF
--- a/src/rdvarint.h
+++ b/src/rdvarint.h
@@ -66,7 +66,7 @@ size_t rd_uvarint_enc_u64 (char *dst, size_t dstsize, uint64_t num) {
  */
 static RD_INLINE RD_UNUSED
 size_t rd_uvarint_enc_i64 (char *dst, size_t dstsize, int64_t num) {
-        return rd_uvarint_enc_u64(dst, dstsize, (num << 1) ^ (num >> 63));
+        return rd_uvarint_enc_u64(dst, dstsize, ((uint64_t)num << 1) ^ (num >> 63));
 }
 
 


### PR DESCRIPTION
Fixes an issue in #2403 

Neither latest gcc/clang seem to have codegen differences based
on this change, and are unlikely ever to since left shift of
negative isn't UB in c++20. It's still worth fixing to get
less print outs when running with fsanitize=undefined

