### PR TITLE
Set socket connection setup timeout in 0105:do_test_txn_concurrent_operations

### DIFF
--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3533,7 +3533,14 @@ static void do_test_txn_concurrent_operations(rd_bool_t do_commit) {
 
         test_timeout_set(90);
 
-        rk = create_txn_producer(&mcluster, transactional_id, 1, NULL);
+        /* We need to override the value of socket.connection.setup.timeout.ms
+         * to be twice the RTT of the mock broker. This is because the first
+         * ApiVersion request will fail, since we make the request with v3, and
+         * the mock broker's MaxVersion is 2, so the request is retried with v0.
+         */
+        rk = create_txn_producer(&mcluster, transactional_id, 1,
+                                 "socket.connection.setup.timeout.ms", "10000",
+                                 NULL);
 
         /* Set broker RTT to 5s so that the background thread has ample
          * time to call its conflicting APIs. */

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3534,12 +3534,13 @@ static void do_test_txn_concurrent_operations(rd_bool_t do_commit) {
         test_timeout_set(90);
 
         /* We need to override the value of socket.connection.setup.timeout.ms
-         * to be twice the RTT of the mock broker. This is because the first
+         * to be at least 2*RTT of the mock broker. This is because the first
          * ApiVersion request will fail, since we make the request with v3, and
          * the mock broker's MaxVersion is 2, so the request is retried with v0.
+         * We use the value 3*RTT to add some buffer.
          */
         rk = create_txn_producer(&mcluster, transactional_id, 1,
-                                 "socket.connection.setup.timeout.ms", "10000",
+                                 "socket.connection.setup.timeout.ms", "15000",
                                  NULL);
 
         /* Set broker RTT to 5s so that the background thread has ample


### PR DESCRIPTION
While using create_txn_producer for any test, we set the socket.connection.setup.timeout.ms to 5s, see https://github.com/confluentinc/librdkafka/pull/4076/commits/a6a5e53c7cfb6430de7dfafb4a49fc1f8d34bc16 . 

However, for this test, we are setting the mock broker's RTT to 5s, and due to the fact that we might make the ApiVersionRequest twice (once with version 3, and then with version 0 when the first one fails)