### PR TITLE
[consumer] Trigger a rejoin on partition racks' change [KIP-881]

### DIFF
--- a/src/rdkafka_metadata.h
+++ b/src/rdkafka_metadata.h
@@ -39,6 +39,10 @@ typedef struct rd_kafka_metadata_partition_internal_s {
         int32_t id;
         /** Partition leader epoch */
         int32_t leader_epoch;
+        /* Racks for this partition. Sorted and de-duplicated. */
+        char **racks;
+        /* Count of the racks */
+        size_t racks_cnt;
 } rd_kafka_metadata_partition_internal_t;
 
 /**
@@ -95,6 +99,10 @@ rd_kafka_resp_err_t rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
 rd_kafka_metadata_internal_t *
 rd_kafka_metadata_copy(const rd_kafka_metadata_internal_t *mdi, size_t size);
 
+rd_kafka_metadata_internal_t *
+rd_kafka_metadata_copy_add_racks(const rd_kafka_metadata_internal_t *mdi,
+                                 size_t size);
+
 size_t
 rd_kafka_metadata_topic_match(rd_kafka_t *rk,
                               rd_list_t *tinfos,
@@ -148,6 +156,8 @@ rd_kafka_metadata_request(rd_kafka_t *rk,
 
 
 int rd_kafka_metadata_partition_id_cmp(const void *_a, const void *_b);
+
+int rd_kafka_metadata_broker_internal_cmp(const void *_a, const void *_b);
 
 rd_kafka_metadata_t *
 rd_kafka_metadata_new_topic_mock(const rd_kafka_metadata_topic_t *topics,
@@ -216,10 +226,10 @@ void rd_kafka_metadata_cache_topic_update(
     rd_kafka_t *rk,
     const rd_kafka_metadata_topic_t *mdt,
     const rd_kafka_metadata_topic_internal_t *mdit,
-    rd_bool_t propagate);
-void rd_kafka_metadata_cache_update(rd_kafka_t *rk,
-                                    const rd_kafka_metadata_internal_t *mdi,
-                                    int abs_update);
+    rd_bool_t propagate,
+    rd_bool_t include_metadata,
+    rd_kafka_metadata_broker_internal_t *brokers,
+    size_t broker_cnt);
 void rd_kafka_metadata_cache_propagate_changes(rd_kafka_t *rk);
 struct rd_kafka_metadata_cache_entry *
 rd_kafka_metadata_cache_find(rd_kafka_t *rk, const char *topic, int valid);

--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -449,7 +449,7 @@ void rd_kafka_metadata_cache_topic_update(
     const rd_kafka_metadata_topic_t *mdt,
     const rd_kafka_metadata_topic_internal_t *mdit,
     rd_bool_t propagate,
-    rd_bool_t include_metadata,
+    rd_bool_t include_racks,
     rd_kafka_metadata_broker_internal_t *brokers,
     size_t broker_cnt) {
         rd_ts_t now        = rd_clock();
@@ -465,7 +465,7 @@ void rd_kafka_metadata_cache_topic_update(
             mdt->err == RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED ||
             mdt->err == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART)
                 rd_kafka_metadata_cache_insert(rk, mdt, mdit, now, ts_expires,
-                                               include_metadata, brokers,
+                                               include_racks, brokers,
                                                broker_cnt);
         else
                 changed =

--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -79,11 +79,28 @@ static RD_INLINE void
 rd_kafka_metadata_cache_delete(rd_kafka_t *rk,
                                struct rd_kafka_metadata_cache_entry *rkmce,
                                int unlink_avl) {
+        int i;
         if (unlink_avl)
                 RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl, rkmce);
         TAILQ_REMOVE(&rk->rk_metadata_cache.rkmc_expiry, rkmce, rkmce_link);
         rd_kafka_assert(NULL, rk->rk_metadata_cache.rkmc_cnt > 0);
         rk->rk_metadata_cache.rkmc_cnt--;
+
+        /* The racks need to be freed since they're not contained in the
+         * tmpabuf. */
+        for (i = 0; i < rkmce->rkmce_mtopic.partition_cnt; i++) {
+                size_t j;
+                rd_kafka_metadata_partition_internal_t *partition_internal =
+                    &rkmce->rkmce_metadata_internal_topic.partitions[i];
+
+                if (partition_internal->racks_cnt == 0)
+                        continue;
+
+                for (j = 0; j < partition_internal->racks_cnt; j++) {
+                        rd_free(partition_internal->racks[j]);
+                }
+                rd_free(partition_internal->racks);
+        }
 
         rd_free(rkmce);
 }
@@ -243,7 +260,10 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
     const rd_kafka_metadata_topic_t *mtopic,
     const rd_kafka_metadata_topic_internal_t *metadata_internal_topic,
     rd_ts_t now,
-    rd_ts_t ts_expires) {
+    rd_ts_t ts_expires,
+    rd_bool_t include_racks,
+    rd_kafka_metadata_broker_internal_t *brokers_internal,
+    size_t broker_cnt) {
         struct rd_kafka_metadata_cache_entry *rkmce, *old;
         size_t topic_len;
         rd_tmpabuf_t tbuf;
@@ -254,7 +274,11 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
          * rd_tmpabuf_t provides the infrastructure to do this.
          * Because of this we copy all the structs verbatim but
          * any pointer fields needs to be copied explicitly to update
-         * the pointer address. */
+         * the pointer address.
+         * An exception to this are the racks stored inside
+         * rkmce->rkmce_metadata_internal_topic->partitions[i], because it's
+         * difficult to calculate the size beforehand. See also
+         * rd_kafka_metadata_cache_delete which frees this. */
         topic_len = strlen(mtopic->topic) + 1;
         rd_tmpabuf_new(
             &tbuf,
@@ -285,13 +309,6 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
                              mtopic->partition_cnt *
                                  sizeof(*metadata_internal_topic->partitions));
 
-        /* Clear uncached fields. */
-        for (i = 0; i < mtopic->partition_cnt; i++) {
-                rkmce->rkmce_mtopic.partitions[i].replicas    = NULL;
-                rkmce->rkmce_mtopic.partitions[i].replica_cnt = 0;
-                rkmce->rkmce_mtopic.partitions[i].isrs        = NULL;
-                rkmce->rkmce_mtopic.partitions[i].isr_cnt     = 0;
-        }
 
         /* Sort partitions for future bsearch() lookups. */
         qsort(rkmce->rkmce_mtopic.partitions, rkmce->rkmce_mtopic.partition_cnt,
@@ -300,6 +317,55 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
 
         /* partitions (internal) are already sorted. */
 
+        if (include_racks) {
+                for (i = 0; i < rkmce->rkmce_mtopic.partition_cnt; i++) {
+                        int j;
+                        rd_kafka_metadata_partition_t *partition =
+                            &rkmce->rkmce_mtopic.partitions[i];
+                        rd_kafka_metadata_partition_internal_t
+                            *partition_internal =
+                                &rkmce->rkmce_metadata_internal_topic
+                                     .partitions[i];
+                        rd_list_t *curr_list;
+                        char *rack;
+
+                        if (partition->replica_cnt == 0)
+                                continue;
+
+                        curr_list = rd_list_new(
+                            0, NULL); /* use a list for de-duplication */
+                        for (j = 0; j < partition->replica_cnt; j++) {
+                                rd_kafka_metadata_broker_internal_t key = {
+                                    .id = partition->replicas[j]};
+                                rd_kafka_metadata_broker_internal_t *broker =
+                                    bsearch(
+                                        &key, brokers_internal, broker_cnt,
+                                        sizeof(
+                                            rd_kafka_metadata_broker_internal_t),
+                                        rd_kafka_metadata_broker_internal_cmp);
+                                if (!broker || !broker->rack_id)
+                                        continue;
+                                rd_list_add(curr_list, broker->rack_id);
+                        }
+                        rd_list_deduplicate(&curr_list, rd_strcmp2);
+
+                        partition_internal->racks_cnt = rd_list_cnt(curr_list);
+                        partition_internal->racks     = rd_malloc(
+                            sizeof(char *) * partition_internal->racks_cnt);
+                        RD_LIST_FOREACH(rack, curr_list, j) {
+                                partition_internal->racks[j] = rd_strdup(rack);
+                        }
+                        rd_list_destroy(curr_list);
+                }
+        }
+
+        /* Clear uncached fields. */
+        for (i = 0; i < mtopic->partition_cnt; i++) {
+                rkmce->rkmce_mtopic.partitions[i].replicas    = NULL;
+                rkmce->rkmce_mtopic.partitions[i].replica_cnt = 0;
+                rkmce->rkmce_mtopic.partitions[i].isrs        = NULL;
+                rkmce->rkmce_mtopic.partitions[i].isr_cnt     = 0;
+        }
         TAILQ_INSERT_TAIL(&rk->rk_metadata_cache.rkmc_expiry, rkmce,
                           rkmce_link);
         rk->rk_metadata_cache.rkmc_cnt++;
@@ -382,7 +448,10 @@ void rd_kafka_metadata_cache_topic_update(
     rd_kafka_t *rk,
     const rd_kafka_metadata_topic_t *mdt,
     const rd_kafka_metadata_topic_internal_t *mdit,
-    rd_bool_t propagate) {
+    rd_bool_t propagate,
+    rd_bool_t include_metadata,
+    rd_kafka_metadata_broker_internal_t *brokers,
+    size_t broker_cnt) {
         rd_ts_t now        = rd_clock();
         rd_ts_t ts_expires = now + (rk->rk_conf.metadata_max_age_ms * 1000);
         int changed        = 1;
@@ -395,52 +464,14 @@ void rd_kafka_metadata_cache_topic_update(
         if (!mdt->err ||
             mdt->err == RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED ||
             mdt->err == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART)
-                rd_kafka_metadata_cache_insert(rk, mdt, mdit, now, ts_expires);
+                rd_kafka_metadata_cache_insert(rk, mdt, mdit, now, ts_expires,
+                                               include_metadata, brokers,
+                                               broker_cnt);
         else
                 changed =
                     rd_kafka_metadata_cache_delete_by_name(rk, mdt->topic);
 
         if (changed && propagate)
-                rd_kafka_metadata_cache_propagate_changes(rk);
-}
-
-
-/**
- * @brief Update the metadata cache with the provided metadata.
- *
- * @param abs_update int: absolute update: purge cache before updating.
- *
- * @locks rd_kafka_wrlock()
- */
-void rd_kafka_metadata_cache_update(rd_kafka_t *rk,
-                                    const rd_kafka_metadata_internal_t *mdi,
-                                    int abs_update) {
-        struct rd_kafka_metadata_cache_entry *rkmce;
-        rd_ts_t now        = rd_clock();
-        rd_ts_t ts_expires = now + (rk->rk_conf.metadata_max_age_ms * 1000);
-        int i;
-
-        rd_kafka_dbg(
-            rk, METADATA, "METADATA", "%s of metadata cache with %d topic(s)",
-            abs_update ? "Absolute update" : "Update", mdi->metadata.topic_cnt);
-
-        if (abs_update)
-                rd_kafka_metadata_cache_purge(rk, rd_false /*not observers*/);
-
-
-        for (i = 0; i < mdi->metadata.topic_cnt; i++)
-                rd_kafka_metadata_cache_insert(rk, &mdi->metadata.topics[i],
-                                               &mdi->topics[i], now,
-                                               ts_expires);
-
-        /* Update expiry timer */
-        if ((rkmce = TAILQ_FIRST(&rk->rk_metadata_cache.rkmc_expiry)))
-                rd_kafka_timer_start(&rk->rk_timers,
-                                     &rk->rk_metadata_cache.rkmc_expiry_tmr,
-                                     rkmce->rkmce_ts_expires - now,
-                                     rd_kafka_metadata_cache_evict_tmr_cb, rk);
-
-        if (mdi->metadata.topic_cnt > 0 || abs_update)
                 rd_kafka_metadata_cache_propagate_changes(rk);
 }
 
@@ -530,8 +561,9 @@ int rd_kafka_metadata_cache_hint(rd_kafka_t *rk,
                         /* FALLTHRU */
                 }
 
-                rd_kafka_metadata_cache_insert(
-                    rk, &mtopic, &metadata_internal_topic, now, ts_expires);
+                rd_kafka_metadata_cache_insert(rk, &mtopic,
+                                               &metadata_internal_topic, now,
+                                               ts_expires, rd_false, NULL, 0);
                 cnt++;
 
                 if (dst)

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1754,12 +1754,35 @@ void *rd_kafka_topic_opaque(const rd_kafka_topic_t *app_rkt) {
 
 int rd_kafka_topic_info_cmp(const void *_a, const void *_b) {
         const rd_kafka_topic_info_t *a = _a, *b = _b;
-        int r;
+        int r, i;
 
         if ((r = strcmp(a->topic, b->topic)))
                 return r;
 
-        return RD_CMP(a->partition_cnt, b->partition_cnt);
+        if ((r = RD_CMP(a->partition_cnt, b->partition_cnt)))
+                return r;
+
+        if (a->partitions_internal == NULL && b->partitions_internal == NULL)
+                return 0;
+
+        if (a->partitions_internal == NULL || b->partitions_internal == NULL)
+                return (a->partitions_internal == NULL) ? 1 : -1;
+
+        /* We're certain partitions_internal and have the same count. */
+        for (i = 0; i < a->partition_cnt; i++) {
+                size_t k;
+                if ((r = RD_CMP(a->partitions_internal[i].racks_cnt,
+                                b->partitions_internal[i].racks_cnt)))
+                        return r;
+
+                for (k = 0; k < a->partitions_internal[i].racks_cnt; k++) {
+                        if ((r = rd_strcmp(a->partitions_internal[i].racks[k],
+                                           b->partitions_internal[i].racks[k])))
+                                return r;
+                }
+        }
+
+        return 0;
 }
 
 
@@ -1789,7 +1812,77 @@ rd_kafka_topic_info_t *rd_kafka_topic_info_new(const char *topic,
         ti        = rd_malloc(sizeof(*ti) + tlen);
         ti->topic = (char *)(ti + 1);
         memcpy((char *)ti->topic, topic, tlen);
-        ti->partition_cnt = partition_cnt;
+        ti->partition_cnt       = partition_cnt;
+        ti->partitions_internal = NULL;
+
+        return ti;
+}
+
+/**
+ * Allocate new topic_info, including rack information.
+ * \p topic is copied.
+ */
+rd_kafka_topic_info_t *rd_kafka_topic_info_new_with_rack(
+    const char *topic,
+    int partition_cnt,
+    const rd_kafka_metadata_partition_internal_t *mdpi) {
+        rd_kafka_topic_info_t *ti;
+        rd_tmpabuf_t tbuf;
+        size_t tlen             = RD_ROUNDUP(strlen(topic) + 1, 8);
+        size_t total_racks_size = 0;
+        int i;
+
+        for (i = 0; i < partition_cnt; i++) {
+                size_t j;
+                if (!mdpi[i].racks)
+                        continue;
+
+                for (j = 0; j < mdpi[i].racks_cnt; j++) {
+                        total_racks_size +=
+                            RD_ROUNDUP(strlen(mdpi[i].racks[j]) + 1, 8);
+                }
+                total_racks_size +=
+                    RD_ROUNDUP(sizeof(char *) * mdpi[i].racks_cnt, 8);
+        }
+
+        if (total_racks_size) /* Only bother allocating this if at least one
+                                 rack is there. */
+                total_racks_size +=
+                    RD_ROUNDUP(sizeof(rd_kafka_metadata_partition_internal_t) *
+                                   partition_cnt,
+                               8);
+
+        rd_tmpabuf_new(&tbuf, sizeof(*ti) + tlen + total_racks_size,
+                       1 /* assert on fail */);
+        ti                      = rd_tmpabuf_alloc(&tbuf, sizeof(*ti));
+        ti->topic               = rd_tmpabuf_write_str(&tbuf, topic);
+        ti->partition_cnt       = partition_cnt;
+        ti->partitions_internal = NULL;
+
+        if (total_racks_size) {
+                ti->partitions_internal = rd_tmpabuf_alloc(
+                    &tbuf, sizeof(*ti->partitions_internal) * partition_cnt);
+
+                for (i = 0; i < partition_cnt; i++) {
+                        size_t j;
+                        ti->partitions_internal[i].id    = mdpi[i].id;
+                        ti->partitions_internal[i].racks = NULL;
+
+                        if (!mdpi[i].racks)
+                                continue;
+
+                        ti->partitions_internal[i].racks_cnt =
+                            mdpi[i].racks_cnt;
+                        ti->partitions_internal[i].racks = rd_tmpabuf_alloc(
+                            &tbuf, sizeof(char *) * mdpi[i].racks_cnt);
+
+                        for (j = 0; j < mdpi[i].racks_cnt; j++) {
+                                ti->partitions_internal[i].racks[j] =
+                                    rd_tmpabuf_write_str(&tbuf,
+                                                         mdpi[i].racks[j]);
+                        }
+                }
+        }
 
         return ti;
 }
@@ -1902,7 +1995,8 @@ void rd_ut_kafka_topic_set_topic_exists(rd_kafka_topic_t *rkt,
         }
 
         rd_kafka_wrlock(rkt->rkt_rk);
-        rd_kafka_metadata_cache_topic_update(rkt->rkt_rk, &mdt, &mdit, rd_true);
+        rd_kafka_metadata_cache_topic_update(rkt->rkt_rk, &mdt, &mdit, rd_true,
+                                             rd_false, NULL, 0);
         rd_kafka_topic_metadata_update(rkt, &mdt, &mdit, rd_clock());
         rd_kafka_wrunlock(rkt->rkt_rk);
         rd_free(partitions);

--- a/src/rdkafka_topic.h
+++ b/src/rdkafka_topic.h
@@ -266,12 +266,17 @@ void rd_kafka_topic_scan_all(rd_kafka_t *rk, rd_ts_t now);
 typedef struct rd_kafka_topic_info_s {
         const char *topic; /**< Allocated along with struct */
         int partition_cnt;
+        rd_kafka_metadata_partition_internal_t *partitions_internal;
 } rd_kafka_topic_info_t;
 
 int rd_kafka_topic_info_topic_cmp(const void *_a, const void *_b);
 int rd_kafka_topic_info_cmp(const void *_a, const void *_b);
 rd_kafka_topic_info_t *rd_kafka_topic_info_new(const char *topic,
                                                int partition_cnt);
+rd_kafka_topic_info_t *rd_kafka_topic_info_new_with_rack(
+    const char *topic,
+    int partition_cnt,
+    const rd_kafka_metadata_partition_internal_t *mdpi);
 void rd_kafka_topic_info_destroy(rd_kafka_topic_info_t *ti);
 
 int rd_kafka_topic_match(rd_kafka_t *rk,

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -383,7 +383,9 @@ void rd_list_deduplicate(rd_list_t **rl,
         void *prev_elem = NULL;
         int i;
 
-        rd_list_sort(*rl, cmp);
+        if (!((*rl)->rl_flags & RD_LIST_F_SORTED))
+                rd_list_sort(*rl, cmp);
+
         RD_LIST_FOREACH(elem, *rl, i) {
                 if (prev_elem && cmp(elem, prev_elem) == 0) {
                         /* Skip this element, and destroy it */

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -376,6 +376,32 @@ void *rd_list_find_duplicate(const rd_list_t *rl,
         return NULL;
 }
 
+void rd_list_deduplicate(rd_list_t **rl,
+                         int (*cmp)(const void *, const void *)) {
+        rd_list_t *deduped = rd_list_new(0, (*rl)->rl_free_cb);
+        void *elem;
+        void *prev_elem = NULL;
+        int i;
+
+        rd_list_sort(*rl, cmp);
+        RD_LIST_FOREACH(elem, *rl, i) {
+                if (prev_elem && cmp(elem, prev_elem) == 0) {
+                        /* Skip this element, and destroy it */
+                        rd_list_free_cb(*rl, elem);
+                        continue;
+                }
+                rd_list_add(deduped, elem);
+                prev_elem = elem;
+        }
+        /* The elements we want destroyed are already destroyed. */
+        (*rl)->rl_free_cb = NULL;
+        rd_list_destroy(*rl);
+
+        /* The parent list was sorted, we can set this without re-sorting. */
+        deduped->rl_flags |= RD_LIST_F_SORTED;
+        *rl = deduped;
+}
+
 int rd_list_cmp(const rd_list_t *a,
                 const rd_list_t *b,
                 int (*cmp)(const void *, const void *)) {

--- a/src/rdlist.h
+++ b/src/rdlist.h
@@ -302,6 +302,18 @@ void *rd_list_find_duplicate(const rd_list_t *rl,
 
 
 /**
+ * @brief Deduplicates a list.
+ *
+ * @param rl is a ptrptr since a new list is created and assigned to *rl, for
+ * efficiency.
+ * @returns a deduplicated and sorted version of \p *rl.
+ * @warning the original \p *rl is destroyed.
+ */
+void rd_list_deduplicate(rd_list_t **rl,
+                         int (*cmp)(const void *, const void *));
+
+
+/**
  * @brief Compare list \p a to \p b.
  *
  * @returns < 0 if a was "lesser" than b,

--- a/src/rdstring.c
+++ b/src/rdstring.c
@@ -289,6 +289,13 @@ int rd_strcmp(const char *a, const char *b) {
 }
 
 
+/**
+ * @brief Same as rd_strcmp() but works with rd_list comparator.
+ */
+int rd_strcmp2(const void *a, const void *b) {
+        return rd_strcmp((const char *)a, (const char *)b);
+}
+
 
 /**
  * @brief Case-insensitive strstr() for platforms where strcasestr()

--- a/src/rdstring.h
+++ b/src/rdstring.h
@@ -80,6 +80,8 @@ unsigned int rd_string_hash(const char *str, ssize_t len);
 
 int rd_strcmp(const char *a, const char *b);
 
+int rd_strcmp2(const void *a, const void *b);
+
 char *_rd_strcasestr(const char *haystack, const char *needle);
 
 char **rd_string_split(const char *input,

--- a/tests/0045-subscribe_update.c
+++ b/tests/0045-subscribe_update.c
@@ -598,6 +598,11 @@ int main_0045_subscribe_update_racks_mock(int argc, char **argv) {
         int use_replica_rack = 0;
         int use_client_rack  = 0;
 
+        if (test_needs_auth()) {
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
+        }
+
         for (use_replica_rack = 0; use_replica_rack < 2; use_replica_rack++) {
                 for (use_client_rack = 0; use_client_rack < 2;
                      use_client_rack++) {

--- a/tests/0045-subscribe_update.c
+++ b/tests/0045-subscribe_update.c
@@ -36,6 +36,7 @@
  *  - topic additions
  *  - topic deletions
  *  - partition count changes
+ *  - replica rack changes (using mock broker)
  */
 
 
@@ -140,6 +141,49 @@ static void await_no_rebalance(const char *pfx,
         TEST_ASSERT(rkev, "did not expect %s: %s", rd_kafka_event_name(rkev),
                     rd_kafka_err2str(rd_kafka_event_error(rkev)));
         rd_kafka_event_destroy(rkev);
+}
+
+
+/**
+ * Wait for REBALANCE event and perform assignment/unassignment.
+ * For the first time and after each event, wait till for \p timeout before
+ * stopping. Asserts if no rebalance event was processed.
+ */
+static void await_rebalance(const char *pfx,
+                            rd_kafka_t *rk,
+                            rd_kafka_queue_t *queue,
+                            int timeout_ms) {
+        rd_kafka_event_t *rkev;
+        int processed = 0;
+
+        while (1) {
+                TEST_SAY("%s: waiting for %d ms for rebalance event\n", pfx,
+                         timeout_ms);
+
+                rkev = test_wait_event(queue, RD_KAFKA_EVENT_REBALANCE,
+                                       timeout_ms);
+                if (!rkev)
+                        break;
+                TEST_ASSERT(rd_kafka_event_type(rkev) ==
+                                RD_KAFKA_EVENT_REBALANCE,
+                            "either expected a timeout or a "
+                            "RD_KAFKA_EVENT_REBALANCE, got %s : %s",
+                            rd_kafka_event_name(rkev),
+                            rd_kafka_err2str(rd_kafka_event_error(rkev)));
+
+                TEST_SAY("Calling test_rebalance_cb, assignment type is %s\n",
+                         rd_kafka_rebalance_protocol(rk));
+                test_rebalance_cb(rk, rd_kafka_event_error(rkev),
+                                  rd_kafka_event_topic_partition_list(rkev),
+                                  NULL);
+
+                processed++;
+
+                rd_kafka_event_destroy(rkev);
+        }
+        TEST_ASSERT(
+            processed,
+            "Expected to process at least 1 rebalance event, processed 0");
 }
 
 static void do_test_non_exist_and_partchange(void) {
@@ -421,6 +465,93 @@ static void do_test_regex_many_mock(const char *assignment_strategy,
 }
 
 
+/**
+ * @brief Changing the broker racks should trigger a rejoin, if the client rack
+ * is set, and the set of partition racks changes due to the broker rack change.
+ *
+ * This is using the mock cluster.
+ *
+ */
+static void do_test_replica_rack_change_mock(const char *assignment_strategy,
+                                             rd_bool_t use_regex,
+                                             rd_bool_t use_client_rack,
+                                             rd_bool_t use_replica_rack) {
+        const char *subscription = use_regex ? "^top" : "topic";
+        const char *topic        = "topic";
+        const char *test_name    = tsprintf(
+            "Replica rack changes (%s, subscription = \"%s\", %s client.rack, "
+            "%s replica.rack)",
+            assignment_strategy, subscription,
+            use_client_rack ? "with" : "without",
+            use_replica_rack ? "with" : "without");
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_queue_t *queue;
+        int i;
+
+        SUB_TEST("Testing %s", test_name);
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        test_conf_init(&conf, NULL, 60 * 5);
+
+        if (use_replica_rack) {
+                rd_kafka_mock_broker_set_rack(mcluster, 1, "rack0");
+                rd_kafka_mock_broker_set_rack(mcluster, 2, "rack1");
+                rd_kafka_mock_broker_set_rack(mcluster, 3, "rack2");
+        }
+
+        TEST_SAY("Creating topic %s\n", topic);
+        TEST_CALL_ERR__(rd_kafka_mock_topic_create(mcluster, topic,
+                                                   2 /* partition_cnt */,
+                                                   1 /* replication_factor */));
+
+        test_conf_set(conf, "security.protocol", "plaintext");
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "partition.assignment.strategy",
+                      assignment_strategy);
+        /* Decrease metadata interval to speed up topic change discovery. */
+        test_conf_set(conf, "topic.metadata.refresh.interval.ms", "3000");
+
+        if (use_client_rack)
+                test_conf_set(conf, "client.rack", "client_rack");
+
+        rd_kafka_conf_set_events(conf, RD_KAFKA_EVENT_REBALANCE);
+        rk = test_create_consumer(test_str_id_generate_tmp(), NULL, conf, NULL);
+        queue = rd_kafka_queue_get_consumer(rk);
+
+        TEST_SAY("%s: Subscribing via %s\n", test_name, subscription);
+        test_consumer_subscribe(rk, subscription);
+
+        await_rebalance(tsprintf("%s: initial assignment", test_name), rk,
+                        queue, 10000);
+
+        /* Avoid issues if the replica assignment algorithm for mock broker
+         * changes, and change all the racks. */
+        if (use_replica_rack) {
+                TEST_SAY("%s: changing rack for all brokers\n", test_name);
+                rd_kafka_mock_broker_set_rack(mcluster, 1, "rack2");
+                rd_kafka_mock_broker_set_rack(mcluster, 2, "rack0");
+                rd_kafka_mock_broker_set_rack(mcluster, 3, "rack1");
+        }
+
+        if (use_client_rack && use_replica_rack)
+                await_rebalance(tsprintf("%s: rebalance", test_name), rk, queue,
+                                10000);
+        else
+                await_no_rebalance(
+                    tsprintf("%s: no rebalance without racks", test_name), rk,
+                    queue, 10000);
+
+        test_consumer_close(rk);
+        rd_kafka_queue_destroy(queue);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
 
 int main_0045_subscribe_update(int argc, char **argv) {
 
@@ -454,6 +585,33 @@ int main_0045_subscribe_update_mock(int argc, char **argv) {
         do_test_regex_many_mock("range", rd_false);
         do_test_regex_many_mock("cooperative-sticky", rd_false);
         do_test_regex_many_mock("cooperative-sticky", rd_true);
+
+        return 0;
+}
+
+
+int main_0045_subscribe_update_racks_mock(int argc, char **argv) {
+        const char *assignor = "range";
+        int use_replica_rack = 0;
+        int use_client_rack  = 0;
+
+        for (use_replica_rack = 0; use_replica_rack < 2; use_replica_rack++) {
+                for (use_client_rack = 0; use_client_rack < 2;
+                     use_client_rack++) {
+                        do_test_replica_rack_change_mock(
+                            "range", rd_true /* use_regex */, use_client_rack,
+                            use_replica_rack);
+                        do_test_replica_rack_change_mock(
+                            "range", rd_true /* use_regex */, use_client_rack,
+                            use_replica_rack);
+                        do_test_replica_rack_change_mock(
+                            "cooperative-sticky", rd_true /* use_regex */,
+                            use_client_rack, use_replica_rack);
+                        do_test_replica_rack_change_mock(
+                            "cooperative-sticky", rd_true /* use_regex */,
+                            use_client_rack, use_replica_rack);
+                }
+        }
 
         return 0;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -152,6 +152,7 @@ _TEST_DECL(0045_subscribe_update);
 _TEST_DECL(0045_subscribe_update_topic_remove);
 _TEST_DECL(0045_subscribe_update_non_exist_and_partchange);
 _TEST_DECL(0045_subscribe_update_mock);
+_TEST_DECL(0045_subscribe_update_racks_mock);
 _TEST_DECL(0046_rkt_cache);
 _TEST_DECL(0047_partial_buf_tmout);
 _TEST_DECL(0048_partitioner);
@@ -363,6 +364,7 @@ struct test tests[] = {
           TEST_BRKVER(0, 9, 0, 0),
           .scenario = "noautocreate"),
     _TEST(0045_subscribe_update_mock, TEST_F_LOCAL),
+    _TEST(0045_subscribe_update_racks_mock, TEST_F_LOCAL),
     _TEST(0046_rkt_cache, TEST_F_LOCAL),
     _TEST(0047_partial_buf_tmout, TEST_F_KNOWN_ISSUE),
     _TEST(0048_partitioner,


### PR DESCRIPTION
This change handles the final part of KIP-881: triggering a rejoin, in case we detect that one of the topics we are subscribed to, has a change in the set of racks of one of its partitions. 
More precisely, 
trigger a rejoin, if 
1. client.rack is set for consumer
2. there exists a partition P of a topic T, such that we are subscribed to T and racks_in_cached_metadata(P) != racks_in_fresh_metadata(P).

As for the implementation details:
1. `rd_kafka_metadata_partition_internal_t` now contain an racks and their count.  
2. `rd_kafka_topic_info_t` now contains a list of `rd_kafka_metadata_partition_internal_t*`
3. Constructors for (2) have been modified for the changes.

For non-regex case (where we look up the topic information from the topic metadata cache), the topic metadata cache entry is internally, using `rd_kafka_metadata_topic_internal_t`. We just populate the racks inside the `rd_kafka_metadata_partition_internal_t` from the broker/rack mapping. 
This operation allocates strings, since there's no linkage of the lifetime between the cache entry and the broker/rack mapping.

For the regex case (where we look up the topic information from the full cache), we use the `rd_kafka_metadata_partition_internal_t` inside the full cache.  We just populate the racks inside the `rd_kafka_metadata_partition_internal_t` from the broker/rack mapping. However, since the full cache also contains the broker/rack mapping, we don't allocate extra space for the string, just point inside the broker/rack mapping.

All the allocation/deduplication/sorting costs are only paid if the client rack is set. And when the replica racks are set. Otherwise, it's avoided. 

A test is also added, and some fixes/changes to the mock broker to facilitate that.