### PR TITLE
Fix number or bytes skipped when receiving tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# librdkafka v2.1.2
+
+librdkafka v2.1.2 is a maintenance release:
+
+ * Fix a bug that happens when skipping tags, causing buffer underflow in
+   MetadataResponse (#4278).
+
+## Fixes
+
+### General fixes
+
+ * Fix a bug that happens when skipping tags, causing buffer underflow in
+   MetadataResponse. This is triggered since RPC version 9 (v2.1.0),
+   when using Confluent Platform, only when racks are set,
+   observers are activated and there is more than one partition.
+   Fixed by skipping the correct amount of bytes when tags are received.
+
+
 # librdkafka v2.1.1
 
 librdkafka v2.1.1 is a maintenance release:

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -784,9 +784,8 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
                         uint64_t _tagtype, _taglen;                            \
                         rd_kafka_buf_read_uvarint(rkbuf, &_tagtype);           \
                         rd_kafka_buf_read_uvarint(rkbuf, &_taglen);            \
-                        if (_taglen > 1)                                       \
-                                rd_kafka_buf_skip(rkbuf,                       \
-                                                  (size_t)(_taglen - 1));      \
+                        if (_taglen > 0)                                       \
+                                rd_kafka_buf_skip(rkbuf, (size_t)(_taglen));   \
                 }                                                              \
         } while (0)
 


### PR DESCRIPTION
Not being for a nullable field those unsigned varints don't start from 1