### PR TITLE
Add boilerplate for the entire flow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
     rdkafka_mock_cgrp.c
     rdkafka_error.c
     rdkafka_fetcher.c
+    rdkafka_telemetry.c
     rdlist.c
     rdlog.c
     rdmurmur2.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ SRCS=		rdkafka.c rdkafka_broker.c rdkafka_msg.c rdkafka_topic.c \
 		rdkafka_txnmgr.c rdkafka_coord.c \
 		rdvarint.c rdbuf.c rdmap.c rdunittest.c \
 		rdkafka_mock.c rdkafka_mock_handlers.c rdkafka_mock_cgrp.c \
-		rdkafka_error.c rdkafka_fetcher.c \
+		rdkafka_error.c rdkafka_fetcher.c rdkafka_telemetry.c \
 		$(SRCS_y)
 
 HDRS=		rdkafka.h rdkafka_mock.h

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -193,6 +193,10 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                 rd_atomic64_t ts_recv; /**< Timestamp of last receive */
         } rkb_c;
 
+        struct {
+                /* TODO: fill this out. */
+        } rkb_c_historic;
+
         int rkb_req_timeouts; /* Current value */
 
         thrd_t rkb_thread;

--- a/src/rdkafka_protocol.h
+++ b/src/rdkafka_protocol.h
@@ -114,7 +114,11 @@
 #define RD_KAFKAP_ListTransactions             66
 #define RD_KAFKAP_AllocateProducerIds          67
 
-#define RD_KAFKAP__NUM 68
+/* Using dummy numbers for now. */
+#define RD_KAFKAP_GetTelemetrySubscriptions 68
+#define RD_KAFKAP_PushTelemetry             69
+
+#define RD_KAFKAP__NUM 70
 
 
 #endif /* _RDKAFKA_PROTOCOL_H_ */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -36,6 +36,7 @@
 #include "rdkafka_topic.h"
 #include "rdkafka_partition.h"
 #include "rdkafka_metadata.h"
+#include "rdkafka_telemetry.h"
 #include "rdkafka_msgset.h"
 #include "rdkafka_idempotence.h"
 #include "rdkafka_txnmgr.h"
@@ -5191,6 +5192,57 @@ rd_kafka_resp_err_t rd_kafka_EndTxnRequest(rd_kafka_broker_t *rkb,
         rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
 
         return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+rd_kafka_resp_err_t
+rd_kafka_GetTelemetrySubscriptionsRequest(rd_kafka_broker_t *rkb,
+                           char *errstr,
+                           size_t errstr_size,
+                           rd_kafka_replyq_t replyq,
+                           rd_kafka_resp_cb_t *resp_cb,
+                           void *opaque) {
+        rd_kafka_buf_t *rkbuf;
+
+        /* Processing... */
+        rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+}
+
+rd_kafka_resp_err_t
+rd_kafka_PushTelemetryRequest(rd_kafka_broker_t *rkb,
+                           char *errstr,
+                           size_t errstr_size,
+                           rd_kafka_replyq_t replyq,
+                           rd_kafka_resp_cb_t *resp_cb,
+                           void *opaque) {
+        rd_kafka_buf_t *rkbuf;
+
+        /* Processing... */
+        rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+void rd_kafka_handle_GetTelemetrySubscriptions(rd_kafka_t *rk,
+                                    rd_kafka_broker_t *rkb,
+                                    rd_kafka_resp_err_t err,
+                                    rd_kafka_buf_t *rkbuf,
+                                    rd_kafka_buf_t *request,
+                                    void *opaque) {
+        /* Parsing */
+        rd_kafka_handle_get_telemetry_subscriptions(rk /*, some other fields that we need to pass from the parsed request. */);
+}
+
+void rd_kafka_handle_PushTelemetry(rd_kafka_t *rk,
+                                    rd_kafka_broker_t *rkb,
+                                    rd_kafka_resp_err_t err,
+                                    rd_kafka_buf_t *rkbuf,
+                                    rd_kafka_buf_t *request,
+                                    void *opaque) {
+        /* Parsing */
+        rd_kafka_handle_push_telemetry(rk /*, some other fields that we need to pass from the parsed request. */);
 }
 
 

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -471,5 +471,35 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
                            rd_kafka_resp_cb_t *resp_cb,
                            void *opaque);
 
+rd_kafka_resp_err_t
+rd_kafka_GetTelemetrySubscriptionsRequest(rd_kafka_broker_t *rkb,
+                           char *errstr,
+                           size_t errstr_size,
+                           rd_kafka_replyq_t replyq,
+                           rd_kafka_resp_cb_t *resp_cb,
+                           void *opaque);
+
+rd_kafka_resp_err_t
+rd_kafka_PushTelemetryRequest(rd_kafka_broker_t *rkb,
+                           char *errstr,
+                           size_t errstr_size,
+                           rd_kafka_replyq_t replyq,
+                           rd_kafka_resp_cb_t *resp_cb,
+                           void *opaque);
+
+void rd_kafka_handle_GetTelemetrySubscriptions(rd_kafka_t *rk,
+                                    rd_kafka_broker_t *rkb,
+                                    rd_kafka_resp_err_t err,
+                                    rd_kafka_buf_t *rkbuf,
+                                    rd_kafka_buf_t *request,
+                                    void *opaque);
+
+void rd_kafka_handle_PushTelemetry(rd_kafka_t *rk,
+                                    rd_kafka_broker_t *rkb,
+                                    rd_kafka_resp_err_t err,
+                                    rd_kafka_buf_t *rkbuf,
+                                    rd_kafka_buf_t *request,
+                                    void *opaque);
+
 
 #endif /* _RDKAFKA_REQUEST_H_ */

--- a/src/rdkafka_telemetry.c
+++ b/src/rdkafka_telemetry.c
@@ -1,0 +1,159 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rdkafka_int.h"
+#include "rdkafka_telemetry.h"
+#include "rdkafka_request.h"
+
+/**
+ * @brief Returns the preferred metrics broker or NULL if unavailable.
+ *
+ * @locks_acquired rk_telemetry.lock
+ */
+static rd_kafka_broker_t *rd_kafka_get_preferred_broker(rd_kafka_t *rk) {
+        return NULL;
+}
+
+/**
+ * @brief Enqueues a GetTelemetrySubscriptionsRequest.
+ *
+ */
+static void rd_kafka_send_get_telemetry_subscriptions(rd_kafka_t *rk,
+                                                      rd_kafka_broker_t *rkb) {
+        /* Do some processing. */
+
+        /* Enqueue on broker transmit queue.
+         * The preferred broker might change in the meanwhile but let it fail.
+         */
+        rd_kafka_GetTelemetrySubscriptionsRequest(
+            rkb, NULL, 0, RD_KAFKA_REPLYQ(rk->rk_ops, 0),
+            rd_kafka_handle_GetTelemetrySubscriptions, NULL);
+
+        /* Change state */
+        rk->rk_telemetry.state = RD_KAFKA_TELEMETRY_GET_SUBSCRIPTIONS_SENT;
+}
+
+
+void rd_kafka_handle_get_telemetry_subscriptions(
+    rd_kafka_t *rk /*, other fields */) {
+        /* Do any persisting of the fields into rk_telemetry struct, like
+         * client_instance_id. */
+        if (/* metrics_requested == rd_true */ 1) {
+                rk->rk_telemetry.state = RD_KAFKA_TELEMETRY_PUSH_SCHEDULED;
+                rd_kafka_timer_start_oneshot(
+                    &rk->rk_timers, &rk->rk_telemetry.request_timer, rd_false,
+                    1 /* 0.8 - 1.2 * the push interval ms */,
+                    rd_kafka_telemetry_fsm, rk);
+        } else { /* no metrics requested */
+                rk->rk_telemetry.state =
+                    RD_KAFKA_TELEMETRY_GET_SUBSCRIPTIONS_SCHEDULED;
+                rd_kafka_timer_start_oneshot(
+                    &rk->rk_timers, &rk->rk_telemetry.request_timer, rd_false,
+                    1 /* the push interval ms */, rd_kafka_telemetry_fsm, rk);
+        }
+}
+
+static void rd_kafka_send_push_telemetry(rd_kafka_t *rk,
+                                         rd_kafka_broker_t *rkb) {
+        /* Do some processing. */
+
+        /* Enqueue on broker transmit queue.
+         * The preferred broker might change in the meanwhile but let it fail.
+         */
+        rd_kafka_PushTelemetryRequest(rkb, NULL, 0,
+                                      RD_KAFKA_REPLYQ(rk->rk_ops, 0),
+                                      rd_kafka_handle_PushTelemetry, NULL);
+
+        rk->rk_telemetry.state = RD_KAFKA_TELEMETRY_PUSH_SENT;
+}
+
+void rd_kafka_handle_push_telemetry(rd_kafka_t *rk /* , other fields */) {
+        if (/* successful */ 1) {
+                rk->rk_telemetry.state = RD_KAFKA_TELEMETRY_PUSH_SCHEDULED;
+                rd_kafka_timer_start_oneshot(
+                    &rk->rk_timers, &rk->rk_telemetry.request_timer, rd_false,
+                    1 /* the push interval ms */, rd_kafka_telemetry_fsm, rk);
+        } else { /* error */
+                rk->rk_telemetry.state =
+                    RD_KAFKA_TELEMETRY_GET_SUBSCRIPTIONS_SCHEDULED;
+                rd_kafka_timer_start_oneshot(
+                    &rk->rk_timers, &rk->rk_telemetry.request_timer, rd_false,
+                    1 /* the push interval ms */, rd_kafka_telemetry_fsm, rk);
+        }
+}
+
+/**
+ * @brief Progress the telemetry state machine.
+ *
+ * @locality main thread
+ */
+void rd_kafka_telemetry_fsm(rd_kafka_t *rk) {
+        rd_kafka_telemetry_state_t state;
+        rd_kafka_broker_t *preferred_broker;
+
+        /* We don't require a lock here, as the only way we can reach this
+         * function is if we've already set the state from the broker thread,
+         * and further state transitions happen only on the main thread. */
+        state = rk->rk_telemetry.state;
+
+        switch (state) {
+        case RD_KAFKA_TELEMETRY_AWAIT_BROKER:
+                rd_dassert(!*"Should never be awaiting a broker when the telemetry fsm is called.");
+                break;
+
+        case RD_KAFKA_TELEMETRY_GET_SUBSCRIPTIONS_SCHEDULED:
+                preferred_broker = rd_kafka_get_preferred_broker(rk);
+                if (!preferred_broker) {
+                        state = RD_KAFKA_TELEMETRY_AWAIT_BROKER;
+                        break;
+                }
+                rd_kafka_send_get_telemetry_subscriptions(rk, preferred_broker);
+                break;
+
+        case RD_KAFKA_TELEMETRY_PUSH_SCHEDULED:
+                preferred_broker = rd_kafka_get_preferred_broker(rk);
+                if (!preferred_broker) {
+                        state = RD_KAFKA_TELEMETRY_AWAIT_BROKER;
+                        break;
+                }
+                rd_kafka_send_push_telemetry(rk, preferred_broker);
+                break;
+
+        case RD_KAFKA_TELEMETRY_PUSH_SENT:
+        case RD_KAFKA_TELEMETRY_GET_SUBSCRIPTIONS_SENT:
+                rd_dassert(!*"Should never be awaiting response when the telemetry fsm is called.");
+                break;
+
+        case RD_KAFKA_TELEMETRY_TERMINATING:
+            /* TODO: Add special terminating handler here. */
+            break;
+
+        default:
+                rd_assert(!*"Unknown state");
+        }
+}

--- a/src/rdkafka_telemetry.h
+++ b/src/rdkafka_telemetry.h
@@ -1,0 +1,38 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _RD_KAFKA_TELEMETRY_H_
+#define _RD_KAFKA_TELEMETRY_H_
+
+void rd_kafka_telemetry_fsm(rd_kafka_t *rk);
+
+void rd_kafka_handle_get_telemetry_subscriptions(rd_kafka_t *rk);
+void rd_kafka_handle_push_telemetry(rd_kafka_t *rk);
+
+#endif /* _RD_KAFKA_TELEMETRY_H_ */

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="..\src\rdkafka_mock_cgrp.c" />
     <ClCompile Include="..\src\rdkafka_error.c" />
     <ClCompile Include="..\src\rdkafka_fetcher.c" />
+    <ClCompile Include="..\src\rdkafka_telemetry.c" />
     <ClCompile Include="..\src\rdlist.c" />
     <ClCompile Include="..\src\rdlog.c" />
     <ClCompile Include="..\src\rdmurmur2.c" />


### PR DESCRIPTION
Contains some initial boilerplate for the entire codeflow, please feel free to add more push specific items, I've added the bare minimum for both the protocols. 

I created a new file entirely, as I think it's justified, seeing how we have different ones for things like fetcher, cgrp, idempotence, etc.

The code compiles, but with warnings.