### PR TITLE
Update lz4.c from upstream

### DIFF
--- a/src/lz4.c
+++ b/src/lz4.c
@@ -1,6 +1,6 @@
 /*
    LZ4 - Fast LZ compression algorithm
-   Copyright (C) 2011-present, Yann Collet.
+   Copyright (C) 2011-2020, Yann Collet.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
@@ -1051,7 +1051,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
 _next_match:
         /* at this stage, the following variables must be correctly set :
          * - ip : at start of LZ operation
-         * - match : at start of previous pattern occurence; can be within current prefix, or within extDict
+         * - match : at start of previous pattern occurrence; can be within current prefix, or within extDict
          * - offset : if maybe_ext_memSegment==1 (constant)
          * - lowLimit : must be == dictionary to mean "match is within extDict"; must be == source otherwise
          * - token and *token : position to write 4-bits for match length; higher 4-bits for literal length supposed already written
@@ -1752,7 +1752,7 @@ LZ4_decompress_generic(
                  const size_t dictSize         /* note : = 0 if noDict */
                  )
 {
-    if (src == NULL) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
 
     {   const BYTE* ip = (const BYTE*) src;
         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
Update lz4.c from upstream
Fix potential memory corruption with negative memmove() size
[CVE-2021-3520](https://github.com/advisories/GHSA-gmc7-pqv9-966m)

Check also https://github.com/lz4/lz4/pull/972 

Backporting https://github.com/ClickHouse/librdkafka/pull/6

P.S. newer lz4 1.9.4 has a lot of other improvements. Maybe worth upgrading?