### PR TITLE
Avoid clock calls on poll when enforcing max.poll.interval.ms - 60% cpu consumption reduction on poll

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2185,8 +2185,9 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
          */
         rk = rd_calloc(1, sizeof(*rk));
 
-        rk->rk_type       = type;
-        rk->rk_ts_created = rd_clock();
+        rk->rk_type         = type;
+        rk->rk_ts_created   = rd_clock();
+        rk->rk_ts_last_poll = rk->rk_ts_created;
 
         /* Struct-copy the config object. */
         rk->rk_conf = *conf;
@@ -2222,7 +2223,7 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
         rd_interval_init(&rk->rk_suppress.sparse_connect_random);
         mtx_init(&rk->rk_suppress.sparse_connect_lock, mtx_plain);
 
-        rd_atomic64_init(&rk->rk_ts_last_poll, rk->rk_ts_created);
+        rd_atomic32_init(&rk->rk_polled_flag, 0);
         rd_atomic32_init(&rk->rk_flushing, 0);
 
         rk->rk_rep             = rd_kafka_q_new(rk);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3323,11 +3323,11 @@ rd_kafka_cgrp_incremental_assign(rd_kafka_cgrp_t *rkcg,
                          * call, which would be costly (once per message),
                          * set up an intervalled timer that checks a timestamp
                          * (that is updated on ..poll()).
-                         * The timer interval is 2 hz. */
+                         * The timer interval is 4 hz. */
                         rd_kafka_timer_start(
                             &rkcg->rkcg_rk->rk_timers,
                             &rkcg->rkcg_max_poll_interval_tmr,
-                            500 * 1000ll /* 500ms */,
+                            250 * 1000ll /* 250ms */,
                             rd_kafka_cgrp_max_poll_interval_check_tmr_cb, rkcg);
                 }
         }
@@ -3589,11 +3589,11 @@ rd_kafka_cgrp_assign(rd_kafka_cgrp_t *rkcg,
                          * call, which would be costly (once per message),
                          * set up an intervalled timer that checks a timestamp
                          * (that is updated on ..poll()).
-                         * The timer interval is 2 hz. */
+                         * The timer interval is 4 hz. */
                         rd_kafka_timer_start(
                             &rkcg->rkcg_rk->rk_timers,
                             &rkcg->rkcg_max_poll_interval_tmr,
-                            500 * 1000ll /* 500ms */,
+                            250 * 1000ll /* 250ms */,
                             rd_kafka_cgrp_max_poll_interval_check_tmr_cb, rkcg);
                 }
         }

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -1150,7 +1150,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
      "offsets (using offsets_store()) *after* message processing, to "
      "make sure offsets are not auto-committed prior to processing "
      "has finished. "
-     "The interval is checked two times per second. "
+     "Whether we recently polled is checked four times per second. "
+     "It takes at most 500ms to notice that application code hasn't "
+     "polled recently enough. "
      "See KIP-62 for more information.",
      1, 86400 * 1000, 300000},
 


### PR DESCRIPTION
Helps #4196.

This reworks slightly max.poll.interval.ms enforcement so that it costs basically nothing as we poll for messages, while still achieving the same constraints in the worse-case (that is, it still takes 500ms at most to realize that app hasn't polled in those 500ms.)

This has a very significant performance impact, as described at https://github.com/confluentinc/librdkafka/issues/4196.

Notably, when making calls that don't involve timeouts:

Before:
![image](https://user-images.githubusercontent.com/9094255/224560197-7879f8aa-7405-46b8-83e1-7addf8977ad0.png)

After:
![image](https://user-images.githubusercontent.com/9094255/224560204-473580ac-71f1-42a0-b414-1bc69596a403.png)
