### PR TITLE
KIP 368: SASL Reauthentication

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2342,6 +2342,9 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                 rk->rk_conf.security_protocol = RD_KAFKA_PROTO_PLAINTEXT;
         }
 
+        if (rk->rk_conf.sasl.enable_refresh)
+            rd_kafka_features_sasl_authenticate_update_kip368();
+
         if (rk->rk_conf.security_protocol == RD_KAFKA_PROTO_SASL_SSL ||
             rk->rk_conf.security_protocol == RD_KAFKA_PROTO_SASL_PLAINTEXT) {
                 /* Select SASL provider */

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -1706,7 +1706,8 @@ rd_kafka_broker_controller(rd_kafka_t *rk, int state, rd_ts_t abs_timeout) {
  * Find a waitresp (rkbuf awaiting response) by the correlation id.
  */
 static rd_kafka_buf_t *rd_kafka_waitresp_find(rd_kafka_broker_t *rkb,
-                                              int32_t corrid) {
+                                              int32_t corrid,
+                                              rd_bool_t skipStats) {
         rd_kafka_buf_t *rkbuf;
         rd_ts_t now = rd_clock();
 
@@ -1715,8 +1716,10 @@ static rd_kafka_buf_t *rd_kafka_waitresp_find(rd_kafka_broker_t *rkb,
         TAILQ_FOREACH(rkbuf, &rkb->rkb_waitresps.rkbq_bufs, rkbuf_link)
         if (rkbuf->rkbuf_corrid == corrid) {
                 /* Convert ts_sent to RTT */
-                rkbuf->rkbuf_ts_sent = now - rkbuf->rkbuf_ts_sent;
-                rd_avg_add(&rkb->rkb_avg_rtt, rkbuf->rkbuf_ts_sent);
+                if (unlikely(!skipStats)) {
+                    rkbuf->rkbuf_ts_sent = now - rkbuf->rkbuf_ts_sent;
+                    rd_avg_add(&rkb->rkb_avg_rtt, rkbuf->rkbuf_ts_sent);
+                }
 
                 if (rkbuf->rkbuf_flags & RD_KAFKA_OP_F_BLOCKING &&
                     rd_atomic32_sub(&rkb->rkb_blocking_request_cnt, 1) == 1)
@@ -1728,22 +1731,72 @@ static rd_kafka_buf_t *rd_kafka_waitresp_find(rd_kafka_broker_t *rkb,
         return NULL;
 }
 
-
+/**
+ * Find a waitresp (rkbuf awaiting response) by the correlation id.
+ */
+static rd_kafka_buf_t *rd_kafka_waitresp_find_peek(rd_kafka_broker_t *rkb,
+                                                   int32_t corrid) {
+        rd_kafka_buf_t *rkbuf;
+        rd_ts_t now = rd_clock();
+        rd_kafka_assert(rkb->rkb_rk, thrd_is_current(rkb->rkb_thread));
+        TAILQ_FOREACH(rkbuf, &rkb->rkb_waitresps.rkbq_bufs, rkbuf_link)
+        if (rkbuf->rkbuf_corrid == corrid) {
+                /* Convert ts_sent to RTT */
+                rkbuf->rkbuf_ts_sent = now - rkbuf->rkbuf_ts_sent;
+                rd_avg_add(&rkb->rkb_avg_rtt, rkbuf->rkbuf_ts_sent);
+                return rkbuf;
+        }
+        return NULL;
+}
 
 /**
  * Map a response message to a request.
  */
 static int rd_kafka_req_response(rd_kafka_broker_t *rkb,
-                                 rd_kafka_buf_t *rkbuf) {
-        rd_kafka_buf_t *req;
+                                 rd_kafka_buf_t *rkbuf,
+                                 rd_bool_t replay) {
+        rd_kafka_buf_t *req = NULL;
         int log_decode_errors = LOG_ERR;
 
         rd_kafka_assert(rkb->rkb_rk, thrd_is_current(rkb->rkb_thread));
 
+        
+    if (rkb->rkb_rk->rk_conf.sasl.enable_refresh) {
+                if (rkb->rkb_sasl.auth_in_progress == 1) {
+                        /* Find corresponding request message by correlation id
+                         */
+                        if (unlikely(!(req = rd_kafka_waitresp_find_peek(
+                                           rkb, rkbuf->rkbuf_reshdr.CorrId)))) {
+                                /* unknown response. probably due to request
+                                 * timeout */
+                                rd_atomic64_add(&rkb->rkb_c.rx_corrid_err, 1);
+                                rd_rkb_dbg(
+                                    rkb, BROKER, "RESPONSE",
+                                    "Response for unknown CorrId %" PRId32
+                                    " (timed out?)",
+                                    rkbuf->rkbuf_reshdr.CorrId);
+                                rd_kafka_buf_destroy(rkbuf);
+                                return -1;
+                        }
+
+                        /*if not related to sasl reauth (handshake or request)*/
+                        if ((req->rkbuf_reqhdr.ApiKey !=
+                             RD_KAFKAP_SaslAuthenticate) &&
+                            (req->rkbuf_reqhdr.ApiKey !=
+                             RD_KAFKAP_SaslHandshake)) {
+                                rkbuf->rkbuf_ts_sent =
+                                    req->rkbuf_ts_sent; /* copy rtt */
+                                /*hold these requests into another queue*/
+                                rd_kafka_bufq_enq(
+                                    &rkb->rkb_sasl.rkb_recv_reauth_buf, rkbuf);
+                                return 0;
+                        }
+                }
+        }
 
         /* Find corresponding request message by correlation id */
         if (unlikely(!(req = rd_kafka_waitresp_find(
-                           rkb, rkbuf->rkbuf_reshdr.CorrId)))) {
+                           rkb, rkbuf->rkbuf_reshdr.CorrId, replay)))) {
                 /* unknown response. probably due to request timeout */
                 rd_atomic64_add(&rkb->rkb_c.rx_corrid_err, 1);
                 rd_rkb_dbg(rkb, BROKER, "RESPONSE",
@@ -1812,6 +1865,18 @@ int rd_kafka_recv(rd_kafka_broker_t *rkb) {
         rd_kafka_resp_err_t err     = RD_KAFKA_RESP_ERR_NO_ERROR;
         const int log_decode_errors = LOG_ERR;
 
+        /* if auth not in progress, drain queue */
+        if (rkb->rkb_rk->rk_conf.sasl.enable_refresh) {
+                if (rkb->rkb_sasl.auth_in_progress == 0) {
+                        TAILQ_FOREACH(
+                            rkbuf, &rkb->rkb_sasl.rkb_recv_reauth_buf.rkbq_bufs,
+                            rkbuf_link) {
+                                rd_kafka_req_response(rkb, rkbuf, rd_true);
+                                rd_kafka_bufq_deq(
+                                    &rkb->rkb_sasl.rkb_recv_reauth_buf, rkbuf);
+                        }
+                }
+        }
 
         /* It is impossible to estimate the correct size of the response
          * so we split the read up in two parts: first we read the protocol
@@ -1910,7 +1975,7 @@ int rd_kafka_recv(rd_kafka_broker_t *rkb) {
                 rd_atomic64_add(&rkb->rkb_c.rx, 1);
                 rd_atomic64_add(&rkb->rkb_c.rx_bytes,
                                 rd_buf_write_pos(&rkbuf->rkbuf_buf));
-                rd_kafka_req_response(rkb, rkbuf);
+                rd_kafka_req_response(rkb, rkbuf, rd_false);
         }
 
         return 1;
@@ -2127,6 +2192,36 @@ static int rd_kafka_broker_connect(rd_kafka_broker_t *rkb) {
         return 1;
 }
 
+/**
+ * @brief Drain the requests that were received during the reauthentication process
+ *
+ * @locality Broker thread
+ */
+void rd_kafka_broker_drain_reauth_requests(rd_kafka_broker_t *rkb) {
+
+        rd_kafka_buf_t *rkbuf;
+        /*Add reauth queue to original queue*/
+        while (rkb->rkb_state >= RD_KAFKA_BROKER_STATE_UP &&
+               rd_kafka_bufq_cnt(&rkb->rkb_waitresps) < rkb->rkb_max_inflight &&
+               (rkbuf = TAILQ_FIRST(
+                    &rkb->rkb_sasl.rkb_req_during_auth.rkbq_bufs))) {
+
+                /*Remove from current reauth queue*/
+                rd_kafka_bufq_deq(&rkb->rkb_sasl.rkb_req_during_auth, rkbuf);
+
+                /*Hold these requests into outbuf queue*/
+                TAILQ_INSERT_HEAD(&rkb->rkb_outbufs.rkbq_bufs, rkbuf,
+                                  rkbuf_link);
+                rd_atomic32_add(&rkb->rkb_outbufs.rkbq_cnt, 1);
+                if (rkbuf->rkbuf_reqhdr.ApiKey == RD_KAFKAP_Produce)
+                        rd_atomic32_add(
+                            &rkb->rkb_outbufs.rkbq_msg_cnt,
+                            rd_kafka_msgq_len(&rkbuf->rkbuf_batch.msgq));
+        }
+
+        /*Set auth to complete*/
+        rkb->rkb_sasl.auth_in_progress = 0;
+}
 
 /**
  * @brief Call when connection is ready to transition to fully functional
@@ -2135,6 +2230,10 @@ static int rd_kafka_broker_connect(rd_kafka_broker_t *rkb) {
  * @locality Broker thread
  */
 void rd_kafka_broker_connect_up(rd_kafka_broker_t *rkb) {
+
+        if (rkb->rkb_rk->rk_conf.sasl.enable_refresh) {
+                rd_kafka_broker_drain_reauth_requests(rkb);
+        }
 
         rkb->rkb_max_inflight = rkb->rkb_rk->rk_conf.max_inflight;
 
@@ -2273,6 +2372,13 @@ static void rd_kafka_broker_connect_auth(rd_kafka_broker_t *rkb) {
                                 ? RD_KAFKA_BROKER_STATE_AUTH_REQ
                                 : RD_KAFKA_BROKER_STATE_AUTH_LEGACY);
                         rd_kafka_broker_unlock(rkb);
+
+                        // Check if reauth is in progress, if so then client close
+                        if (rkb->rkb_rk->rk_conf.sasl.enable_refresh) {
+                                if (rkb->rkb_sasl.session_lifetime_ms > 0) {
+                                        rd_kafka_sasl_close(rkb->rkb_transport);
+                                }
+                        }
 
                         if (rd_kafka_sasl_client_new(
                                 rkb->rkb_transport, sasl_errstr,
@@ -2638,6 +2744,65 @@ int rd_kafka_send(rd_kafka_broker_t *rkb) {
                             rkbuf->rkbuf_corrid, pre_of,
                             rd_slice_size(&rkbuf->rkbuf_reader));
                 }
+
+                 if (rkb->rkb_rk->rk_conf.sasl.enable_refresh) {
+                        if ((rkb->rkb_sasl.auth_in_progress == 0)) {
+                                rd_ts_t now_wallclock;
+                                now_wallclock = rd_uclock();
+
+                                if ((rkb->rkb_rk->rk_conf.sasl
+                                         .oauthbearer.token_refresh_cb &&
+                                     rkb->rkb_sasl.session_lifetime_ms > 0 &&
+                                     now_wallclock >
+                                         rkb->rkb_sasl.session_lifetime_ms)) {
+
+                                    rd_rkb_log(rkb, LOG_INFO, "SASL",
+                                                   "Reauthenticating SASL "
+                                                   "connection.");
+
+                                        /*begin reauth*/
+                                        rkb->rkb_sasl.auth_in_progress = 1;
+                                        rd_kafka_broker_connect_auth(rkb);
+                                }
+                        }
+
+                        // Check here to block requests during reauth
+                        if (rkb->rkb_sasl.auth_in_progress == 1) {
+                                // if not related to sasl reauth (handshake or
+                                // request)
+                                if ((rkbuf->rkbuf_reqhdr.ApiKey !=
+                                     RD_KAFKAP_SaslAuthenticate) &&
+                                    (rkbuf->rkbuf_reqhdr.ApiKey !=
+                                     RD_KAFKAP_SaslHandshake)) {
+                                        // remove from current queue
+                                        rd_kafka_bufq_deq(&rkb->rkb_outbufs,
+                                                          rkbuf);
+
+                                        // hold these requests into another
+                                        // queue
+                                        TAILQ_INSERT_HEAD(
+                                            &rkb->rkb_sasl.rkb_req_during_auth
+                                                 .rkbq_bufs,
+                                            rkbuf, rkbuf_link);
+                                        rd_atomic32_add(
+                                            &rkb->rkb_sasl.rkb_req_during_auth
+                                                 .rkbq_cnt,
+                                            1);
+                                        if (rkbuf->rkbuf_reqhdr.ApiKey ==
+                                            RD_KAFKAP_Produce)
+                                                rd_atomic32_add(
+                                                    &rkb->rkb_sasl
+                                                         .rkb_req_during_auth
+                                                         .rkbq_msg_cnt,
+                                                    rd_kafka_msgq_len(
+                                                        &rkbuf->rkbuf_batch
+                                                             .msgq));
+
+                                        continue;
+                                }
+                        }
+                }
+
 
                 if ((r = rd_kafka_broker_send(rkb, &rkbuf->rkbuf_reader)) == -1)
                         return -1;
@@ -5495,6 +5660,8 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
         rkb->rkb_proto    = proto;
         rkb->rkb_port     = port;
         rkb->rkb_origname = rd_strdup(name);
+        rkb->rkb_sasl.auth_in_progress    = 0;
+        rkb->rkb_sasl.session_lifetime_ms = 0;
 
         mtx_init(&rkb->rkb_lock, mtx_plain);
         mtx_init(&rkb->rkb_logname_lock, mtx_plain);
@@ -5505,6 +5672,8 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
         rd_kafka_bufq_init(&rkb->rkb_outbufs);
         rd_kafka_bufq_init(&rkb->rkb_waitresps);
         rd_kafka_bufq_init(&rkb->rkb_retrybufs);
+        rd_kafka_bufq_init(&rkb->rkb_sasl.rkb_req_during_auth);
+        rd_kafka_bufq_init(&rkb->rkb_sasl.rkb_recv_reauth_buf);
         rkb->rkb_ops = rd_kafka_q_new(rk);
         rd_avg_init(&rkb->rkb_avg_int_latency, RD_AVG_GAUGE, 0, 100 * 1000, 2,
                     rk->rk_conf.stats_interval_ms ? 1 : 0);

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -316,6 +316,13 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                 rd_kafka_resp_err_t err; /**< Last error code */
                 int cnt;                 /**< Number of identical errors */
         } rkb_last_err;
+
+        struct {
+                rd_kafka_bufq_t rkb_req_during_auth; /*Did not get sent due to reauth*/
+                rd_kafka_bufq_t rkb_recv_reauth_buf; /*Responses received during reauth*/
+                int64_t session_lifetime_ms; /*Lifetime of the current token*/
+                int auth_in_progress; /*1 if auth is ongoing, 0 if auth is complete*/
+        } rkb_sasl;
 };
 
 #define rd_kafka_broker_keep(rkb) rd_refcnt_add(&(rkb)->rkb_refcnt)

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -926,6 +926,12 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
      "This builtin handler should only be used for development "
      "or testing, and not in production.",
      0, 1, 0, _UNSUPPORTED_OAUTHBEARER},
+    {_RK_GLOBAL, "enable.sasl.token.refresh", _RK_C_BOOL,
+     _RK(sasl.enable_refresh),
+     "Enable token refresh for SASL connections. "
+     "This verification can be extended by the application by "
+     "implementing a oauthbearer_token_refresh_cb.",
+     0, 1, 0, _UNSUPPORTED_OAUTHBEARER},
     {_RK_GLOBAL, "oauthbearer_token_refresh_cb", _RK_C_PTR,
      _RK(sasl.oauthbearer.token_refresh_cb),
      "SASL/OAUTHBEARER token refresh callback (set with "

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -286,6 +286,7 @@ struct rd_kafka_conf_s {
 #endif
                 char *oauthbearer_config;
                 int enable_oauthbearer_unsecure_jwt;
+                int enable_refresh;
                 int enable_callback_queue;
                 struct {
                         rd_kafka_oauthbearer_method_t method;

--- a/src/rdkafka_feature.c
+++ b/src/rdkafka_feature.c
@@ -49,7 +49,10 @@ static const char *rd_kafka_feature_names[] = {"MsgVer1",
                                                NULL};
 
 
-static const struct rd_kafka_feature_map {
+/* KIP-368: Disabling const modifier for KIP-368 feature rollout.
+ * RD_KAFKAP_SaslAuthenticate MaxVer will be updated from 0 to 1
+ * when conf.sasl.enable_refresh is set to true. */
+static /*const*/ struct rd_kafka_feature_map {
         /* RD_KAFKA_FEATURE_... */
         int feature;
 
@@ -354,6 +357,30 @@ rd_kafka_ApiVersion_check(const struct rd_kafka_ApiVersion *apis,
         return match->MinVer <= api->MaxVer && api->MinVer <= match->MaxVer;
 }
 
+/**
+ * @brief Updates SASLAuthenticate feature version to suppport KIP 368
+ *
+ * @returns void.
+ */
+void rd_kafka_features_sasl_authenticate_update_kip368() {
+        int i;
+        /* Scan through features. */
+        for (i = 0; rd_kafka_feature_map[i].feature != 0; i++) {
+                if (rd_kafka_feature_map[i].feature ==
+                    RD_KAFKA_FEATURE_SASL_AUTH_REQ) {
+                        struct rd_kafka_ApiVersion *match;
+                        for (match = &rd_kafka_feature_map[i].depends[0];
+                             match->ApiKey != -1; match++) {
+                                if (match->ApiKey ==
+                                    RD_KAFKAP_SaslAuthenticate) {
+                                        match->MaxVer = 1;
+                                        break;
+                                }
+                        }
+                        break;
+                }
+        }
+}
 
 /**
  * @brief Compare broker's supported API versions to our feature request map

--- a/src/rdkafka_feature.h
+++ b/src/rdkafka_feature.h
@@ -96,6 +96,7 @@ void rd_kafka_ApiVersions_copy(const struct rd_kafka_ApiVersion *src,
 int rd_kafka_features_check(rd_kafka_broker_t *rkb,
                             struct rd_kafka_ApiVersion *broker_apis,
                             size_t broker_api_cnt);
+void rd_kafka_features_sasl_authenticate_update_kip368();
 
 const char *rd_kafka_features2str(int features);
 

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -247,6 +247,12 @@ void rd_kafka_handle_SaslAuthenticate(rd_kafka_t *rk,
                                       rd_kafka_buf_t *rkbuf,
                                       rd_kafka_buf_t *request,
                                       void *opaque);
+
+void rd_kafka_prepare_SaslReauth(rd_kafka_t *rk,
+                                 rd_kafka_broker_t *rkb,
+                                 rd_kafka_resp_err_t err,
+                                 rd_kafka_buf_t *rkbuf);
+
 void rd_kafka_SaslAuthenticateRequest(rd_kafka_broker_t *rkb,
                                       const void *buf,
                                       size_t size,


### PR DESCRIPTION
Added SASL reauthentication for the following feature: [KIP-368](https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate)