### PR TITLE
Use built-in command -v instead of which (#3974)

### DIFF
--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -2446,7 +2446,7 @@ function mkl_download_archive {
 
         # OSX has shasum by default, on Linux it is typically in
         # some Perl package that may or may not be installed.
-        if $(which shasum >/dev/null 2>&1); then
+        if $(command -v shasum >/dev/null 2>&1); then
             checksum_tool="shasum -b -a ${shabits}"
         else
             # shaXsum is available in Linux coreutils

--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -112,12 +112,12 @@ function checks {
 	if [[ $MKL_DISTRO == "sunos" ]]; then
 	    mkl_meta_set ginstall name "GNU install"
 	    if mkl_command_check ginstall "" ignore "ginstall --version"; then
-		INSTALL=$(which ginstall)
+		INSTALL=$(command -v ginstall)
 	    else
-		INSTALL=$(which install)
+		INSTALL=$(command -v install)
 	    fi
         else
-            INSTALL=$(which install)
+            INSTALL=$(command -v install)
 	fi
     fi
 


### PR DESCRIPTION
It is preferable that it works without "which" package by default.