### PR TITLE
Proposal for broker rack metadata using private type

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -235,6 +235,7 @@ typedef struct rd_kafka_topic_conf_s rd_kafka_topic_conf_t;
 typedef struct rd_kafka_queue_s rd_kafka_queue_t;
 typedef struct rd_kafka_op_s rd_kafka_event_t;
 typedef struct rd_kafka_topic_result_s rd_kafka_topic_result_t;
+typedef struct rd_kafka_metadata_broker_extended_s rd_kafka_metadata_broker_extended_t;
 /* @endcond */
 
 
@@ -3869,6 +3870,7 @@ typedef struct rd_kafka_metadata_broker {
         int         port;           /**< Broker listening port */
 } rd_kafka_metadata_broker_t;
 
+
 /**
  * @brief Partition information
  */
@@ -3936,6 +3938,65 @@ rd_kafka_metadata (rd_kafka_t *rk, int all_topics,
  */
 RD_EXPORT
 void rd_kafka_metadata_destroy(const struct rd_kafka_metadata *metadata);
+
+
+/**
+ * @brief Generates a handle for retrieving extended metadata (i.e. rack) from
+ * broker \p i in the given \p metadata's broker array.
+ * 
+ * * Parameters:
+ *  - \p metadata       pointer to metadata result.
+ *  - \p i              index of broker in the metadata struct's broker array.
+ *
+ * @returns returns an opaque handle for use with the rd_kafka_metadata_broker_XX
+ * accessor methods.
+ *
+ * @remarks this function should only be used with broker metadata generated from a
+ * rd_kafka_metadata call.
+ *
+ */
+RD_EXPORT rd_kafka_metadata_broker_extended_t *
+rd_kafka_metadata_broker_get(const rd_kafka_metadata_t *metadata, int i);
+
+
+/**
+ * @brief Retrieves the broker id.
+ *
+ * @returns broker id (integer)
+ *
+ */
+RD_EXPORT
+int32_t rd_kafka_metadata_broker_id (const rd_kafka_metadata_broker_extended_t *mdb);
+
+
+/**
+ * @brief Retrieves the broker's host name.
+ *
+ * @returns broker host
+ *
+ */
+RD_EXPORT
+const char *rd_kafka_metadata_broker_host (const rd_kafka_metadata_broker_extended_t *mdb);
+
+
+/**
+ * @brief Retrieves the broker's port.
+ *
+ * @returns broker port (integer)
+ *
+ */
+RD_EXPORT
+int rd_kafka_metadata_broker_port (const rd_kafka_metadata_broker_extended_t *mdb);
+
+
+/**
+ * @brief Retrieves the broker's rack identifier.
+ *
+ * @returns broker rack
+ *
+ */
+RD_EXPORT
+const char *rd_kafka_metadata_broker_rack (const rd_kafka_metadata_broker_extended_t *mdb);
 
 
 /**@}*/

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -357,13 +357,18 @@ rd_tmpabuf_write_str0 (const char *func, int line,
         } while (0)
 
 /* Read Kafka String representation (2+N) and write it to the \p tmpabuf
- * with a trailing nul byte. */
+ * with a trailing nul byte. If the marshalled string is nul, nothing is
+ * written to the \p tmpabuf and the \p dst string is set to NULL. */
 #define rd_kafka_buf_read_str_tmpabuf(rkbuf, tmpabuf, dst) do {		\
                 rd_kafkap_str_t _kstr;					\
 		size_t _slen;						\
 		char *_dst;						\
 		rd_kafka_buf_read_str(rkbuf, &_kstr);			\
-		_slen = RD_KAFKAP_STR_LEN(&_kstr);			\
+                if (RD_KAFKAP_STR_IS_NULL(&_kstr)) {                    \
+                        dst = NULL;                                     \
+                        break;                                          \
+                }                                                       \
+                _slen = RD_KAFKAP_STR_LEN(&_kstr);                      \
 		if (!(_dst =						\
 		      rd_tmpabuf_write(tmpabuf, _kstr.str, _slen+1)))	\
 			rd_kafka_buf_parse_fail(			\

--- a/src/rdkafka_metadata.h
+++ b/src/rdkafka_metadata.h
@@ -161,5 +161,7 @@ void rd_kafka_metadata_cache_destroy (rd_kafka_t *rk);
 int  rd_kafka_metadata_cache_wait_change (rd_kafka_t *rk, int timeout_ms);
 void rd_kafka_metadata_cache_dump (FILE *fp, rd_kafka_t *rk);
 
+int unittest_metadata (void);
+
 /**@}*/
 #endif /* _RDKAFKA_METADATA_H_ */

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -408,6 +408,7 @@ int rd_unittest (void) {
 #endif
                 { "conf", unittest_conf },
                 { "broker", unittest_broker },
+                { "metadata", unittest_metadata },
                 { "request", unittest_request },
 #if WITH_SASL_OAUTHBEARER
                 { "sasl_oauthbearer", unittest_sasl_oauthbearer },

--- a/tests/0105-broker_metadata.c
+++ b/tests/0105-broker_metadata.c
@@ -1,0 +1,141 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2012-2013, Magnus Edenhill
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer. 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Tests the extended broker metadata API.
+ */
+
+#include "test.h"
+
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is built from within the librdkafka source tree and thus differs. */
+#include "rdkafka.h"  /* for Kafka driver */
+
+
+
+int main_0105_broker_metadata (int argc, char **argv) {
+	char topic[64];
+	rd_kafka_t *rk;
+	rd_kafka_topic_t *rkt;
+	rd_kafka_conf_t *conf;
+	rd_kafka_topic_conf_t *topic_conf;
+	const rd_kafka_metadata_t *md = NULL;
+	rd_kafka_resp_err_t err;
+	int i;
+
+	/* Generate unique topic name */
+	test_conf_init(&conf, &topic_conf, 10);
+
+	rd_snprintf(topic, sizeof(topic), "rdkafkatest1_unk_%x%x",
+		 rand(), rand());
+
+	/* Create kafka instance */
+	rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+	rkt = rd_kafka_topic_new(rk, topic, topic_conf);
+	if (!rkt)
+		TEST_FAIL("Failed to create topic: %s\n",
+			  	  strerror(errno));
+
+	
+	err = rd_kafka_metadata(rk, 0, rkt, &md, 5000);
+	if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
+		TEST_FAIL("Failed to get metadata: %s\n",
+			  	  strerror(errno));
+
+	if (!md) {
+		TEST_FAIL("Metadata was not assigned\n");
+	}
+
+	TEST_SAY("Broker count: %d\n", md->broker_cnt);
+	if (md->broker_cnt <= 0) {
+		// TODO verify broker count
+		TEST_FAIL("Invalid broker count: %"PRId32"\n",
+				  md->broker_cnt);
+	}
+
+	for (i = 0; i < md->broker_cnt; i++) {
+		const rd_kafka_metadata_broker_extended_t *b;
+		const char *host, *rack;
+		int port;
+		int32_t bid;
+
+		b = rd_kafka_metadata_broker_get(md, i);
+		if (!b) {
+			TEST_FAIL("broker (%d/%d) return null\n",
+					  i, md->broker_cnt);
+		}
+
+		bid = rd_kafka_metadata_broker_id(b);
+		host = rd_kafka_metadata_broker_host(b);
+		port = rd_kafka_metadata_broker_port(b);
+		rack = rd_kafka_metadata_broker_rack(b);
+
+		TEST_SAY("Broker (%d/%d): %s:%d (Rack: %s) Node %d\n",
+				 i, md->broker_cnt, host, port, rack, bid);
+
+		if (strcmp(host, "localhost") != 0) {
+			TEST_FAIL("unexpected host: %s\n", host);
+		}
+		if (bid <= 0) {
+			TEST_FAIL("unexpected broker id: %d\n", bid);
+		}
+		if (port <= 0) {
+			TEST_FAIL("unexpected port: %d\n", port);
+		}
+		if (rack) {
+			TEST_FAIL("expected rack to be NULL");
+		}
+
+		// ABI backwards-compatibility checks
+		if (md->brokers[i].id != bid) {
+			TEST_FAIL("ABI compatibility check failed: "
+					  "id %d != %d\n",
+					  md->brokers[i].id, bid);
+		}
+		if (strcmp(md->brokers[i].host, host) != 0) {
+			TEST_FAIL("ABI compatibility check failed: "
+					  "host \"%s\" != \"%s\"\n",
+					  md->brokers[i].host, host);
+		}
+		if (md->brokers[i].port != port) {
+			TEST_FAIL("ABI compatibility check failed: "
+					  "port %d != %d\n",
+					  md->brokers[i].port, port);
+		}
+	}
+
+	/* Destroy topic */
+	rd_kafka_topic_destroy(rkt);
+
+	/* Destroy rdkafka instance */
+	TEST_SAY("Destroying kafka instance %s\n", rd_kafka_name(rk));
+	rd_kafka_destroy(rk);
+
+	return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ set(
     0101-fetch-from-follower.cpp
     0102-static_group_rebalance.c
     0104-fetch_from_follower_mock.c
+    0105-broker_metadata.c
     8000-idle.cpp
     test.c
     testcpp.cpp

--- a/tests/test.c
+++ b/tests/test.c
@@ -206,6 +206,7 @@ _TEST_DECL(0100_thread_interceptors);
 _TEST_DECL(0101_fetch_from_follower);
 _TEST_DECL(0102_static_group_rebalance);
 _TEST_DECL(0104_fetch_from_follower_mock);
+_TEST_DECL(0105_broker_metadata);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -380,6 +381,7 @@ struct test tests[] = {
               TEST_BRKVER(2,3,0,0)),
         _TEST(0104_fetch_from_follower_mock, TEST_F_LOCAL,
               TEST_BRKVER(2,4,0,0)),
+        _TEST(0105_broker_metadata, 0, TEST_BRKVER(0,9,0,0)),
 
         /* Manual tests */
         _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="..\..\tests\0101-fetch-from-follower.cpp" />
     <ClCompile Include="..\..\tests\0102-static_group_rebalance.c" />
     <ClCompile Include="..\..\tests\0104-fetch_from_follower_mock.c" />
+    <ClCompile Include="..\..\tests\0105-broker_metadata.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />


### PR DESCRIPTION
This proposed change intends to expose the rack field on broker metadata without breaking backwards ABI compatibility, by relying on private types and accessor methods.

The idea is that we can hang additional fields (i.e. rack) off of the `char *host` pointer on the public `struct rd_kafka_metadata_broker` type, as long as the host string is the first thing found at the memory location it points to. I'm introducing a new private type for extended broker metadata  (`struct rd_kafka_metadata_broker_extended`), which instead of the host field, contains a pointer to an extension struct.

```
typedef struct rd_kafka_metadata_broker_extended_s {
        int32_t                         id;     /**< Broker Id */
        rd_kafka_metadata_broker_ext_t  *ext;   /**< Pointer to extended broker information */
        int                             port;   /**< Broker listening port */
} rd_kafka_metadata_broker_extended_t;
```
```
typedef struct rd_kafka_metadata_broker_ext_s {
        char       host[256];    /**< Broker hostname */
        const char *rack;                          /**< Broker rack */
} rd_kafka_metadata_broker_ext_t;
```
When a metadata response is parsed, the broker metadata will be unmarshalled into an array of  `rd_kafka_metadata_broker_extended_t` structs, however the returned broker metadata will still appear to the application as `struct rd_kafka_metadata_broker`. Since the `host` and `ext` pointers are of the same size and the host is a char array directly within the extension struct, applications compiled against previous library versions will not know the difference and can simply read the host string from the memory allocated to `ext` and pointed to by `host` as before.

The tradeoff here is that we must impose a limit on the host name length. However, according to the research I've done, host names on Unix systems are limited to 253 chars (see: http://man7.org/linux/man-pages/man7/hostname.7.html), while the POSIX standard guarantees it not to exceed 255 chars (http://man7.org/linux/man-pages/man3/sysconf.3.html). Of course, this also means that we must allocated 256 bytes for each broker host name, regardless of the actual length. I believe this to be a small tradeoff, however there may be ways to optimize.

In order to access the extended broker metadata fields (i.e. rack), the application must obtain a handle to an opaque `rd_kafka_metadata_broker_extended_s` value by calling `rd_kafka_metadata_broker_get(metadata, i)`, where `metadata` is the what's obtained from a metadata request and `i` is the index of the broker within the broker array. The following accessor methods may then be used to access the id, host, port and rack fields of the underlying value:

```
int32_t rd_kafka_metadata_broker_id (const rd_kafka_metadata_broker_extended_t *mdb);
const char *rd_kafka_metadata_broker_host (const rd_kafka_metadata_broker_extended_t *mdb);
int rd_kafka_metadata_broker_port (const rd_kafka_metadata_broker_extended_t *mdb);
const char *rd_kafka_metadata_broker_rack (const rd_kafka_metadata_broker_extended_t *mdb);
```

Please take a look and let me know if this seems like a sensible approach. I've included an integration test to test its validity. There is still some work to be done on the C++ implementation, but I wanted your feedback before continuing down this path. Looking forward to hearing your thoughts.