### PR TITLE
Fix memory leaks [KIP-714]

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -46,6 +46,7 @@
 #include "rdkafka_topic.h"
 #include "rdkafka_partition.h"
 #include "rdkafka_offset.h"
+#include "rdkafka_telemetry.h"
 #include "rdkafka_transport.h"
 #include "rdkafka_cgrp.h"
 #include "rdkafka_assignor.h"
@@ -925,6 +926,8 @@ void rd_kafka_destroy_final(rd_kafka_t *rk) {
         /* Synchronize state */
         rd_kafka_wrlock(rk);
         rd_kafka_wrunlock(rk);
+
+        rd_kafka_telemetry_clear(rk, rd_true /*clear_control_flow_fields*/);
 
         /* Terminate SASL provider */
         if (rk->rk_conf.sasl.provider)
@@ -2245,6 +2248,8 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
         rd_interval_init(&rk->rk_suppress.broker_metadata_refresh);
         rd_interval_init(&rk->rk_suppress.sparse_connect_random);
         mtx_init(&rk->rk_suppress.sparse_connect_lock, mtx_plain);
+
+        mtx_init(&rk->rk_telemetry.lock, mtx_plain);
 
         rd_atomic64_init(&rk->rk_ts_last_poll, rk->rk_ts_created);
         rd_atomic32_init(&rk->rk_flushing, 0);

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -2451,6 +2451,7 @@ static void rd_kafka_mock_cluster_destroy0(rd_kafka_mock_cluster_t *mcluster) {
         rd_kafka_mock_error_stack_t *errstack;
         thrd_t dummy_rkb_thread;
         int ret;
+        size_t i;
 
         while ((mtopic = TAILQ_FIRST(&mcluster->topics)))
                 rd_kafka_mock_topic_destroy(mtopic);
@@ -2500,6 +2501,13 @@ static void rd_kafka_mock_cluster_destroy0(rd_kafka_mock_cluster_t *mcluster) {
 
         rd_socket_close(mcluster->wakeup_fds[0]);
         rd_socket_close(mcluster->wakeup_fds[1]);
+
+        if (mcluster->metrics) {
+                for (i = 0; i < mcluster->metrics_cnt; i++) {
+                        rd_free(mcluster->metrics[i]);
+                }
+                rd_free(mcluster->metrics);
+        }
 }
 
 

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -2115,7 +2115,7 @@ static int rd_kafka_mock_handle_GetTelemetrySubscriptions(
         rd_kafka_mock_cluster_t *mcluster = mconn->broker->cluster;
         rd_kafka_buf_t *resp = rd_kafka_mock_buf_new_response(rkbuf);
         rd_kafka_resp_err_t err;
-        int32_t TopicsCnt, i;
+        size_t i;
         rd_kafka_uuid_t ClientInstanceId;
         rd_kafka_uuid_t zero_uuid = RD_KAFKA_ZERO_UUID;
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -441,7 +441,7 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
                 RD_IF_FREE(rko->rko_u.mock.name, rd_free);
                 RD_IF_FREE(rko->rko_u.mock.str, rd_free);
                 if (rko->rko_u.mock.metrics) {
-                        size_t i;
+                        int64_t i;
                         for (i = 0; i < rko->rko_u.mock.hi; i++)
                                 rd_free(rko->rko_u.mock.metrics[i]);
                         rd_free(rko->rko_u.mock.metrics);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5319,7 +5319,6 @@ void rd_kafka_handle_GetTelemetrySubscriptions(rd_kafka_t *rk,
         rd_kafka_dbg(rk, TELEMETRY, "GETPARSE", "Parsing:: Subscription id %d",
                      rk->rk_telemetry.subscription_id);
 
-        int32_t cnt;
         rd_kafka_buf_read_arraycnt(rkbuf, &arraycnt, -1);
 
         if (arraycnt) {
@@ -5327,7 +5326,7 @@ void rd_kafka_handle_GetTelemetrySubscriptions(rd_kafka_t *rk,
                 rk->rk_telemetry.accepted_compression_types =
                     rd_calloc(arraycnt, sizeof(rd_kafka_compression_t));
 
-                for (i = 0; i < arraycnt; i++)
+                for (i = 0; i < (size_t)arraycnt; i++)
                         rd_kafka_buf_read_i8(
                             rkbuf,
                             &rk->rk_telemetry.accepted_compression_types[i]);
@@ -5359,7 +5358,7 @@ void rd_kafka_handle_GetTelemetrySubscriptions(rd_kafka_t *rk,
         rk->rk_telemetry.requested_metrics =
             rd_calloc(arraycnt, sizeof(char *));
 
-        for (i = 0; i < arraycnt; i++) {
+        for (i = 0; i < (size_t)arraycnt; i++) {
                 rd_kafkap_str_t Metric;
                 rd_kafka_buf_read_str(rkbuf, &Metric);
                 rk->rk_telemetry.requested_metrics[i] = rd_strdup(Metric.str);

--- a/src/rdkafka_telemetry.h
+++ b/src/rdkafka_telemetry.h
@@ -36,4 +36,7 @@ void rd_kafka_handle_get_telemetry_subscriptions(rd_kafka_t *rk,
                                                  rd_kafka_resp_err_t err);
 void rd_kafka_handle_push_telemetry(rd_kafka_t *rk, rd_kafka_resp_err_t err);
 
+void rd_kafka_telemetry_clear(rd_kafka_t *rk,
+                              rd_bool_t clear_control_flow_fields);
+
 #endif /* _RD_KAFKA_TELEMETRY_H_ */


### PR DESCRIPTION
There were some memory leaks in mock broker and while terminating. 

Fixes those + adds some missing init stuff + some warnings addressed 