### PR TITLE
Add field to rd_kafka_queue which denotes if it contains fetched msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ librdkafka v2.1.1 is a maintenance release:
  * Fix CMake pkg-config cURL require and use
    pkg-config `Requires.private` field (@FantasqueX, @stertingen, #4180).
  * Fixes certain cases where polling would not rejoin the consumer group
-   when the cause of leaving the group was exceeding `max.poll.interval.ms`.
-   (#4256).
+ * Fixes certain cases where polling would not keep the consumer
+   in the group or make it rejoin it (#4256).
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ librdkafka v2.1.1 is a maintenance release:
  * Fix CMake pkg-config cURL require and use
    pkg-config `Requires.private` field (@FantasqueX, @stertingen, #4180).
  * Fixes certain cases where polling would not rejoin the consumer group
-   when the cause of leaving the group was exceeding `max.poll.interval.ms`
+   when the cause of leaving the group was exceeding `max.poll.interval.ms`.
    (#4256).
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ librdkafka v2.1.1 is a maintenance release:
    expires while waiting for the result of a list offsets operation (#4254).
  * Fix CMake pkg-config cURL require and use
    pkg-config `Requires.private` field (@FantasqueX, @stertingen, #4180).
- * Fixes certain cases where polling would not rejoin the consumer group
  * Fixes certain cases where polling would not keep the consumer
    in the group or make it rejoin it (#4256).
 
@@ -31,7 +30,7 @@ librdkafka v2.1.1 is a maintenance release:
    `max.poll.interval.ms`. Only certain functions were made to reset the timer,
    but it is possible for the user to obtain the queue with messages from
    the broker, skipping these functions. This was fixed by encoding information
-   in a queue itself, that whether polling it should reset the timer.
+   in a queue itself, that, whether polling, resets the timer.
 
 
 # librdkafka v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ librdkafka v2.1.1 is a maintenance release:
    expires while waiting for the result of a list offsets operation (#4254).
  * Fix CMake pkg-config cURL require and use
    pkg-config `Requires.private` field (@FantasqueX, @stertingen, #4180).
+ * Fixes certain cases where polling would not rejoin the consumer group
+   when the cause of leaving the group was exceeding `max.poll.interval.ms`
+   (#4256).
 
 ## Fixes
 
@@ -24,8 +27,11 @@ librdkafka v2.1.1 is a maintenance release:
    allowing threads different from the main one to call
    the `rd_kafka_toppar_set_fetch_state` function, given they hold
    the lock on the `rktp`.
-
-
+ * In v2.1.0, a bug was fixed which caused polling any queue to reset the
+   `max.poll.interval.ms`. Only certain functions were made to reset the timer,
+   but it is possible for the user to obtain the queue with messages from
+   the broker, skipping these functions. This was fixed by encoding information
+   in a queue itself, that whether polling it should reset the timer.
 
 # librdkafka v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ librdkafka v2.1.1 is a maintenance release:
    the broker, skipping these functions. This was fixed by encoding information
    in a queue itself, that whether polling it should reset the timer.
 
+
 # librdkafka v2.1.0
 
 librdkafka v2.1.0 is a feature release:

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3050,16 +3050,16 @@ static rd_kafka_op_res_t rd_kafka_consume_callback0(
     void *opaque) {
         struct consume_ctx ctx = {.consume_cb = consume_cb, .opaque = opaque};
         rd_kafka_op_res_t res;
-        const int does_q_contain_consumer_msgs =
-            rd_kafka_q_consumer_cnt(rkq, 1);
+        const rd_bool_t can_q_contain_fetched_msgs =
+            rd_kafka_q_can_contain_fetched_msgs(rkq, RD_DO_LOCK);
 
-        if (timeout_ms && does_q_contain_consumer_msgs)
+        if (timeout_ms && can_q_contain_fetched_msgs)
                 rd_kafka_app_poll_blocking(rkq->rkq_rk);
 
         res = rd_kafka_q_serve(rkq, timeout_ms, max_cnt, RD_KAFKA_Q_CB_RETURN,
                                rd_kafka_consume_cb, &ctx);
 
-        if (does_q_contain_consumer_msgs)
+        if (can_q_contain_fetched_msgs)
                 rd_kafka_app_polled(rkq->rkq_rk);
 
         return res;
@@ -3124,10 +3124,10 @@ rd_kafka_consume0(rd_kafka_t *rk, rd_kafka_q_t *rkq, int timeout_ms) {
         rd_kafka_op_t *rko;
         rd_kafka_message_t *rkmessage = NULL;
         rd_ts_t abs_timeout           = rd_timeout_init(timeout_ms);
-        const int does_q_contain_consumer_msgs =
-            rd_kafka_q_consumer_cnt(rkq, 1);
+        const rd_bool_t can_q_contain_fetched_msgs =
+            rd_kafka_q_can_contain_fetched_msgs(rkq, RD_DO_LOCK);
 
-        if (timeout_ms && does_q_contain_consumer_msgs)
+        if (timeout_ms && can_q_contain_fetched_msgs)
                 rd_kafka_app_poll_blocking(rk);
 
         rd_kafka_yield_thread = 0;
@@ -3146,7 +3146,7 @@ rd_kafka_consume0(rd_kafka_t *rk, rd_kafka_q_t *rkq, int timeout_ms) {
                         /* Callback called rd_kafka_yield(), we must
                          * stop dispatching the queue and return. */
                         rd_kafka_set_last_error(RD_KAFKA_RESP_ERR__INTR, EINTR);
-                        if (does_q_contain_consumer_msgs)
+                        if (can_q_contain_fetched_msgs)
                                 rd_kafka_app_polled(rk);
                         return NULL;
                 }
@@ -3159,7 +3159,7 @@ rd_kafka_consume0(rd_kafka_t *rk, rd_kafka_q_t *rkq, int timeout_ms) {
                 /* Timeout reached with no op returned. */
                 rd_kafka_set_last_error(RD_KAFKA_RESP_ERR__TIMED_OUT,
                                         ETIMEDOUT);
-                if (does_q_contain_consumer_msgs)
+                if (can_q_contain_fetched_msgs)
                         rd_kafka_app_polled(rk);
                 return NULL;
         }
@@ -3175,7 +3175,7 @@ rd_kafka_consume0(rd_kafka_t *rk, rd_kafka_q_t *rkq, int timeout_ms) {
 
         rd_kafka_set_last_error(0, 0);
 
-        if (does_q_contain_consumer_msgs)
+        if (can_q_contain_fetched_msgs)
                 rd_kafka_app_polled(rk);
 
         return rkmessage;
@@ -4011,16 +4011,16 @@ rd_kafka_op_res_t rd_kafka_poll_cb(rd_kafka_t *rk,
 
 int rd_kafka_poll(rd_kafka_t *rk, int timeout_ms) {
         int r;
-        const int does_q_contain_consumer_msgs =
-            rd_kafka_q_consumer_cnt(rk->rk_rep, 1);
+        const rd_bool_t can_q_contain_fetched_msgs =
+            rd_kafka_q_can_contain_fetched_msgs(rk->rk_rep, RD_DO_LOCK);
 
-        if (timeout_ms && does_q_contain_consumer_msgs)
+        if (timeout_ms && can_q_contain_fetched_msgs)
                 rd_kafka_app_poll_blocking(rk);
 
         r = rd_kafka_q_serve(rk->rk_rep, timeout_ms, 0, RD_KAFKA_Q_CB_CALLBACK,
                              rd_kafka_poll_cb, NULL);
 
-        if (does_q_contain_consumer_msgs)
+        if (can_q_contain_fetched_msgs)
                 rd_kafka_app_polled(rk);
 
         return r;
@@ -4029,16 +4029,17 @@ int rd_kafka_poll(rd_kafka_t *rk, int timeout_ms) {
 
 rd_kafka_event_t *rd_kafka_queue_poll(rd_kafka_queue_t *rkqu, int timeout_ms) {
         rd_kafka_op_t *rko;
-        const int does_q_contain_consumer_msgs =
-            rd_kafka_q_consumer_cnt(rkqu->rkqu_q, 1);
+        const rd_bool_t can_q_contain_fetched_msgs =
+            rd_kafka_q_can_contain_fetched_msgs(rkqu->rkqu_q, RD_DO_LOCK);
 
-        if (timeout_ms && does_q_contain_consumer_msgs)
+
+        if (timeout_ms && can_q_contain_fetched_msgs)
                 rd_kafka_app_poll_blocking(rkqu->rkqu_rk);
 
         rko = rd_kafka_q_pop_serve(rkqu->rkqu_q, rd_timeout_us(timeout_ms), 0,
                                    RD_KAFKA_Q_CB_EVENT, rd_kafka_poll_cb, NULL);
 
-        if (does_q_contain_consumer_msgs)
+        if (can_q_contain_fetched_msgs)
                 rd_kafka_app_polled(rkqu->rkqu_rk);
 
         if (!rko)
@@ -4049,16 +4050,16 @@ rd_kafka_event_t *rd_kafka_queue_poll(rd_kafka_queue_t *rkqu, int timeout_ms) {
 
 int rd_kafka_queue_poll_callback(rd_kafka_queue_t *rkqu, int timeout_ms) {
         int r;
-        const int does_q_contain_consumer_msgs =
-            rd_kafka_q_consumer_cnt(rkqu->rkqu_q, 1);
+        const rd_bool_t can_q_contain_fetched_msgs =
+            rd_kafka_q_can_contain_fetched_msgs(rkqu->rkqu_q, RD_DO_LOCK);
 
-        if (timeout_ms && does_q_contain_consumer_msgs)
+        if (timeout_ms && can_q_contain_fetched_msgs)
                 rd_kafka_app_poll_blocking(rkqu->rkqu_rk);
 
         r = rd_kafka_q_serve(rkqu->rkqu_q, timeout_ms, 0,
                              RD_KAFKA_Q_CB_CALLBACK, rd_kafka_poll_cb, NULL);
 
-        if (does_q_contain_consumer_msgs)
+        if (can_q_contain_fetched_msgs)
                 rd_kafka_app_polled(rkqu->rkqu_rk);
 
         return r;

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3427,7 +3427,7 @@ rd_kafka_error_t *rd_kafka_sasl_set_credentials(rd_kafka_t *rk,
  * @returns a reference to the librdkafka consumer queue.
  * This is the queue served by rd_kafka_consumer_poll().
  *
- * Use rd_kafka_queue_destroy() to lose the reference.
+ * Use rd_kafka_queue_destroy() to loose the reference.
  *
  * @remark rd_kafka_queue_destroy() MUST be called on this queue
  *         prior to calling rd_kafka_consumer_close().

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3427,10 +3427,16 @@ rd_kafka_error_t *rd_kafka_sasl_set_credentials(rd_kafka_t *rk,
  * @returns a reference to the librdkafka consumer queue.
  * This is the queue served by rd_kafka_consumer_poll().
  *
- * Use rd_kafka_queue_destroy() to loose the reference.
+ * Use rd_kafka_queue_destroy() to lose the reference.
  *
  * @remark rd_kafka_queue_destroy() MUST be called on this queue
  *         prior to calling rd_kafka_consumer_close().
+ * @remark Polling the returned queue counts as a consumer poll, and will reset
+ *         the timer for max.poll.interval.ms. If this queue is forwarded to a
+ *         "destq", polling destq also counts as a consumer poll (this works
+ *         for any number of forwards). However, even if this queue is
+ *         unforwarded or forwarded elsewhere, polling destq will continue
+ *         to count as a consumer poll.
  */
 RD_EXPORT
 rd_kafka_queue_t *rd_kafka_queue_get_consumer(rd_kafka_t *rk);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -415,7 +415,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_wait_coord_q             = rd_kafka_q_new(rk);
         rkcg->rkcg_wait_coord_q->rkq_serve  = rkcg->rkcg_ops->rkq_serve;
         rkcg->rkcg_wait_coord_q->rkq_opaque = rkcg->rkcg_ops->rkq_opaque;
-        rkcg->rkcg_q                        = rd_kafka_q_new(rk);
+        rkcg->rkcg_q                        = rd_kafka_q_new_consume(rk);
         rkcg->rkcg_group_instance_id =
             rd_kafkap_str_new(rk->rk_conf.group_instance_id, -1);
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -415,7 +415,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_wait_coord_q             = rd_kafka_q_new(rk);
         rkcg->rkcg_wait_coord_q->rkq_serve  = rkcg->rkcg_ops->rkq_serve;
         rkcg->rkcg_wait_coord_q->rkq_opaque = rkcg->rkcg_ops->rkq_opaque;
-        rkcg->rkcg_q                        = rd_kafka_q_new_consume(rk);
+        rkcg->rkcg_q                        = rd_kafka_consume_q_new(rk);
         rkcg->rkcg_group_instance_id =
             rd_kafkap_str_new(rk->rk_conf.group_instance_id, -1);
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -252,7 +252,7 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0(rd_kafka_topic_t *rkt,
         mtx_init(&rktp->rktp_lock, mtx_plain);
 
         rd_refcnt_init(&rktp->rktp_refcnt, 0);
-        rktp->rktp_fetchq          = rd_kafka_q_new_consume(rkt->rkt_rk);
+        rktp->rktp_fetchq          = rd_kafka_consume_q_new(rkt->rkt_rk);
         rktp->rktp_ops             = rd_kafka_q_new(rkt->rkt_rk);
         rktp->rktp_ops->rkq_serve  = rd_kafka_toppar_op_serve;
         rktp->rktp_ops->rkq_opaque = rktp;

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -252,7 +252,7 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0(rd_kafka_topic_t *rkt,
         mtx_init(&rktp->rktp_lock, mtx_plain);
 
         rd_refcnt_init(&rktp->rktp_refcnt, 0);
-        rktp->rktp_fetchq          = rd_kafka_q_new(rkt->rkt_rk);
+        rktp->rktp_fetchq          = rd_kafka_q_new_consume(rkt->rkt_rk);
         rktp->rktp_ops             = rd_kafka_q_new(rkt->rkt_rk);
         rktp->rktp_ops->rkq_serve  = rd_kafka_toppar_op_serve;
         rktp->rktp_ops->rkq_opaque = rktp;

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -90,9 +90,8 @@ void rd_kafka_q_init0(rd_kafka_q_t *rkq,
         rkq->rkq_fwdq   = NULL;
         rkq->rkq_refcnt = 1;
         rkq->rkq_flags  = RD_KAFKA_Q_F_READY;
-        if (for_consume) {
+        if (for_consume)
                 rkq->rkq_flags |= RD_KAFKA_Q_F_CONSUMER;
-        }
         rkq->rkq_rk     = rk;
         rkq->rkq_qio    = NULL;
         rkq->rkq_serve  = NULL;

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -638,7 +638,6 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
         rd_kafka_q_t *fwdq;
         struct timespec timeout_tspec;
         int i;
-        rd_bool_t can_q_contain_fetched_msgs;
 
         mtx_lock(&rkq->rkq_lock);
         if ((fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
@@ -651,11 +650,9 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 return cnt;
         }
 
-        can_q_contain_fetched_msgs =
-            rd_kafka_q_can_contain_fetched_msgs(rkq, RD_DONT_LOCK);
         mtx_unlock(&rkq->rkq_lock);
 
-        if (timeout_ms && can_q_contain_fetched_msgs)
+        if (timeout_ms)
                 rd_kafka_app_poll_blocking(rk);
 
         rd_timeout_init_timespec(&timeout_tspec, timeout_ms);
@@ -762,8 +759,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 rd_kafka_op_destroy(rko);
         }
 
-        if (can_q_contain_fetched_msgs)
-                rd_kafka_app_polled(rk);
+        rd_kafka_app_polled(rk);
 
         return cnt;
 }

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -76,6 +76,12 @@ struct rd_kafka_q_s {
              * but without having to enqueue                                   \
              * an op. */
 
+        /* Set to 1 for queues which contain consumer messages, and 0 otherwise.
+         * If a queue A forwards its messages to a queue B, B.rkq_consumer_cnt
+         * +=  A.rkq_consumer_cnt. When queue A is set to forward to NULL, this
+         * is reverted. */
+        int rkq_consumer_cnt;
+
         rd_kafka_t *rkq_rk;
         struct rd_kafka_q_io *rkq_qio; /* FD-based application signalling */
 
@@ -123,12 +129,18 @@ static RD_INLINE RD_UNUSED int rd_kafka_q_ready(rd_kafka_q_t *rkq) {
 
 void rd_kafka_q_init0(rd_kafka_q_t *rkq,
                       rd_kafka_t *rk,
+                      int is_consume,
                       const char *func,
                       int line);
 #define rd_kafka_q_init(rkq, rk)                                               \
-        rd_kafka_q_init0(rkq, rk, __FUNCTION__, __LINE__)
-rd_kafka_q_t *rd_kafka_q_new0(rd_kafka_t *rk, const char *func, int line);
-#define rd_kafka_q_new(rk) rd_kafka_q_new0(rk, __FUNCTION__, __LINE__)
+        rd_kafka_q_init0(rkq, rk, 0, __FUNCTION__, __LINE__)
+#define rd_kafka_q_init_consume(rkq, rk)                                       \
+        rd_kafka_q_init0(rkq, rk, 1, __FUNCTION__, __LINE__)
+rd_kafka_q_t *
+rd_kafka_q_new0(rd_kafka_t *rk, int is_consume, const char *func, int line);
+#define rd_kafka_q_new(rk) rd_kafka_q_new0(rk, 0, __FUNCTION__, __LINE__)
+#define rd_kafka_q_new_consume(rk)                                             \
+        rd_kafka_q_new0(rk, 1, __FUNCTION__, __LINE__)
 void rd_kafka_q_destroy_final(rd_kafka_q_t *rkq);
 
 #define rd_kafka_q_lock(rkqu)   mtx_lock(&(rkqu)->rkq_lock)
@@ -1162,6 +1174,22 @@ rd_kafka_enq_once_disable(rd_kafka_enq_once_t *eonce) {
         }
 
         return rko;
+}
+
+/**
+ * @brief Returns the rkq's rkq_consumer_cnt.
+ *
+ * @locks rd_kafka_q_lock(rkq) if do_lock is set.
+ */
+static RD_INLINE RD_UNUSED int rd_kafka_q_consumer_cnt(rd_kafka_q_t *rkq,
+                                                       int do_lock) {
+        int cnt;
+        if (do_lock)
+                mtx_lock(&rkq->rkq_lock);
+        cnt = rkq->rkq_consumer_cnt;
+        if (do_lock)
+                mtx_unlock(&rkq->rkq_lock);
+        return cnt;
 }
 
 

--- a/tests/0089-max_poll_interval.c
+++ b/tests/0089-max_poll_interval.c
@@ -357,8 +357,11 @@ done:
  * leaving due to a max.poll.interval.ms timeout. The poll does not need to
  * go through any special function, any queue containing consumer messages
  * should suffice.
+ * We test with the result of rd_kafka_queue_get_consumer, and an arbitrary
+ * queue that is forwarded to by the result of rd_kafka_queue_get_consumer.
  */
-static void do_test_rejoin_after_interval_expire(void) {
+static void
+do_test_rejoin_after_interval_expire(rd_bool_t forward_to_another_q) {
         const char *topic = test_mk_topic_name("0089_max_poll_interval", 1);
         rd_kafka_conf_t *conf;
         int i;
@@ -366,8 +369,10 @@ static void do_test_rejoin_after_interval_expire(void) {
         rd_kafka_t *rk                   = NULL;
         rd_kafka_queue_t *consumer_queue = NULL;
         rd_kafka_event_t *event          = NULL;
+        rd_kafka_queue_t *polling_queue  = NULL;
 
-        SUB_TEST();
+        SUB_TEST("Testing with forward_to_another_q = %d",
+                 forward_to_another_q);
 
         test_create_topic(NULL, topic, 1, 1);
 
@@ -382,9 +387,16 @@ static void do_test_rejoin_after_interval_expire(void) {
         rk = test_create_consumer(groupid, test_rebalance_cb, conf, NULL);
 
         consumer_queue = rd_kafka_queue_get_consumer(rk);
+
         test_consumer_subscribe(rk, topic);
 
-        event = test_wait_event(consumer_queue, RD_KAFKA_EVENT_REBALANCE,
+        if (forward_to_another_q) {
+                polling_queue = rd_kafka_queue_new(rk);
+                rd_kafka_queue_forward(consumer_queue, polling_queue);
+        } else
+                polling_queue = consumer_queue;
+
+        event = test_wait_event(polling_queue, RD_KAFKA_EVENT_REBALANCE,
                                 (int)(test_timeout_multiplier * 10000));
         TEST_ASSERT(event,
                     "Did not get a rebalance event for initial group join");
@@ -398,7 +410,7 @@ static void do_test_rejoin_after_interval_expire(void) {
 
         /* Note that by polling for the group leave, we're also polling the
          * consumer queue, and hence it should trigger a rejoin. */
-        event = test_wait_event(consumer_queue, RD_KAFKA_EVENT_REBALANCE,
+        event = test_wait_event(polling_queue, RD_KAFKA_EVENT_REBALANCE,
                                 (int)(test_timeout_multiplier * 10000));
         TEST_ASSERT(event, "Did not get a rebalance event for the group leave");
         TEST_ASSERT(rd_kafka_event_error(event) ==
@@ -407,7 +419,7 @@ static void do_test_rejoin_after_interval_expire(void) {
         rd_kafka_assign(rk, NULL);
         rd_kafka_event_destroy(event);
 
-        event = test_wait_event(consumer_queue, RD_KAFKA_EVENT_REBALANCE,
+        event = test_wait_event(polling_queue, RD_KAFKA_EVENT_REBALANCE,
                                 (int)(test_timeout_multiplier * 10000));
         TEST_ASSERT(event, "Should get a rebalance event for the group rejoin");
         TEST_ASSERT(rd_kafka_event_error(event) ==
@@ -416,6 +428,8 @@ static void do_test_rejoin_after_interval_expire(void) {
         rd_kafka_assign(rk, rd_kafka_event_topic_partition_list(event));
         rd_kafka_event_destroy(event);
 
+        if (forward_to_another_q)
+                rd_kafka_queue_destroy(polling_queue);
         rd_kafka_queue_destroy(consumer_queue);
         test_consumer_close(rk);
         rd_kafka_destroy(rk);
@@ -426,6 +440,7 @@ static void do_test_rejoin_after_interval_expire(void) {
 int main_0089_max_poll_interval(int argc, char **argv) {
         do_test();
         do_test_with_log_queue();
-        do_test_rejoin_after_interval_expire();
+        do_test_rejoin_after_interval_expire(rd_false);
+        do_test_rejoin_after_interval_expire(rd_true);
         return 0;
 }

--- a/tests/0089-max_poll_interval.c
+++ b/tests/0089-max_poll_interval.c
@@ -364,7 +364,6 @@ static void
 do_test_rejoin_after_interval_expire(rd_bool_t forward_to_another_q) {
         const char *topic = test_mk_topic_name("0089_max_poll_interval", 1);
         rd_kafka_conf_t *conf;
-        int i;
         char groupid[64];
         rd_kafka_t *rk                   = NULL;
         rd_kafka_queue_t *consumer_queue = NULL;

--- a/tests/0089-max_poll_interval.c
+++ b/tests/0089-max_poll_interval.c
@@ -354,7 +354,9 @@ done:
 
 /**
  * @brief Consumer should be able to rejoin the group just by polling after
- * leaving due to a max.poll.interval.ms timeout.
+ * leaving due to a max.poll.interval.ms timeout. The poll does not need to
+ * go through any special function, any queue containing consumer messages
+ * should suffice.
  */
 static void do_test_rejoin_after_interval_expire(void) {
         const char *topic = test_mk_topic_name("0089_max_poll_interval", 1);


### PR DESCRIPTION
   An issue in v2.1.0 was fixed in which max.poll.interval.ms was not honored,
    because it was reset on any queue poll, not just consumer poll.
    It was changed it so that only certain rdkafka.h functions which were polling
    would reset the timer.
    
   However, librdkafka exposes a method rd_kafka_queue_get_consumer, which returns
    the consumer queue, and the application can poll this queue for events rather
    than calling consume poll. There is no way to distinguish polls to this queue
    and an arbitrary queue, and it won't reset the timer.
    
   So, a new field is maintained inside the queue denoting if it might
    contain fetched messages, or not. It deals with forwarding of queues, so
    if a queue which receives fetched messages is forwarded multiple times,
    calling poll on the forwardee will also reset the timer.

Note that there are a few points where someone might forward/unforward into a queue _while_ polling it. (See cases with `does_q_contain_consumer_msgs = rd_kafka_q_consumer_cnt(rkq, 1);`) which might make the timer reset wrong on these occasions. 

I don't think it matters much since that's a somewhat convoluted use case and to fix it will require taking a lock over the duration of the entire poll. But let me know what you think.

Fixes [confluentinc/confluent-kafka-go#980](https://github.com/confluentinc/confluent-kafka-go/issues/980)