### PR TITLE
Include cURL headers not publicly, they are only used in .c files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,7 +199,7 @@ target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${dummy}>")
 
 if(WITH_CURL)
   find_package(CURL REQUIRED)
-  target_include_directories(rdkafka PUBLIC ${CURL_INCLUDE_DIRS})
+  target_include_directories(rdkafka PRIVATE ${CURL_INCLUDE_DIRS})
   target_link_libraries(rdkafka PUBLIC ${CURL_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Follow-up of https://github.com/confluentinc/librdkafka/pull/4003

I noticed that the other libraries have their include directories set privately and cURL is the only library also setting the interface include directories, so that's an oversight from me back then.

I have checked that no public API header includes any cURL header, so this will probably not break any build.