### PR TITLE
Fix out-of-bounds memory accesses in regex parsing

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -512,7 +512,8 @@ static int empty(Renode *node) {
         }
 }
 
-static Renode *newrep(Restate *g, Renode *atom, int ng, int min, int max) {
+static Renode *
+newrep(Restate *g, Renode *atom, int ng, unsigned char min, unsigned char max) {
         Renode *rep = newnode(g, P_REP);
         if (max == REPINF && empty(atom))
                 die(g, "infinite loop matching the empty string");
@@ -618,11 +619,14 @@ static Renode *parserep(Restate *g) {
 
         atom = parseatom(g);
         if (g->lookahead == L_COUNT) {
-                int min = g->yymin, max = g->yymax;
+                unsigned char min = g->yymin, max = g->yymax;
                 next(g);
+                if ((g->yymin & ~(0xff)) || (g->yymax & ~(0xff)))
+                        die(g,
+                            "invalid quantifier: min & max should be in "
+                            "[0-255]");
                 if (max < min)
                         die(g, "invalid quantifier");
-                return newrep(g, atom, re_accept(g, '?'), min, max);
         }
         if (re_accept(g, '*'))
                 return newrep(g, atom, re_accept(g, '?'), 0, REPINF);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -559,7 +559,8 @@ static Renode *parseatom(Restate *g) {
         }
         if (g->lookahead == L_REF) {
                 atom = newnode(g, P_REF);
-                if (g->yychar == 0 || g->yychar > g->nsub || !g->sub[g->yychar])
+                if (g->yychar == 0 || g->yychar >= g->nsub ||
+                    !g->sub[g->yychar])
                         die(g, "invalid back-reference");
                 atom->n = g->yychar;
                 atom->x = g->sub[g->yychar];


### PR DESCRIPTION
This PR fixes out-of-bounds memory accesses in regex parsing found by OSS-Fuzz.

#  Out-of-bounds write

The implicit casting from integer to unsigned char of min & max in `parserep` allowed a maliciously crafted input to bypass the `max < min` check in parserep. This would later lead to a mismatch between the result of `count` and the number of `emit` calls, resulting in an heap out-of-bounds write in `emit`.

Example input: `3{3,65}3{55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555553,65}35{61,}`

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27631
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27735

# Out-of-bounds read in `parseatom`

Example input: `((((((((((((((((\17+`

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28561

