### PR TITLE
Debuging c99 mode

### DIFF
--- a/examples/list_consumer_group_offsets.c
+++ b/examples/list_consumer_group_offsets.c
@@ -174,6 +174,7 @@ cmd_list_consumer_group_offsets(rd_kafka_conf_t *conf, int argc, char **argv) {
         rd_kafka_event_t *event; /* ListConsumerGroupOffsets result event */
         const int min_argc = 2;
         char *topic;
+        int i;
         int partition;
         int require_stable_offsets = 0, num_partitions = 0;
         rd_kafka_ListConsumerGroupOffsets_t *list_cgrp_offsets;


### PR DESCRIPTION
I have found an issue with the path and line 292:
https://github.com/confluentinc/librdkafka/blob/1f9f245ac409f50f724695c628c7a0d54a763b9a/examples/list_consumer_group_offsets.c

I found an issue with tags [v2.0.0-RC2](https://github.com/confluentinc/librdkafka/releases/tag/v2.0.0-RC2)

![image](https://user-images.githubusercontent.com/73454291/211242473-21553e2d-b0ed-499d-a64e-42a99ea54490.png)
