### PR TITLE
Fix ListGroup protocol message for ApiVersion >= 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# librdkakfa v2.0.3
+
+librdkafka v2.0.3 is a bugfix release:
+
+* Fix a protocol issue with ListGroups protocol request, where some extra
+  fields were appended for API Versions greater than or equal to 3.
+
+
 # librdkafka v2.0.2
 
 librdkafka v2.0.2 is a bugfix release:

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1789,7 +1789,6 @@ rd_kafka_error_t *rd_kafka_ListGroupsRequest(rd_kafka_broker_t *rkb,
         rd_kafka_buf_t *rkbuf;
         int16_t ApiVersion = 0;
         size_t i;
-        rd_bool_t is_flexver = rd_false;
 
         if (max_ApiVersion < 0)
                 max_ApiVersion = 4;
@@ -1800,7 +1799,6 @@ rd_kafka_error_t *rd_kafka_ListGroupsRequest(rd_kafka_broker_t *rkb,
                  * in the application thread reliably . */
                 ApiVersion = rd_kafka_broker_ApiVersion_supported(
                     rkb, RD_KAFKAP_ListGroups, 0, max_ApiVersion, NULL);
-                is_flexver = ApiVersion >= 3;
         }
 
         if (ApiVersion == -1) {
@@ -1812,7 +1810,7 @@ rd_kafka_error_t *rd_kafka_ListGroupsRequest(rd_kafka_broker_t *rkb,
         rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_ListGroups, 1,
             /* rd_kafka_buf_write_arraycnt_pos + tags + StatesFilter */
-            4 + 1 + 32 * states_cnt, is_flexver);
+            4 + 1 + 32 * states_cnt, ApiVersion >= 3 /* is_flexver */);
 
         if (ApiVersion >= 4) {
                 size_t of_GroupsArrayCnt =
@@ -1821,9 +1819,6 @@ rd_kafka_error_t *rd_kafka_ListGroupsRequest(rd_kafka_broker_t *rkb,
                         rd_kafka_buf_write_str(rkbuf, states[i], -1);
                 }
                 rd_kafka_buf_finalize_arraycnt(rkbuf, of_GroupsArrayCnt, i);
-        }
-        if (is_flexver) {
-                rd_kafka_buf_write_tags(rkbuf);
         }
 
         rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);


### PR DESCRIPTION
Earlier, we were adding extra tagged fields when the version was a flexver. (The tagged fields are added at a common place, so this was extra)

I've run tests 0081 and 0080