### PR TITLE
Generates a random salt only when RAND_priv_bytes is available

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -8736,7 +8736,7 @@ typedef struct rd_kafka_UserScramCredentialAlteration_s
 /**
  * @brief Allocates a new UserScramCredentialUpsertion given its fields.
  *        If salt isn't given a 64 B salt is generated using OpenSSL
- *        RAND_bytes, if available.
+ *        RAND_priv_bytes, if available.
  *
  * @param username The username (not empty).
  * @param mechanism SASL/SCRAM mechanism.
@@ -8745,6 +8745,9 @@ typedef struct rd_kafka_UserScramCredentialAlteration_s
  * @param password_size Size of \p password (greater than 0).
  * @param salt Salt bytes (optional).
  * @param salt_size Size of \p salt (optional).
+ *
+ * @remark A random salt is generated, when NULL, only if OpenSSL >= 1.1.1.
+ *         Otherwise it's a required param.
  *
  * @return A newly created instance of rd_kafka_UserScramCredentialAlteration_t.
  *         Ownership belongs to the caller, use

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -5426,7 +5426,7 @@ rd_kafka_UserScramCredentialUpsertion_new(const char *username,
                 alteration->alteration.upsertion.salt =
                     rd_kafkap_bytes_new(salt, salt_size);
         } else {
-#if WITH_SSL
+#if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10101000L
                 unsigned char random_salt[64];
                 if (RAND_priv_bytes(random_salt, sizeof(random_salt)) == 1) {
                         alteration->alteration.upsertion.salt =


### PR DESCRIPTION
since OpenSSL 1.1.1