### PR TITLE
consumer: auto.offset.store commits incorrect offsets

### DIFF
--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -724,7 +724,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
         for (i = cnt - 1; i >= 0; i--) {
                 rko = (rd_kafka_op_t *)rkmessages[i]->_private;
                 rd_kafka_toppar_t *rktp = rko->rko_rktp;
-                int64_t offset          = rkmessages[i]->offset + 1;
+                int64_t offset          = rkmessages[i]->offset;
                 if (unlikely(rktp && (rktp->rktp_app_pos.offset < offset)))
                         rd_kafka_update_app_pos(
                             rk, rktp,
@@ -748,7 +748,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                 rko                     = next;
                 next                    = TAILQ_NEXT(next, rko_link);
                 rd_kafka_toppar_t *rktp = rko->rko_rktp;
-                int64_t offset = rko->rko_u.fetch.rkm.rkm_rkmessage.offset + 1;
+                int64_t offset = rko->rko_u.fetch.rkm.rkm_rkmessage.offset;
                 if (rktp && (rktp->rktp_app_pos.offset < offset))
                         rd_kafka_update_app_pos(
                             rk, rktp,


### PR DESCRIPTION
Sponsored-by: China Medical University Hospital

--
Hi,

I guess this issue is introduced by #4208, but I do not understand the details in that issue.

I inspected the partition offset via `on_commit` by the Python library.
W/o this patch, there are two case tried and I found the offsets committed are different:

#### case 1. consumer configured with 
```python
c = Consumer({
    'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS'),
    'group.id': 'magic',
    'auto.offset.reset': 'earliest',
    'enable.auto.offset.store': True,
    'enable.auto.commit': True,
    'on_commit': on_commit,
})
```
where the `on_commit` function is:
```python
from confluent_kafka import  TopicPartition
                                          
def on_commit(err, partitions: list[TopicPartition]):
    for i in sorted(partitions, key=lambda x: x.partition):
        print(f'{i.partition}\t-> {i.offset}')

```

#### case 2
```
c = Consumer({
    'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS'),
    'group.id': 'magic2',
    'auto.offset.reset': 'earliest',
    'enable.auto.offset.store': False,
    'enable.auto.commit': True,
    'on_commit': on_commit,
})
```
and then I invoked the `c.store_offset(message=msg)` manually, after processed a message.

#### results
I run case 1 and case 2 twice. The first run is for reading the topic to the end and waiting for the offsets committed.
The expected results in the second run is that the consumers should not get any message, since I do not have any producer running at this point.

The case 2 works correctly in the second run.
The case 1 starts consuming the log from some unexpected point of offset in the second run.

This patch fixed my problem. But I'm not sure of the side effect of it.