### PR TITLE
DP-9370 - use cc-service-bot to manage Semaphore project

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,18 @@
+name: librdkafka
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+github:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_enable: false
+  triggers:
+  - tags
+  - branches
+  branches:
+  - master
+  - /semaphore.*/
+  - /dev_.*/
+  - /feature\/.*/


### PR DESCRIPTION
This PR onboards the repo to cc-service-bot for managing its Semaphore project via code.