### PR TITLE
Fixed issues related to store_offset and next_offset during Barrier op in consume batch API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ librdkafka v2.0.3 is a bugfix release:
   the timeout to be reset (#4176).
 * Fix seek partition timeout, was one thousand times lower than the passed
   value (#4230).
+* Batch consumer fixes: TODO: describe (#4208).
 
 
 ## Fixes

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -1148,3 +1148,29 @@ void rd_kafka_offset_store_init(rd_kafka_toppar_t *rktp) {
 
         rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_OFFSET_STORE;
 }
+
+
+/**
+ * Update toppar app_offset and store_offset (if enabled) to the provided
+ * offset.
+ *
+ */
+void rd_kafka_update_app_offset(rd_kafka_t *rk,
+                                rd_kafka_toppar_t *rktp,
+                                int64_t offset,
+                                rd_dolock_t do_lock) {
+
+        rd_assert(rk == rktp->rktp_rkt->rkt_rk);
+
+        if (do_lock)
+                rd_kafka_toppar_lock(rktp);
+
+        rktp->rktp_app_offset = offset;
+        if (rk->rk_conf.enable_auto_offset_store)
+                rd_kafka_offset_store0(rktp, offset,
+                                       /* force: ignore assignment state */
+                                       rd_true, RD_DONT_LOCK);
+
+        if (do_lock)
+                rd_kafka_toppar_unlock(rktp);
+}

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -1160,8 +1160,6 @@ void rd_kafka_update_app_offset(rd_kafka_t *rk,
                                 int64_t offset,
                                 rd_dolock_t do_lock) {
 
-        rd_assert(rk == rktp->rktp_rkt->rkt_rk);
-
         if (do_lock)
                 rd_kafka_toppar_lock(rktp);
 

--- a/src/rdkafka_offset.h
+++ b/src/rdkafka_offset.h
@@ -121,4 +121,9 @@ void rd_kafka_offset_reset(rd_kafka_toppar_t *rktp,
 
 void rd_kafka_offset_query_tmr_cb(rd_kafka_timers_t *rkts, void *arg);
 
+void rd_kafka_update_app_offset(rd_kafka_t *rk,
+                                rd_kafka_toppar_t *rktp,
+                                int64_t offset,
+                                rd_dolock_t do_lock);
+
 #endif /* _RDKAFKA_OFFSET_H_ */

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -923,11 +923,5 @@ void rd_kafka_fetch_op_app_prepare(rd_kafka_t *rk, rd_kafka_op_t *rko) {
 
         offset = rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
 
-        rd_kafka_toppar_lock(rktp);
-        rktp->rktp_app_offset = offset;
-        if (rk->rk_conf.enable_auto_offset_store)
-                rd_kafka_offset_store0(rktp, offset,
-                                       /* force: ignore assignment state */
-                                       rd_true, RD_DONT_LOCK);
-        rd_kafka_toppar_unlock(rktp);
+        rd_kafka_update_app_offset(rk, rktp, offset, RD_DO_LOCK);
 }

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -670,6 +670,9 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                  * application. Add it to a tmp queue from where we can store
                  * the offset and destroy the op */
                 if (unlikely(rd_kafka_op_is_ctrl_msg(rko))) {
+                        /* FIXME: Fix TAILQ_REMOVE call to handle this case */
+                        if (TAILQ_FIRST(&ctrl_msg_q) == NULL)
+                                TAILQ_INIT(&ctrl_msg_q);
                         TAILQ_INSERT_TAIL(&ctrl_msg_q, rko, rko_link);
                         continue;
                 }
@@ -702,7 +705,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 next                    = TAILQ_NEXT(next, rko_link);
                 rd_kafka_toppar_t *rktp = rko->rko_rktp;
                 int64_t offset = rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
-                if (unlikely(rktp->rktp_app_offset < offset))
+                if (rktp->rktp_app_offset < offset)
                         rd_kafka_update_app_offset(rk, rktp, offset,
                                                    RD_DO_LOCK);
                 rd_kafka_op_destroy(rko);

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -666,16 +666,9 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 rko = (rd_kafka_op_t *)rkmessages[i]->_private;
                 rd_kafka_toppar_t *rktp = rko->rko_rktp;
                 int64_t offset          = rkmessages[i]->offset + 1;
-                if (unlikely(rktp->rktp_app_offset < offset)) {
-                        rd_kafka_toppar_lock(rktp);
-                        rktp->rktp_app_offset = offset;
-                        if (rk->rk_conf.enable_auto_offset_store)
-                                rd_kafka_offset_store0(
-                                    rktp, offset,
-                                    /* force: ignore assignment state */
-                                    rd_true, RD_DONT_LOCK);
-                        rd_kafka_toppar_unlock(rktp);
-                }
+                if (unlikely(rktp->rktp_app_offset < offset))
+                        rd_kafka_update_app_offset(rk, rktp, offset,
+                                                   RD_DO_LOCK);
         }
 
         /* Discard non-desired and already handled ops */
@@ -687,16 +680,9 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                         rd_kafka_toppar_t *rktp = rko->rko_rktp;
                         int64_t offset =
                             rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
-                        if (unlikely(rktp->rktp_app_offset < offset)) {
-                                rd_kafka_toppar_lock(rktp);
-                                rktp->rktp_app_offset = offset;
-                                if (rk->rk_conf.enable_auto_offset_store)
-                                        rd_kafka_offset_store0(
-                                            rktp, offset,
-                                            /* force: ignore assignment state */
-                                            rd_true, RD_DONT_LOCK);
-                                rd_kafka_toppar_unlock(rktp);
-                        }
+                        if (unlikely(rktp->rktp_app_offset < offset))
+                                rd_kafka_update_app_offset(rk, rktp, offset,
+                                                           RD_DO_LOCK);
                 }
                 rd_kafka_op_destroy(rko);
         }

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -652,7 +652,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
 
                 /* If this is a control messages, don't return
                  * message to application. Add it to the tmp queue
-                 * from where we can store the offset and destroy them */
+                 * from where we can store the offset and destroy the op */
                 if (unlikely(rd_kafka_op_is_ctrl_msg(rko))) {
                         TAILQ_INSERT_TAIL(&tmpq, rko, rko_link);
                         continue;
@@ -676,7 +676,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
         while (next) {
                 rko  = next;
                 next = TAILQ_NEXT(next, rko_link);
-                if (unlikely(rd_kafka_op_is_ctrl_msg(rko))) {
+                if (rd_kafka_op_is_ctrl_msg(rko)) {
                         rd_kafka_toppar_t *rktp = rko->rko_rktp;
                         int64_t offset =
                             rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -539,15 +539,17 @@ int rd_kafka_q_serve(rd_kafka_q_t *rkq,
  *
  * @locality Any thread.
  */
-static size_t rd_kafka_purge_outdated_messages(rd_kafka_toppar_t *rktp,
-                                               int32_t version,
-                                               rd_kafka_message_t **rkmessages,
-                                               size_t cnt) {
+static size_t
+rd_kafka_purge_outdated_messages(rd_kafka_toppar_t *rktp,
+                                 int32_t version,
+                                 rd_kafka_message_t **rkmessages,
+                                 size_t cnt,
+                                 struct rd_kafka_op_tailq ctrl_msg_q) {
         size_t valid_count = 0;
         size_t i;
+        rd_kafka_op_t *rko, *next;
 
         for (i = 0; i < cnt; i++) {
-                rd_kafka_op_t *rko;
                 rko = rkmessages[i]->_private;
                 if (rko->rko_rktp == rktp &&
                     rd_kafka_op_version_outdated(rko, version)) {
@@ -559,6 +561,17 @@ static size_t rd_kafka_purge_outdated_messages(rd_kafka_toppar_t *rktp,
                         valid_count++;
                 }
         }
+
+        /* Discard outdated control msgs ops */
+        next = TAILQ_FIRST(&ctrl_msg_q);
+        while (next && next->rko_rktp == rktp &&
+               rd_kafka_op_version_outdated(next, version)) {
+                rko  = next;
+                next = TAILQ_NEXT(rko, rko_link);
+                TAILQ_REMOVE(&ctrl_msg_q, rko, rko_link);
+                rd_kafka_op_destroy(rko);
+        }
+
         return valid_count;
 }
 
@@ -577,6 +590,8 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                                 size_t rkmessages_size) {
         unsigned int cnt = 0;
         TAILQ_HEAD(, rd_kafka_op_s) tmpq = TAILQ_HEAD_INITIALIZER(tmpq);
+        struct rd_kafka_op_tailq ctrl_msg_q =
+            TAILQ_HEAD_INITIALIZER(ctrl_msg_q);
         rd_kafka_op_t *rko, *next;
         rd_kafka_t *rk = rkq->rkq_rk;
         rd_kafka_q_t *fwdq;
@@ -625,7 +640,8 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
 
                 if (unlikely(rko->rko_type == RD_KAFKA_OP_BARRIER)) {
                         cnt = (unsigned int)rd_kafka_purge_outdated_messages(
-                            rko->rko_rktp, rko->rko_version, rkmessages, cnt);
+                            rko->rko_rktp, rko->rko_version, rkmessages, cnt,
+                            ctrl_msg_q);
                         rd_kafka_op_destroy(rko);
                         continue;
                 }
@@ -650,11 +666,11 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 }
                 rd_dassert(res == RD_KAFKA_OP_RES_PASS);
 
-                /* If this is a control messages, don't return
-                 * message to application. Add it to the tmp queue
-                 * from where we can store the offset and destroy the op */
+                /* If this is a control messages, don't return message to
+                 * application. Add it to a tmp queue from where we can store
+                 * the offset and destroy the op */
                 if (unlikely(rd_kafka_op_is_ctrl_msg(rko))) {
-                        TAILQ_INSERT_TAIL(&tmpq, rko, rko_link);
+                        TAILQ_INSERT_TAIL(&ctrl_msg_q, rko, rko_link);
                         continue;
                 }
 
@@ -676,14 +692,19 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
         while (next) {
                 rko  = next;
                 next = TAILQ_NEXT(next, rko_link);
-                if (rd_kafka_op_is_ctrl_msg(rko)) {
-                        rd_kafka_toppar_t *rktp = rko->rko_rktp;
-                        int64_t offset =
-                            rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
-                        if (unlikely(rktp->rktp_app_offset < offset))
-                                rd_kafka_update_app_offset(rk, rktp, offset,
-                                                           RD_DO_LOCK);
-                }
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Discard ctrl msgs */
+        next = TAILQ_FIRST(&ctrl_msg_q);
+        while (next) {
+                rko                     = next;
+                next                    = TAILQ_NEXT(next, rko_link);
+                rd_kafka_toppar_t *rktp = rko->rko_rktp;
+                int64_t offset = rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
+                if (unlikely(rktp->rktp_app_offset < offset))
+                        rd_kafka_update_app_offset(rk, rktp, offset,
+                                                   RD_DO_LOCK);
                 rd_kafka_op_destroy(rko);
         }
 

--- a/tests/0080-admin_ut.c
+++ b/tests/0080-admin_ut.c
@@ -588,10 +588,10 @@ static void do_test_ListConsumerGroups(const char *what,
             err ? errstr2 : "n/a");
 
         errors = rd_kafka_ListConsumerGroups_result_errors(rkev, &errors_cnt);
-        TEST_ASSERT(errors_cnt == 1, "expected one error, got %" PRIu64,
+        TEST_ASSERT(errors_cnt == 1, "expected one error, got %" PRIusz,
                     errors_cnt);
         rd_kafka_ListConsumerGroups_result_valid(rkev, &valid_cnt);
-        TEST_ASSERT(valid_cnt == 0, "expected zero valid groups, got %" PRIu64,
+        TEST_ASSERT(valid_cnt == 0, "expected zero valid groups, got %" PRIusz,
                     valid_cnt);
 
         err     = rd_kafka_error_code(errors[0]);

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -87,6 +87,8 @@ static int consumer_batch_queue(void *arg) {
                 rd_kafka_message_destroy(rkmessage[i]);
         }
 
+        free(rkmessage);
+
         return 0;
 }
 

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -462,11 +462,144 @@ static void do_test_consume_batch_store_offset(void) {
 }
 
 
+static void do_test_consume_batch_control_msgs(void) {
+        const char *topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
+        const int32_t partition = 0;
+        rd_kafka_conf_t *conf, *c_conf;
+        rd_kafka_t *producer, *consumer;
+        uint64_t testid;
+        const int msgcnt[2] = {2, 3};
+        test_msgver_t mv;
+        rd_kafka_queue_t *rkq;
+        consumer_t consumer_args   = RD_ZERO_INIT;
+        const int partition_cnt    = 1;
+        const int timeout_ms       = 5000;
+        const int consume_msg_cnt  = 10;
+        const int expected_msg_cnt = 2;
+        int32_t pause_partition    = 0;
+        int64_t expected_offset    = msgcnt[0] + msgcnt[1] + 2;
+        rd_kafka_topic_partition_list_t *pause_partition_list;
+        rd_kafka_resp_err_t err;
+        thrd_t thread_id;
+
+        SUB_TEST("Testing control msgs flow");
+
+        testid = test_id_generate();
+
+        test_conf_init(&conf, NULL, 30);
+
+        test_conf_set(conf, "transactional.id", topic);
+        test_conf_set(conf, "batch.num.messages", "1");
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+
+        producer = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        test_create_topic(producer, topic, partition_cnt, 1);
+
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(producer, 30 * 1000));
+
+        /*
+         * Transaction 1
+         */
+        TEST_SAY("Transaction 1: %d msgs\n", msgcnt[0]);
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, testid, partition, 0, msgcnt[0],
+                           NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, -1));
+
+        /*
+         * Transaction 2
+         */
+        TEST_SAY("Transaction 2: %d msgs\n", msgcnt[1]);
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, testid, partition, 0, msgcnt[1],
+                           NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, -1));
+
+        rd_kafka_destroy(producer);
+
+        rd_sleep(2);
+
+        /*
+         * Consumer
+         */
+        test_conf_init(&c_conf, NULL, 0);
+        test_conf_set(c_conf, "enable.auto.commit", "false");
+        test_conf_set(c_conf, "enable.auto.offset.store", "true");
+        test_conf_set(c_conf, "auto.offset.reset", "earliest");
+        consumer = test_create_consumer(topic, NULL, c_conf, NULL);
+
+        test_consumer_subscribe(consumer, topic);
+        test_consumer_wait_assignment(consumer, rd_false);
+
+        /* Create generic consume queue */
+        rkq = rd_kafka_queue_get_consumer(consumer);
+
+        test_msgver_init(&mv, testid);
+        test_msgver_ignore_eof(&mv);
+
+        consumer_args.what             = "CONSUMER";
+        consumer_args.rkq              = rkq;
+        consumer_args.timeout_ms       = timeout_ms;
+        consumer_args.consume_msg_cnt  = consume_msg_cnt;
+        consumer_args.expected_msg_cnt = expected_msg_cnt;
+        consumer_args.rk               = consumer;
+        consumer_args.testid           = testid;
+        consumer_args.mv               = &mv;
+        consumer_args.test             = test_curr;
+
+
+        if (thrd_create(&thread_id, consumer_batch_queue, &consumer_args) !=
+            thrd_success)
+                TEST_FAIL("Failed to create thread for %s", "CONSUMER");
+
+        pause_partition_list = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(pause_partition_list, topic,
+                                          pause_partition);
+
+        rd_sleep(1);
+        err = rd_kafka_pause_partitions(consumer, pause_partition_list);
+
+        TEST_ASSERT(!err, "Failed to pause partition %d for topic %s",
+                    pause_partition, topic);
+
+        rd_sleep(1);
+
+        err = rd_kafka_resume_partitions(consumer, pause_partition_list);
+
+        TEST_ASSERT(!err, "Failed to resume partition %d for topic %s",
+                    pause_partition, topic);
+
+        thrd_join(thread_id, NULL);
+
+        rd_kafka_commit(consumer, NULL, rd_false);
+
+        rd_kafka_committed(consumer, pause_partition_list, timeout_ms);
+
+        TEST_ASSERT(pause_partition_list->elems[0].offset == expected_offset,
+                    "Expected offset should be %lld, but it is %lld",
+                    expected_offset, pause_partition_list->elems[0].offset);
+
+        rd_kafka_topic_partition_list_destroy(pause_partition_list);
+
+        rd_kafka_queue_destroy(rkq);
+
+        test_msgver_clear(&mv);
+
+        test_consumer_close(consumer);
+
+        rd_kafka_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0137_barrier_batch_consume(int argc, char **argv) {
         do_test_consume_batch_with_seek();
         do_test_consume_batch_store_offset();
         do_test_consume_batch_with_pause_and_resume_different_batch();
         do_test_consume_batch_with_pause_and_resume_same_batch();
+        do_test_consume_batch_control_msgs();
 
         return 0;
 }

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -164,7 +164,8 @@ static void do_test_consume_batch_with_seek(void) {
 
         thrd_join(thread_id, NULL);
 
-        test_msgver_verify("CONSUME", &mv, TEST_MSGVER_ORDER | TEST_MSGVER_DUP,
+        test_msgver_verify("CONSUME", &mv, TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+                               TEST_MSGVER_BY_OFFSET,
                            0, expected_msg_cnt);
         test_msgver_clear(&mv);
 
@@ -192,7 +193,6 @@ static void do_test_consume_batch_with_pause_and_resume(void) {
         thrd_t thread_id;
         rd_kafka_resp_err_t err;
         rd_kafka_topic_partition_list_t *pause_partition_list;
-        rd_kafka_message_t **rkmessages;
         const int timeout_ms       = 2000;
         const int consume_msg_cnt  = 10;
         const int produce_msg_cnt  = 8;

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -182,7 +182,7 @@ static void do_test_consume_batch_with_seek(void) {
 }
 
 
-static void do_test_consume_batch_with_pause_and_resume(void) {
+static void do_test_consume_batch_with_pause_and_resume_different_batch(void) {
         rd_kafka_queue_t *rkq;
         const char *topic;
         rd_kafka_t *consumer;
@@ -290,6 +290,103 @@ static void do_test_consume_batch_with_pause_and_resume(void) {
 }
 
 
+static void do_test_consume_batch_with_pause_and_resume_same_batch(void) {
+        rd_kafka_queue_t *rkq;
+        const char *topic;
+        rd_kafka_t *consumer;
+        int p;
+        uint64_t testid;
+        rd_kafka_conf_t *conf;
+        consumer_t consumer_args = RD_ZERO_INIT;
+        test_msgver_t mv;
+        thrd_t thread_id;
+        rd_kafka_resp_err_t err;
+        rd_kafka_topic_partition_list_t *pause_partition_list;
+        const int timeout_ms      = 10000;
+        const int consume_msg_cnt = 10;
+        const int produce_msg_cnt = 8;
+        const int partition_cnt   = 2;
+        int32_t pause_partition   = 0;
+
+        SUB_TEST();
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+
+        testid = test_id_generate();
+        test_msgver_init(&mv, testid);
+
+        /* Produce messages */
+        topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
+
+        test_create_topic(NULL, topic, partition_cnt, 1);
+
+        for (p = 0; p < partition_cnt; p++)
+                test_produce_msgs_easy(topic, testid, p,
+                                       produce_msg_cnt / partition_cnt);
+
+        /* Create consumers */
+        consumer =
+            test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
+
+        test_consumer_subscribe(consumer, topic);
+        test_consumer_wait_assignment(consumer, rd_false);
+
+        /* Create generic consume queue */
+        rkq = rd_kafka_queue_get_consumer(consumer);
+
+        consumer_args.what             = "CONSUMER";
+        consumer_args.rkq              = rkq;
+        consumer_args.timeout_ms       = timeout_ms;
+        consumer_args.consume_msg_cnt  = consume_msg_cnt;
+        consumer_args.expected_msg_cnt = produce_msg_cnt;
+        consumer_args.rk               = consumer;
+        consumer_args.testid           = testid;
+        consumer_args.mv               = &mv;
+        consumer_args.test             = test_curr;
+        if (thrd_create(&thread_id, consumer_batch_queue, &consumer_args) !=
+            thrd_success)
+                TEST_FAIL("Failed to create thread for %s", "CONSUMER");
+
+        pause_partition_list = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(pause_partition_list, topic,
+                                          pause_partition);
+
+        rd_sleep(1);
+        err = rd_kafka_pause_partitions(consumer, pause_partition_list);
+
+        TEST_ASSERT(!err, "Failed to pause partition %d for topic %s",
+                    pause_partition, topic);
+
+        rd_sleep(1);
+
+        err = rd_kafka_resume_partitions(consumer, pause_partition_list);
+
+        TEST_ASSERT(!err, "Failed to resume partition %d for topic %s",
+                    pause_partition, topic);
+
+        thrd_join(thread_id, NULL);
+
+        test_msgver_verify("CONSUME", &mv,
+                           TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+                               TEST_MSGVER_BY_OFFSET,
+                           0, produce_msg_cnt);
+
+        rd_kafka_topic_partition_list_destroy(pause_partition_list);
+
+        test_msgver_clear(&mv);
+
+        rd_kafka_queue_destroy(rkq);
+
+        test_consumer_close(consumer);
+
+        rd_kafka_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
 static void do_test_consume_batch_store_offset(void) {
         rd_kafka_queue_t *rkq;
         const char *topic;
@@ -368,6 +465,8 @@ static void do_test_consume_batch_store_offset(void) {
 int main_0137_barrier_batch_consume(int argc, char **argv) {
         do_test_consume_batch_with_seek();
         do_test_consume_batch_store_offset();
-        do_test_consume_batch_with_pause_and_resume();
+        do_test_consume_batch_with_pause_and_resume_different_batch();
+        do_test_consume_batch_with_pause_and_resume_same_batch();
+
         return 0;
 }

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -87,6 +87,8 @@ static int consumer_batch_queue(void *arg) {
                 rd_kafka_message_destroy(rkmessage[i]);
         }
 
+        rd_free(rkmessage);
+
         return 0;
 }
 
@@ -130,8 +132,7 @@ static void do_test_consume_batch_with_seek(void) {
                                        produce_msg_cnt / partition_cnt);
 
         /* Create consumers */
-        consumer =
-            test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
+        consumer = test_create_consumer(topic, NULL, conf, NULL);
 
         test_consumer_subscribe(consumer, topic);
         test_consumer_wait_assignment(consumer, rd_false);
@@ -159,7 +160,7 @@ static void do_test_consume_batch_with_seek(void) {
         err = rd_kafka_seek_partitions(consumer, seek_toppars, 2000);
 
         TEST_ASSERT(!err,
-                    "Failed to seek partition %d for topic %s to offset %lld",
+                    "Failed to seek partition %d for topic %s to offset %ld",
                     seek_partition, topic, seek_offset);
 
         thrd_join(thread_id, NULL);
@@ -221,8 +222,7 @@ static void do_test_consume_batch_with_pause_and_resume_different_batch(void) {
                                        produce_msg_cnt / partition_cnt);
 
         /* Create consumers */
-        consumer =
-            test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
+        consumer = test_create_consumer(topic, NULL, conf, NULL);
 
         test_consumer_subscribe(consumer, topic);
         test_consumer_wait_assignment(consumer, rd_false);
@@ -327,8 +327,7 @@ static void do_test_consume_batch_with_pause_and_resume_same_batch(void) {
                                        produce_msg_cnt / partition_cnt);
 
         /* Create consumers */
-        consumer =
-            test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
+        consumer = test_create_consumer(topic, NULL, conf, NULL);
 
         test_consumer_subscribe(consumer, topic);
         test_consumer_wait_assignment(consumer, rd_false);
@@ -458,6 +457,10 @@ static void do_test_consume_batch_store_offset(void) {
                                TEST_MSGVER_BY_OFFSET,
                            0, expected_msg_cnt);
 
+        test_msgver_clear(&mv);
+
+        rd_kafka_conf_destroy(conf);
+
         SUB_TEST_PASS();
 }
 
@@ -577,7 +580,7 @@ static void do_test_consume_batch_control_msgs(void) {
         rd_kafka_committed(consumer, pause_partition_list, timeout_ms);
 
         TEST_ASSERT(pause_partition_list->elems[0].offset == expected_offset,
-                    "Expected offset should be %lld, but it is %lld",
+                    "Expected offset should be %ld, but it is %ld",
                     expected_offset, pause_partition_list->elems[0].offset);
 
         rd_kafka_topic_partition_list_destroy(pause_partition_list);

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -164,7 +164,8 @@ static void do_test_consume_batch_with_seek(void) {
 
         thrd_join(thread_id, NULL);
 
-        test_msgver_verify("CONSUME", &mv, TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+        test_msgver_verify("CONSUME", &mv,
+                           TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
                                TEST_MSGVER_BY_OFFSET,
                            0, expected_msg_cnt);
         test_msgver_clear(&mv);

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -159,9 +159,9 @@ static void do_test_consume_batch_with_seek(void) {
                                                  seek_partition, seek_offset);
         err = rd_kafka_seek_partitions(consumer, seek_toppars, 2000);
 
-        TEST_ASSERT(!err,
-                    "Failed to seek partition %d for topic %s to offset %ld",
-                    seek_partition, topic, seek_offset);
+        TEST_ASSERT(
+            !err, "Failed to seek partition %d for topic %s to offset %" PRId64,
+            seek_partition, topic, seek_offset);
 
         thrd_join(thread_id, NULL);
 
@@ -580,7 +580,7 @@ static void do_test_consume_batch_control_msgs(void) {
         rd_kafka_committed(consumer, pause_partition_list, timeout_ms);
 
         TEST_ASSERT(pause_partition_list->elems[0].offset == expected_offset,
-                    "Expected offset should be %ld, but it is %ld",
+                    "Expected offset should be %" PRId64 ", but it is %" PRId64,
                     expected_offset, pause_partition_list->elems[0].offset);
 
         rd_kafka_topic_partition_list_destroy(pause_partition_list);

--- a/tests/0137-barrier_batch_consume.c
+++ b/tests/0137-barrier_batch_consume.c
@@ -103,13 +103,13 @@ static void do_test_consume_batch_with_seek(void) {
         thrd_t thread_id;
         rd_kafka_error_t *err;
         rd_kafka_topic_partition_list_t *seek_toppars;
-        const int produce_partition_cnt = 2;
-        const int timeout_ms            = 10000;
-        const int consume_msg_cnt       = 10;
-        const int produce_msg_cnt       = 8;
-        const int32_t seek_partition    = 0;
-        const int64_t seek_offset       = 1;
-        const int expected_msg_cnt      = produce_msg_cnt - seek_offset;
+        const int partition_cnt      = 2;
+        const int timeout_ms         = 10000;
+        const int consume_msg_cnt    = 10;
+        const int produce_msg_cnt    = 8;
+        const int32_t seek_partition = 0;
+        const int64_t seek_offset    = 1;
+        const int expected_msg_cnt   = produce_msg_cnt - seek_offset;
 
         SUB_TEST();
 
@@ -123,9 +123,11 @@ static void do_test_consume_batch_with_seek(void) {
         /* Produce messages */
         topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
 
-        for (p = 0; p < produce_partition_cnt; p++)
+        test_create_topic(NULL, topic, partition_cnt, 1);
+
+        for (p = 0; p < partition_cnt; p++)
                 test_produce_msgs_easy(topic, testid, p,
-                                       produce_msg_cnt / produce_partition_cnt);
+                                       produce_msg_cnt / partition_cnt);
 
         /* Create consumers */
         consumer =
@@ -157,7 +159,7 @@ static void do_test_consume_batch_with_seek(void) {
         err = rd_kafka_seek_partitions(consumer, seek_toppars, 2000);
 
         TEST_ASSERT(!err,
-                    "Failed to seek partition %d for topic %s to offset %ld",
+                    "Failed to seek partition %d for topic %s to offset %lld",
                     seek_partition, topic, seek_offset);
 
         thrd_join(thread_id, NULL);
@@ -178,113 +180,190 @@ static void do_test_consume_batch_with_seek(void) {
 }
 
 
-// static void do_test_consume_batch_with_pause_and_resume(void) {
-//         rd_kafka_queue_t *rkq;
-//         const char *topic;
-//         rd_kafka_t *consumer;
-//         int p;
-//         uint64_t testid;
-//         rd_kafka_conf_t *conf;
-//         consumer_t consumer_args = RD_ZERO_INIT;
-//         test_msgver_t mv;
-//         thrd_t thread_id;
-//         rd_kafka_resp_err_t err;
-//         rd_kafka_topic_partition_list_t *pause_partition_list;
-//         rd_kafka_message_t **rkmessages;
-//         size_t msg_cnt;
-//         const int timeout_ms            = 10000;
-//         const int consume_msg_cnt       = 10;
-//         const int produce_msg_cnt       = 8;
-//         const int produce_partition_cnt = 2;
-//         const int expected_msg_cnt      = 4;
-//         int32_t pause_partition         = 0;
+static void do_test_consume_batch_with_pause_and_resume(void) {
+        rd_kafka_queue_t *rkq;
+        const char *topic;
+        rd_kafka_t *consumer;
+        int p;
+        uint64_t testid;
+        rd_kafka_conf_t *conf;
+        consumer_t consumer_args = RD_ZERO_INIT;
+        test_msgver_t mv;
+        thrd_t thread_id;
+        rd_kafka_resp_err_t err;
+        rd_kafka_topic_partition_list_t *pause_partition_list;
+        rd_kafka_message_t **rkmessages;
+        const int timeout_ms       = 2000;
+        const int consume_msg_cnt  = 10;
+        const int produce_msg_cnt  = 8;
+        const int partition_cnt    = 2;
+        const int expected_msg_cnt = 4;
+        int32_t pause_partition    = 0;
 
-//         SUB_TEST();
+        SUB_TEST();
 
-//         test_conf_init(&conf, NULL, 60);
-//         test_conf_set(conf, "enable.auto.commit", "false");
-//         test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "auto.offset.reset", "earliest");
 
-//         testid = test_id_generate();
-//         test_msgver_init(&mv, testid);
+        testid = test_id_generate();
+        test_msgver_init(&mv, testid);
 
-//         /* Produce messages */
-//         topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
+        /* Produce messages */
+        topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
 
-//         for (p = 0; p < produce_partition_cnt; p++)
-//                 test_produce_msgs_easy(topic, testid, p,
-//                                        produce_msg_cnt /
-//                                        produce_partition_cnt);
+        test_create_topic(NULL, topic, partition_cnt, 1);
 
-//         /* Create consumers */
-//         consumer =
-//             test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
+        for (p = 0; p < partition_cnt; p++)
+                test_produce_msgs_easy(topic, testid, p,
+                                       produce_msg_cnt / partition_cnt);
 
-//         test_consumer_subscribe(consumer, topic);
-//         test_consumer_wait_assignment(consumer, rd_false);
+        /* Create consumers */
+        consumer =
+            test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
 
-//         /* Create generic consume queue */
-//         rkq = rd_kafka_queue_get_consumer(consumer);
+        test_consumer_subscribe(consumer, topic);
+        test_consumer_wait_assignment(consumer, rd_false);
 
-//         consumer_args.what             = "CONSUMER";
-//         consumer_args.rkq              = rkq;
-//         consumer_args.timeout_ms       = timeout_ms;
-//         consumer_args.consume_msg_cnt  = consume_msg_cnt;
-//         consumer_args.expected_msg_cnt = expected_msg_cnt;
-//         consumer_args.rk               = consumer;
-//         consumer_args.testid           = testid;
-//         consumer_args.mv               = &mv;
-//         consumer_args.test             = test_curr;
-//         if (thrd_create(&thread_id, consumer_batch_queue, &consumer_args) !=
-//             thrd_success)
-//                 TEST_FAIL("Failed to create thread for %s", "CONSUMER");
+        /* Create generic consume queue */
+        rkq = rd_kafka_queue_get_consumer(consumer);
 
-//         pause_partition_list = rd_kafka_topic_partition_list_new(1);
-//         rd_kafka_topic_partition_list_add(pause_partition_list, topic,
-//                                           pause_partition);
+        consumer_args.what             = "CONSUMER";
+        consumer_args.rkq              = rkq;
+        consumer_args.timeout_ms       = timeout_ms;
+        consumer_args.consume_msg_cnt  = consume_msg_cnt;
+        consumer_args.expected_msg_cnt = expected_msg_cnt;
+        consumer_args.rk               = consumer;
+        consumer_args.testid           = testid;
+        consumer_args.mv               = &mv;
+        consumer_args.test             = test_curr;
+        if (thrd_create(&thread_id, consumer_batch_queue, &consumer_args) !=
+            thrd_success)
+                TEST_FAIL("Failed to create thread for %s", "CONSUMER");
 
-//         rd_sleep(1);
-//         err = rd_kafka_pause_partitions(consumer, pause_partition_list);
+        pause_partition_list = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(pause_partition_list, topic,
+                                          pause_partition);
 
-//         TEST_ASSERT(!err, "Failed to pause partition %d for topic %s",
-//                     pause_partition, topic);
+        rd_sleep(1);
+        err = rd_kafka_pause_partitions(consumer, pause_partition_list);
 
-//         rd_sleep(1);
+        TEST_ASSERT(!err, "Failed to pause partition %d for topic %s",
+                    pause_partition, topic);
 
-//         err = rd_kafka_resume_partitions(consumer, pause_partition_list);
+        thrd_join(thread_id, NULL);
 
-//         TEST_ASSERT(!err, "Failed to resume partition %d for topic %s",
-//                     pause_partition, topic);
+        test_msgver_verify("CONSUME", &mv,
+                           TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+                               TEST_MSGVER_BY_OFFSET,
+                           0, expected_msg_cnt);
 
-//         thrd_join(thread_id, NULL);
+        err = rd_kafka_resume_partitions(consumer, pause_partition_list);
 
-//         rkmessages = malloc(consume_msg_cnt * sizeof(*rkmessages));
+        TEST_ASSERT(!err, "Failed to resume partition %d for topic %s",
+                    pause_partition, topic);
 
-//         msg_cnt = rd_kafka_consume_batch_queue(rkq, timeout_ms, rkmessages,
-//                                                consume_msg_cnt);
+        rd_sleep(2);
 
-//         TEST_ASSERT(msg_cnt == expected_msg_cnt,
-//                     "consumed %zu messages, expected %d", msg_cnt,
-//                     expected_msg_cnt);
+        consumer_batch_queue(&consumer_args);
 
-//         test_msgver_verify("CONSUME", &mv, TEST_MSGVER_ORDER |
-//         TEST_MSGVER_DUP,
-//                            0, produce_msg_cnt);
-//         test_msgver_clear(&mv);
+        test_msgver_verify("CONSUME", &mv,
+                           TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+                               TEST_MSGVER_BY_OFFSET,
+                           0, produce_msg_cnt);
 
-//         rd_kafka_queue_destroy(rkq);
+        rd_kafka_topic_partition_list_destroy(pause_partition_list);
 
-//         test_consumer_close(consumer);
+        test_msgver_clear(&mv);
 
-//         rd_kafka_destroy(consumer);
+        rd_kafka_queue_destroy(rkq);
 
-//         SUB_TEST_PASS();
-// }
+        test_consumer_close(consumer);
+
+        rd_kafka_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
+static void do_test_consume_batch_store_offset(void) {
+        rd_kafka_queue_t *rkq;
+        const char *topic;
+        rd_kafka_t *consumer;
+        int p;
+        int i;
+        uint64_t testid;
+        rd_kafka_conf_t *conf;
+        consumer_t consumer_args = RD_ZERO_INIT;
+        test_msgver_t mv;
+        const int partition_cnt    = 1;
+        const int timeout_ms       = 10000;
+        const int consume_msg_cnt  = 4;
+        const int no_of_consume    = 2;
+        const int produce_msg_cnt  = 8;
+        const int expected_msg_cnt = produce_msg_cnt;
+
+        SUB_TEST();
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "enable.auto.offset.store", "true");
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+
+        testid = test_id_generate();
+        test_msgver_init(&mv, testid);
+
+        /* Produce messages */
+        topic = test_mk_topic_name("0137-barrier_batch_consume", 1);
+
+        test_create_topic(NULL, topic, partition_cnt, 1);
+
+        for (p = 0; p < partition_cnt; p++)
+                test_produce_msgs_easy(topic, testid, p,
+                                       produce_msg_cnt / partition_cnt);
+
+        for (i = 0; i < no_of_consume; i++) {
+
+                /* Create consumers */
+                consumer = test_create_consumer(topic, NULL,
+                                                rd_kafka_conf_dup(conf), NULL);
+                test_consumer_subscribe(consumer, topic);
+                test_consumer_wait_assignment(consumer, rd_false);
+
+                /* Create generic consume queue */
+                rkq = rd_kafka_queue_get_consumer(consumer);
+
+                consumer_args.what            = "CONSUMER";
+                consumer_args.rkq             = rkq;
+                consumer_args.timeout_ms      = timeout_ms;
+                consumer_args.consume_msg_cnt = consume_msg_cnt;
+                consumer_args.expected_msg_cnt =
+                    produce_msg_cnt / no_of_consume;
+                consumer_args.rk     = consumer;
+                consumer_args.testid = testid;
+                consumer_args.mv     = &mv;
+                consumer_args.test   = test_curr;
+
+                consumer_batch_queue(&consumer_args);
+                rd_kafka_commit(consumer, NULL, rd_false);
+
+                rd_kafka_queue_destroy(rkq);
+                test_consumer_close(consumer);
+                rd_kafka_destroy(consumer);
+        }
+
+        test_msgver_verify("CONSUME", &mv,
+                           TEST_MSGVER_ORDER | TEST_MSGVER_DUP |
+                               TEST_MSGVER_BY_OFFSET,
+                           0, expected_msg_cnt);
+
+        SUB_TEST_PASS();
+}
 
 
 int main_0137_barrier_batch_consume(int argc, char **argv) {
         do_test_consume_batch_with_seek();
-        // FIXME: Run this test once consume batch is fully fixed.
-        // do_test_consume_batch_with_pause_and_resume();
+        do_test_consume_batch_store_offset();
+        do_test_consume_batch_with_pause_and_resume();
         return 0;
 }


### PR DESCRIPTION
1. Fixes app_offset and store_offset getting updated after reading each messages. This would have resulted in incorrect app_offset and store_offset in case of Barrier op purging some messages.
2. Fixes pause and resume skipping some offsets in case of Barrier op due to the above app_offset update.