### PR TITLE
Add small note for installation on Apple Silicone

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ On Mac OSX, install librdkafka with homebrew:
 $ brew install librdkafka
 ```
 
+<sub><sup>If you have trouble on Apple Silicone, please read [this](https://github.com/confluentinc/confluent-kafka-python/issues/1025#issuecomment-827675182)</sup></sub>
+
 On Debian and Ubuntu, install librdkafka from the Confluent APT repositories,
 see instructions [here](https://docs.confluent.io/current/installation/installing_cp/deb-ubuntu.html#get-the-software) and then install librdkafka:
 


### PR DESCRIPTION
We code mainly in Python, we don't usually use docker in development, especially for a small codebase. I believe this is also the case for a lot of Pythonistas. 

This small text will help some people out there save a lot of time figuring out what went wrong since we just follow the current instruction. 