### PR TITLE
destroy conf object in case if rd_kafka_conf_set fails

### DIFF
--- a/examples/producer.c
+++ b/examples/producer.c
@@ -111,6 +111,7 @@ int main(int argc, char **argv) {
          * set of brokers from the cluster. */
         if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, errstr,
                               sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
                 fprintf(stderr, "%s\n", errstr);
                 return 1;
         }


### PR DESCRIPTION
this commit fixes a minor issue related to freeing/destroying conf object should a call to rd_kafka_conf_set returns anything but RD_KAFKA_CONF_OK