### PR TITLE
Fix close blocked by refcnt in test 0113.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# librdkafka v2.0.3
+
+librdkafka v2.0.3 is a bugfix release:
+
+* Fix a reference count issue blocking the consumer from closing (#4187).
+
+
+## Fixes
+
+### Consumer fixes
+
+ * A reference count issue was blocking the consumer from closing.
+   The problem would happen when a partition is lost, because forcibly
+   unassigned from the consumer or if the corresponding topic is deleted.
+
+
+
 # librdkafka v2.0.2
 
 librdkafka v2.0.2 is a bugfix release:

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2734,6 +2734,10 @@ static void rd_kafka_cgrp_partition_del(rd_kafka_cgrp_t *rkcg,
         rd_kafka_toppar_lock(rktp);
         rd_assert(rktp->rktp_flags & RD_KAFKA_TOPPAR_F_ON_CGRP);
         rktp->rktp_flags &= ~RD_KAFKA_TOPPAR_F_ON_CGRP;
+        /* Partition is stopped, so rktp->rktp_fetchq->rkq_fwdq is NULL.
+         * Purge remaining operations in rktp->rktp_fetchq->rkq_q,
+         * while holding locks, to avoid circular references */
+        rd_kafka_q_purge(rktp->rktp_fetchq);
         rd_kafka_toppar_unlock(rktp);
 
         rd_list_remove(&rkcg->rkcg_toppars, rktp);


### PR DESCRIPTION
Breaks a circular dependency from
rko to rktp and back that prevents
the toppar being destroyed.