### PR TITLE
Fixed ListConsumerGroupOffsets not fetching offsets for all the topic s in a group with Apache Kafka version below 2.4.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ cov-int
 gdbrun*.gdb
 TAGS
 vcpkg_installed
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ cov-int
 gdbrun*.gdb
 TAGS
 vcpkg_installed
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 librdkafka v2.2.1 is a maintenance release:
 
  * Added Topic id to the metadata response which is part of the [KIP-516](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers)
+ * Fixed ListConsumerGroupOffsets not fetching offsets for all the topics in a group with Apache Kafka version below 2.4.0.
 
 
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1180,7 +1180,7 @@ void rd_kafka_OffsetFetchRequest(rd_kafka_broker_t *rkb,
                     rkbuf, parts, rd_false /*include invalid offsets*/,
                     rd_false /*skip valid offsets */, fields);
         } else {
-                rd_kafka_buf_write_arraycnt_pos(rkbuf);
+                rd_kafka_buf_write_arraycnt(rkbuf, PartCnt);
         }
 
         if (ApiVersion >= 7) {

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -4308,7 +4308,9 @@ static void do_test_apis(rd_kafka_type_t cltype) {
                 do_test_DeleteConsumerGroupOffsets(
                     "main queue", rk, mainq, 1500,
                     rd_true /*with subscribing consumer*/);
+        }
 
+        if (test_broker_version >= TEST_BRKVER(2, 5, 0, 0)) {
                 /* Alter committed offsets */
                 do_test_AlterConsumerGroupOffsets("temp queue", rk, NULL, -1,
                                                   rd_false, rd_true);
@@ -4321,7 +4323,9 @@ static void do_test_apis(rd_kafka_type_t cltype) {
                     "main queue", rk, mainq, 1500,
                     rd_true, /*with subscribing consumer*/
                     rd_true);
+        }
 
+        if (test_broker_version >= TEST_BRKVER(2, 0, 0, 0)) {
                 /* List committed offsets */
                 do_test_ListConsumerGroupOffsets("temp queue", rk, NULL, -1,
                                                  rd_false, rd_false);


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-python/issues/1600