### PR TITLE
Makefile: use `$(AR)` instead of `ar`

### DIFF
--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -147,7 +147,7 @@ else ifeq ($(HAS_GNU_AR),y)
 	rm $$_tmp)
 else
 	for _f in $(LIBNAME).a $(MKL_STATIC_LIBS) ; do \
-		ar -r $@ $$_f ; \
+		$(AR) -r $@ $$_f ; \
 	done
 endif
 	cp $@ $(LIBNAME)-static-dbg.a


### PR DESCRIPTION
- When compiling `librdkafka` in a musl switch with `--enable-staatic` and `STATIC_LIB_libzstd=/path/to/lib/zstd` as per the [requirements](https://github.com/confluentinc/librdkafka#requirements), the build fails with:


```
rdkafka-x86_64-unknown-linux-musl> cp librdkafka.a librdkafka-dbg.a
rdkafka-x86_64-unknown-linux-musl> Creating self-contained static library librdkafka-static.a
rdkafka-x86_64-unknown-linux-musl> for _f in librdkafka.a /nix/store/bhzyp5mv4bvylx4s75i0y63yjl9y15xc-zstd-x86_64-unknown-linux-musl-1.5.5/lib/libzstd.a ; do \
rdkafka-x86_64-unknown-linux-musl>      ar -r librdkafka-static.a $_f ; \
rdkafka-x86_64-unknown-linux-musl> done
rdkafka-x86_64-unknown-linux-musl> /nix/store/ywi6kzrk88zl22jvazdnlfaf9rqrj2aq-bash-5.2-p15/bin/bash: line 2: ar: command not found
rdkafka-x86_64-unknown-linux-musl> /nix/store/ywi6kzrk88zl22jvazdnlfaf9rqrj2aq-bash-5.2-p15/bin/bash: line 2: ar: command not found
rdkafka-x86_64-unknown-linux-musl> make[1]: *** [../mklove/Makefile.base:135: librdkafka-static.a] Error 127
rdkafka-x86_64-unknown-linux-musl> make[1]: *** Waiting for unfinished jobs....
```

Replacing `ar` with `$(AR)` (as is done in other places in the Makefile) makes the build complete successfully.