### PR TITLE
Add rd_kafka_poll_wake() to wake up threads blocked in rd_kafka_poll().

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3711,6 +3711,9 @@ int rd_kafka_poll (rd_kafka_t *rk, int timeout_ms) {
         return r;
 }
 
+void rd_kafka_poll_wake (rd_kafka_t *rk) {
+        rd_kafka_q_wake(rk->rk_rep);
+}
 
 rd_kafka_event_t *rd_kafka_queue_poll (rd_kafka_queue_t *rkqu, int timeout_ms) {
         rd_kafka_op_t *rko;

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -2912,6 +2912,11 @@ void *rd_kafka_topic_opaque (const rd_kafka_topic_t *rkt);
 RD_EXPORT
 int rd_kafka_poll(rd_kafka_t *rk, int timeout_ms);
 
+ /**
+ * @brief Wake any threads blocked in rd_kafka_poll().
+ */
+RD_EXPORT
+void rd_kafka_poll_wake(rd_kafka_t *rk);
 
 /**
  * @brief Cancels the current callback dispatcher (rd_kafka_poll(),

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -467,12 +467,14 @@ int rd_kafka_q_serve (rd_kafka_q_t *rkq, int timeout_ms,
 	}
 
         rd_timeout_init_timespec(&timeout_tspec, timeout_ms);
+        rkq->rkq_flags &= ~RD_KAFKA_Q_F_EXPLICIT_WAKE;
 
         /* Wait for op */
         while (!(rko = TAILQ_FIRST(&rkq->rkq_q)) &&
                !rd_kafka_q_check_yield(rkq) &&
                cnd_timedwait_abs(&rkq->rkq_cond, &rkq->rkq_lock,
-                                 &timeout_tspec) == thrd_success)
+                                 &timeout_tspec) == thrd_success &&
+               !(rkq->rkq_flags & ~RD_KAFKA_Q_F_EXPLICIT_WAKE))
                 ;
 
 	if (!rko) {

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -349,7 +349,7 @@ rd_kafka_q_yield (rd_kafka_q_t *rkq, rd_bool_t rate_limit) {
 
         if (!(fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
                 rkq->rkq_flags |= RD_KAFKA_Q_F_YIELD;
-                cnd_signal(&rkq->rkq_cond);
+                cnd_broadcast(&rkq->rkq_cond);
                 if (rkq->rkq_qlen == 0)
                         rd_kafka_q_io_event(rkq, rate_limit);
 


### PR DESCRIPTION
The idea is that if one thread is blocked in `rd_kafka_poll(rk, -1)`,
another thread can do `rd_kafka_poll_wake(rk)` to wake it up so
that we can cleanly join the polling thread and cleanly exit.

Addresses #614.

Upstreaming on the hope that if you take it, we don't have to maintain it as a patch anymore.