### PR TITLE
Fix arch for nuget Linux Arm64 mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# librdkafka v2.0.1
+
+librdkafka v2.0.1 is a bugfix release:
+
+* Fixed nuget package for Linux ARM64 release (#4150).
+
+
+
 # librdkafka v2.0.0
 
 librdkafka v2.0.0 is a feature release:

--- a/packaging/nuget/nugetpackage.py
+++ b/packaging/nuget/nugetpackage.py
@@ -92,7 +92,7 @@ class NugetPackage (Package):
                 './usr/local/lib/librdkafka.so.1',
                 'runtimes/linux-x64/native/centos7-librdkafka.so'),
         # Linux glibc centos7 arm64 without GSSAPI (no external deps)
-        Mapping({'arch': 'x64',
+        Mapping({'arch': 'arm64',
                  'plat': 'linux',
                  'dist': 'centos7',
                  'lnk': 'all'},


### PR DESCRIPTION
Updated arch to arm64 for Nuget Linux Arm64 mapping.