### PR TITLE
Added Pragmas for the Debug Libs from Openssl

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -40,6 +40,10 @@
 #ifdef _WIN32
 #include <wincrypt.h>
 #pragma comment(lib, "crypt32.lib")
+#ifdef _DEBUG
+#pragma comment(lib, "libcryptod.lib")
+#pragma comment(lib, "libssld.lib")
+#else
 #pragma comment(lib, "libcrypto.lib")
 #pragma comment(lib, "libssl.lib")
 #endif


### PR DESCRIPTION
If Openssl is build from sources, the Debug Version of the Library ends with an `d`. Added an additional check to set the Pragma to the Correct Library Files.