### PR TITLE
Fixed a bug where topic leader is not refreshed in the same metadata call even if the broker is present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ librdkafka v2.2.0 is a feature release:
  * Store offset commit metadata in `rd_kafka_offsets_store` (@mathispesch, #4084).
  * Fix a bug that happens when skipping tags, causing buffer underflow in
    MetadataResponse (#4278).
+ * Fix a bug where topic leader is not refreshed in the same metadata call even if the leader is
+   present.
  * [KIP-881](https://cwiki.apache.org/confluence/display/KAFKA/KIP-881%3A+Rack-aware+Partition+Assignment+for+Kafka+Consumers):
    Add support for rack-aware partition assignment for consumers
    (#4184, #4291, #4252).

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -722,14 +722,6 @@ rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
                 }
 
                 rd_kafka_buf_skip_tags(rkbuf);
-
-                /* Sort partitions by partition id */
-                qsort(md->topics[i].partitions, md->topics[i].partition_cnt,
-                      sizeof(*md->topics[i].partitions),
-                      rd_kafka_metadata_partition_id_cmp);
-                qsort(mdi->topics[i].partitions, md->topics[i].partition_cnt,
-                      sizeof(*mdi->topics[i].partitions),
-                      rd_kafka_metadata_partition_internal_cmp);
         }
 
         if (ApiVersion >= 8 && ApiVersion <= 10) {
@@ -773,6 +765,14 @@ rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
                                    md->topics[i].topic);
                         continue;
                 }
+
+                /* Sort partitions by partition id */
+                qsort(md->topics[i].partitions, md->topics[i].partition_cnt,
+                      sizeof(*md->topics[i].partitions),
+                      rd_kafka_metadata_partition_id_cmp);
+                qsort(mdi->topics[i].partitions, md->topics[i].partition_cnt,
+                      sizeof(*mdi->topics[i].partitions),
+                      rd_kafka_metadata_partition_internal_cmp);
 
                 if (compute_racks)
                         rd_kafka_populate_metadata_topic_racks(&tbuf, i, mdi);

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -723,18 +723,6 @@ rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
 
                 rd_kafka_buf_skip_tags(rkbuf);
 
-                /* Ignore topics in blacklist */
-                if (rkb->rkb_rk->rk_conf.topic_blacklist &&
-                    rd_kafka_pattern_match(rkb->rkb_rk->rk_conf.topic_blacklist,
-                                           md->topics[i].topic)) {
-                        rd_rkb_dbg(rkb, TOPIC | RD_KAFKA_DBG_METADATA,
-                                   "BLACKLIST",
-                                   "Ignoring blacklisted topic \"%s\" "
-                                   "in metadata",
-                                   md->topics[i].topic);
-                        continue;
-                }
-
                 /* Sort partitions by partition id */
                 qsort(md->topics[i].partitions, md->topics[i].partition_cnt,
                       sizeof(*md->topics[i].partitions),
@@ -742,39 +730,6 @@ rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
                 qsort(mdi->topics[i].partitions, md->topics[i].partition_cnt,
                       sizeof(*mdi->topics[i].partitions),
                       rd_kafka_metadata_partition_internal_cmp);
-
-                if (compute_racks)
-                        rd_kafka_populate_metadata_topic_racks(&tbuf, i, mdi);
-
-                /* Update topic state based on the topic metadata */
-                rd_kafka_parse_Metadata_update_topic(rkb, &md->topics[i],
-                                                     &mdi->topics[i]);
-
-
-                if (requested_topics) {
-                        rd_list_free_cb(missing_topics,
-                                        rd_list_remove_cmp(missing_topics,
-                                                           md->topics[i].topic,
-                                                           (void *)strcmp));
-                        if (!all_topics) {
-                                /* Only update cache when not asking
-                                 * for all topics. */
-
-                                rd_kafka_wrlock(rk);
-                                rd_kafka_metadata_cache_topic_update(
-                                    rk, &md->topics[i], &mdi->topics[i],
-                                    rd_false /*propagate later*/,
-                                    /* use has_client_rack rather than
-                                       compute_racks. We need cached rack ids
-                                       only in case we need to rejoin the group
-                                       if they change and client.rack is set
-                                       (KIP-881). */
-                                    has_client_rack, mdi->brokers,
-                                    md->broker_cnt);
-                                cache_changes++;
-                                rd_kafka_wrunlock(rk);
-                        }
-                }
         }
 
         if (ApiVersion >= 8 && ApiVersion <= 10) {
@@ -803,6 +758,53 @@ rd_kafka_parse_Metadata(rd_kafka_broker_t *rkb,
                            md->brokers[i].port, md->brokers[i].id);
                 rd_kafka_broker_update(rkb->rkb_rk, rkb->rkb_proto,
                                        &md->brokers[i], NULL);
+        }
+
+        for (i = 0; i < md->topic_cnt; i++) {
+
+                /* Ignore topics in blacklist */
+                if (rkb->rkb_rk->rk_conf.topic_blacklist &&
+                    rd_kafka_pattern_match(rkb->rkb_rk->rk_conf.topic_blacklist,
+                                           md->topics[i].topic)) {
+                        rd_rkb_dbg(rkb, TOPIC | RD_KAFKA_DBG_METADATA,
+                                   "BLACKLIST",
+                                   "Ignoring blacklisted topic \"%s\" "
+                                   "in metadata",
+                                   md->topics[i].topic);
+                        continue;
+                }
+
+                if (compute_racks)
+                        rd_kafka_populate_metadata_topic_racks(&tbuf, i, mdi);
+
+                /* Update topic state based on the topic metadata */
+                rd_kafka_parse_Metadata_update_topic(rkb, &md->topics[i],
+                                                     &mdi->topics[i]);
+
+                if (requested_topics) {
+                        rd_list_free_cb(missing_topics,
+                                        rd_list_remove_cmp(missing_topics,
+                                                           md->topics[i].topic,
+                                                           (void *)strcmp));
+                        if (!all_topics) {
+                                /* Only update cache when not asking
+                                 * for all topics. */
+
+                                rd_kafka_wrlock(rk);
+                                rd_kafka_metadata_cache_topic_update(
+                                    rk, &md->topics[i], &mdi->topics[i],
+                                    rd_false /*propagate later*/,
+                                    /* use has_client_rack rather than
+                                       compute_racks. We need cached rack ids
+                                       only in case we need to rejoin the group
+                                       if they change and client.rack is set
+                                       (KIP-881). */
+                                    has_client_rack, mdi->brokers,
+                                    md->broker_cnt);
+                                cache_changes++;
+                                rd_kafka_wrunlock(rk);
+                        }
+                }
         }
 
         /* Requested topics not seen in metadata? Propogate to topic code. */

--- a/tests/0125-immediate_flush.c
+++ b/tests/0125-immediate_flush.c
@@ -33,7 +33,7 @@
  * Verify that flush() overrides the linger.ms time.
  *
  */
-int main_0125_immediate_flush(int argc, char **argv) {
+void do_test_flush_overrides_linger_ms_time() {
         rd_kafka_t *rk;
         rd_kafka_conf_t *conf;
         const char *topic = test_mk_topic_name("0125_immediate_flush", 1);
@@ -73,6 +73,74 @@ int main_0125_immediate_flush(int argc, char **argv) {
 
         /* Verify messages were actually produced by consuming them back. */
         test_consume_msgs_easy(topic, topic, 0, 1, msgcnt, NULL);
+}
+
+/**
+ * @brief Tests if the first metadata call is able to update leader for the
+ * topic or not. If it is not able to update the leader for some partitions,
+ * flush call waits for 1s to refresh the leader and then flush is completed.
+ * Ideally, it should update in the first call itself.
+ *
+ * Number of brokers in the cluster should be more than the number of
+ * brokers in the bootstrap.servers list for this test case to work correctly
+ *
+ */
+void do_test_first_flush_immediate() {
+        rd_kafka_mock_cluster_t *mock_cluster;
+        rd_kafka_t *produce_rk;
+        const char *brokers;
+        char *bootstrap_server;
+        test_timing_t t_time;
+        size_t i;
+        rd_kafka_conf_t *conf = NULL;
+        const char *topic     = test_mk_topic_name("0125_immediate_flush", 1);
+        size_t partition_cnt  = 9;
+        int remains           = 0;
+
+        mock_cluster = test_mock_cluster_new(3, &brokers);
+
+        for (i = 0; brokers[i]; i++)
+                if (brokers[i] == ',' || brokers[i] == ' ')
+                        break;
+        bootstrap_server = rd_strndup(brokers, i);
+
+        test_conf_init(&conf, NULL, 30);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        test_conf_set(conf, "bootstrap.servers", bootstrap_server);
+        free(bootstrap_server);
+
+        rd_kafka_mock_topic_create(mock_cluster, topic, partition_cnt, 1);
+
+        produce_rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        for (i = 0; i < partition_cnt; i++) {
+                test_produce_msgs2_nowait(produce_rk, topic, 0, i, 0, 1, NULL,
+                                          0, &remains);
+        }
+
+        TIMING_START(&t_time, "FLUSH");
+        TEST_CALL_ERR__(rd_kafka_flush(produce_rk, 5000));
+        TIMING_ASSERT(&t_time, 0, 999);
+
+        rd_kafka_destroy(produce_rk);
+        test_mock_cluster_destroy(mock_cluster);
+}
+
+int main_0125_immediate_flush(int argc, char **argv) {
+
+        do_test_flush_overrides_linger_ms_time();
+
+        return 0;
+}
+
+int main_0125_immediate_flush_mock(int argc, char **argv) {
+
+        if (test_needs_auth()) {
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
+        }
+
+        do_test_first_flush_immediate();
 
         return 0;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -235,6 +235,7 @@ _TEST_DECL(0122_buffer_cleaning_after_rebalance);
 _TEST_DECL(0123_connections_max_idle);
 _TEST_DECL(0124_openssl_invalid_engine);
 _TEST_DECL(0125_immediate_flush);
+_TEST_DECL(0125_immediate_flush_mock);
 _TEST_DECL(0126_oauthbearer_oidc);
 _TEST_DECL(0128_sasl_callback_queue);
 _TEST_DECL(0129_fetch_aborted_msgs);
@@ -484,6 +485,7 @@ struct test tests[] = {
     _TEST(0123_connections_max_idle, 0),
     _TEST(0124_openssl_invalid_engine, TEST_F_LOCAL),
     _TEST(0125_immediate_flush, 0),
+    _TEST(0125_immediate_flush_mock, TEST_F_LOCAL),
     _TEST(0126_oauthbearer_oidc, 0, TEST_BRKVER(3, 1, 0, 0)),
     _TEST(0128_sasl_callback_queue, TEST_F_LOCAL, TEST_BRKVER(2, 0, 0, 0)),
     _TEST(0129_fetch_aborted_msgs, 0, TEST_BRKVER(0, 11, 0, 0)),


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-python/issues/1581