### PR TITLE
Remove small bashism from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ rpm: distclean
 	$(MAKE) -C packaging/rpm
 
 LICENSES.txt: .PHONY
-	@(for i in LICENSE LICENSE.*[^~] ; do (echo "$$i" ; echo "--------------------------------------------------------------" ; cat $$i ; echo "" ; echo "") ; done) > $@.tmp
+	@(for i in LICENSE LICENSE.*[!~] ; do (echo "$$i" ; echo "--------------------------------------------------------------" ; cat $$i ; echo "" ; echo "") ; done) > $@.tmp
 	@cmp $@ $@.tmp || mv -f $@.tmp $@ ; rm -f $@.tmp
 
 


### PR DESCRIPTION
The LICENSES.txt target makes a shell for loop, in which it tries to evalute the wildcard "LICENSE.*[^~]".

[^] is a bashism, and fails when /bin/sh is not bash (i.e. every Debian-based system by default):

$ /bin/bash -c "ls LICENSE.*[^~]"
LICENSE.cjson	LICENSE.fnv1a	      LICENSE.lz4      LICENSE.pycrc  LICENSE.regexp  LICENSE.tinycthread
LICENSE.crc32c	LICENSE.hdrhistogram  LICENSE.murmur2  LICENSE.queue  LICENSE.snappy  LICENSE.wingetopt

$ /bin/sh -c "ls LICENSE.*[^~]"
ls: cannot access 'LICENSE.*[^~]': No such file or directory

The equivalent POSIX way to do this is to use [!].

Tested with bash, dash and posh.