### PR TITLE
Don't reset max.poll.interval.ms limit on every poll

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3974,13 +3974,8 @@ rd_kafka_op_res_t rd_kafka_poll_cb(rd_kafka_t *rk,
 int rd_kafka_poll(rd_kafka_t *rk, int timeout_ms) {
         int r;
 
-        if (timeout_ms)
-                rd_kafka_app_poll_blocking(rk);
-
         r = rd_kafka_q_serve(rk->rk_rep, timeout_ms, 0, RD_KAFKA_Q_CB_CALLBACK,
                              rd_kafka_poll_cb, NULL);
-
-        rd_kafka_app_polled(rk);
 
         return r;
 }
@@ -3989,13 +3984,8 @@ int rd_kafka_poll(rd_kafka_t *rk, int timeout_ms) {
 rd_kafka_event_t *rd_kafka_queue_poll(rd_kafka_queue_t *rkqu, int timeout_ms) {
         rd_kafka_op_t *rko;
 
-        if (timeout_ms)
-                rd_kafka_app_poll_blocking(rkqu->rkqu_rk);
-
         rko = rd_kafka_q_pop_serve(rkqu->rkqu_q, rd_timeout_us(timeout_ms), 0,
                                    RD_KAFKA_Q_CB_EVENT, rd_kafka_poll_cb, NULL);
-
-        rd_kafka_app_polled(rkqu->rkqu_rk);
 
         if (!rko)
                 return NULL;
@@ -4006,13 +3996,8 @@ rd_kafka_event_t *rd_kafka_queue_poll(rd_kafka_queue_t *rkqu, int timeout_ms) {
 int rd_kafka_queue_poll_callback(rd_kafka_queue_t *rkqu, int timeout_ms) {
         int r;
 
-        if (timeout_ms)
-                rd_kafka_app_poll_blocking(rkqu->rkqu_rk);
-
         r = rd_kafka_q_serve(rkqu->rkqu_q, timeout_ms, 0,
                              RD_KAFKA_Q_CB_CALLBACK, rd_kafka_poll_cb, NULL);
-
-        rd_kafka_app_polled(rkqu->rkqu_rk);
 
         return r;
 }

--- a/tests/0089-max_poll_interval.c
+++ b/tests/0089-max_poll_interval.c
@@ -92,9 +92,10 @@ void do_test_with_optional_queue(rd_bool_t use_log_queue) {
                         /* Consumer is "processing".
                          * When we are "processing", we poll the log queue. */
                         if (ts_next[i] > test_clock()) {
-                                if (use_log_queue) {
-                                        rd_kafka_queue_poll(logq[i], 100);
-                                }
+                                if (use_log_queue)
+                                        rd_kafka_event_destroy(
+                                                rd_kafka_queue_poll(
+                                                        logq[i], 100));
                                 continue;
                         }
 
@@ -198,6 +199,7 @@ done:
         for (i = 0; i < 2; i++) {
                 rd_kafka_destroy_flags(c[i],
                                        RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
+
                 if (use_log_queue)
                         rd_kafka_queue_destroy(logq[i]);
         }


### PR DESCRIPTION
Earlier on, we changed the code to prevent max.poll.interval.ms from being triggered in case we were inside librdkafka in any sort of a `poll` call. Top achieve this, blocked the timer using `rd_kafka_app_poll_blocking`, and reset it at the end of the call. 

This doesn't work correctly in the cases where we're simply polling an unrelated queue, like the log queue. In that case, just by polling the log queue, the timer is reset, despite us not actually consuming anything (or doing any consume poll).

At the same time, it's a reasonable expectation that max.poll.interval.ms won't be triggered _while_ we are doing any sort of consumer poll.

This PR takes care of both the cases. The methods (from public API) which block/reset the timer are:
1. rd_kafka_consume_batch
2. rd_kafka_consume_batch_queue
3. rd_kafka_consume_callback
4. rd_kafka_consume_callback_queue
5. rd_kafka_consume
6. rd_kafka_consumer_poll

All the other poll methods like queue_poll etc no longer reset or block the timer.
A failing test was added first, to test the change.
 

Ref #2365.
