### PR TITLE
[KIP-714] Mock broker changes for testing

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -1127,6 +1127,14 @@ rd_kafka_mock_connection_parse_request(rd_kafka_mock_connection_t *mconn,
                 return -1;
         }
 
+        /* Add the request to the cluster's request list. */
+        mtx_lock(&mcluster->lock);
+        rd_list_add(&mcluster->request_list,
+                    rd_kafka_mock_request_new(mconn->broker->id,
+                                              rkbuf->rkbuf_reqhdr.ApiKey,
+                                              rd_clock()));
+        mtx_unlock(&mcluster->lock);
+
         rd_kafka_dbg(rk, MOCK, "MOCK",
                      "Broker %" PRId32 ": Received %sRequestV%hd from %s",
                      mconn->broker->id,
@@ -2472,6 +2480,8 @@ static void rd_kafka_mock_cluster_destroy0(rd_kafka_mock_cluster_t *mcluster) {
                 rd_kafka_mock_error_stack_destroy(errstack);
         }
 
+        rd_list_destroy(&mcluster->request_list);
+
         /*
          * Destroy dummy broker
          */
@@ -2580,6 +2590,8 @@ rd_kafka_mock_cluster_t *rd_kafka_mock_cluster_new(rd_kafka_t *rk,
         memcpy(mcluster->api_handlers, rd_kafka_mock_api_handlers,
                sizeof(mcluster->api_handlers));
 
+        rd_list_init(&mcluster->request_list, 10, rd_kafka_mock_request_free);
+
         /* Use an op queue for controlling the cluster in
          * a thread-safe manner without locking. */
         mcluster->ops             = rd_kafka_q_new(rk);
@@ -2644,4 +2656,70 @@ rd_kafka_mock_cluster_t *rd_kafka_handle_mock_cluster(const rd_kafka_t *rk) {
 const char *
 rd_kafka_mock_cluster_bootstraps(const rd_kafka_mock_cluster_t *mcluster) {
         return mcluster->bootstraps;
+}
+
+rd_kafka_mock_request_t *
+rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp) {
+        rd_kafka_mock_request_t *request;
+        request            = rd_malloc(sizeof(*request));
+        request->id        = id;
+        request->api_key   = api_key;
+        request->timestamp = timestamp;
+        return request;
+}
+
+static rd_kafka_mock_request_t *
+rd_kafka_mock_request_copy(rd_kafka_mock_request_t *mrequest) {
+        rd_kafka_mock_request_t *request;
+        request = rd_malloc(sizeof(*request));
+        memcpy(request, mrequest, sizeof(*request));
+        return request;
+}
+
+void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *mreq) {
+        rd_free(mreq);
+}
+
+void rd_kafka_mock_request_free(void *mreq) {
+        rd_kafka_mock_request_destroy((rd_kafka_mock_request_t *)mreq);
+}
+
+rd_kafka_mock_request_t **
+rd_kafka_mock_get_requests(rd_kafka_mock_cluster_t *mcluster, size_t *cntp) {
+        size_t i;
+        rd_kafka_mock_request_t **ret = NULL;
+
+        mtx_lock(&mcluster->lock);
+        *cntp = rd_list_cnt(&mcluster->request_list);
+        if (*cntp > 0) {
+                ret = rd_calloc(*cntp, sizeof(rd_kafka_mock_request_t *));
+                for (i = 0; i < *cntp; i++) {
+                        rd_kafka_mock_request_t *mreq =
+                            rd_list_elem(&mcluster->request_list, i);
+                        ret[i] = rd_kafka_mock_request_copy(mreq);
+                }
+        }
+
+        mtx_unlock(&mcluster->lock);
+
+        return ret;
+}
+
+void rd_kafka_mock_broker_clear_requests(rd_kafka_mock_cluster_t *mcluster) {
+        mtx_lock(&mcluster->lock);
+        rd_list_clear(&mcluster->request_list);
+        mtx_unlock(&mcluster->lock);
+}
+
+RD_EXPORT int32_t rd_kafka_mock_request_id(rd_kafka_mock_request_t *mreq) {
+        return mreq->id;
+}
+
+RD_EXPORT int16_t rd_kafka_mock_request_api_key(rd_kafka_mock_request_t *mreq) {
+        return mreq->api_key;
+}
+
+RD_EXPORT rd_ts_t
+rd_kafka_mock_request_timestamp(rd_kafka_mock_request_t *mreq) {
+        return mreq->timestamp;
 }

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -383,6 +383,49 @@ rd_kafka_mock_telemetry_set_requested_metrics(rd_kafka_mock_cluster_t *mcluster,
                                               size_t metrics_cnt);
 
 
+/**
+ * @name Represents a request to the mock cluster along with a timestamp.
+ */
+typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
+
+/**
+ * @brief Get the list of requests sent to this mock cluster.
+ *
+ * @param cntp is set to the count of requests.
+ * @return List of rd_kafka_mock_request_t *.
+ * @remark each element of the returned array must be freed with
+ *         rd_kafka_mock_request_destroy, and the list itself must be freed too.
+ */
+RD_EXPORT rd_kafka_mock_request_t **
+rd_kafka_mock_get_requests(rd_kafka_mock_cluster_t *mcluster, size_t *cntp);
+
+/**
+ * @brief Clear the list of requests sent to this mock broker.
+ */
+RD_EXPORT void
+rd_kafka_mock_broker_clear_requests(rd_kafka_mock_cluster_t *mcluster);
+
+/**
+ * @brief Destroy a rd_kafka_mock_request_t * and deallocate memory.
+ */
+RD_EXPORT void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *mreq);
+
+/**
+ * @brief Get the broker id to which \p mreq was sent.
+ */
+RD_EXPORT int32_t rd_kafka_mock_request_id(rd_kafka_mock_request_t *mreq);
+
+/**
+ * @brief Get the ApiKey with which \p mreq was sent.
+ */
+RD_EXPORT int16_t rd_kafka_mock_request_api_key(rd_kafka_mock_request_t *mreq);
+
+/**
+ * @brief Get the timestamp at which \p mreq was sent.
+ */
+RD_EXPORT rd_ts_t
+rd_kafka_mock_request_timestamp(rd_kafka_mock_request_t *mreq);
+
 /**@}*/
 
 #ifdef __cplusplus

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -187,6 +187,15 @@ typedef struct rd_kafka_mock_connection_s {
 
 
 /**
+ * @struct Represents a request to the mock cluster along with a timestamp.
+ */
+struct rd_kafka_mock_request_s {
+        int32_t id;      /**< Broker id */
+        int16_t api_key; /**< API Key of request */
+        rd_ts_t timestamp /**< Timestamp at which request was received */;
+};
+
+/**
  * @struct Mock broker
  */
 typedef struct rd_kafka_mock_broker_s {
@@ -209,7 +218,6 @@ typedef struct rd_kafka_mock_broker_s {
 
         struct rd_kafka_mock_cluster_s *cluster;
 } rd_kafka_mock_broker_t;
-
 
 /**
  * @struct A Kafka-serialized MessageSet
@@ -399,9 +407,15 @@ struct rd_kafka_mock_cluster_s {
         /** < Requested metric count. */
         size_t metrics_cnt;
 
+        /**< List of API requests for this broker. Type:
+         * rd_kafka_mock_request_t*
+         */
+        rd_list_t request_list;
+
         /**< Mutex for:
          *   .errstacks
          *   .apiversions
+         *   .request_list
          */
         mtx_t lock;
 
@@ -534,7 +548,9 @@ rd_kafka_mock_cgrp_get(rd_kafka_mock_cluster_t *mcluster,
                        const rd_kafkap_str_t *ProtocolType);
 void rd_kafka_mock_cgrps_connection_closed(rd_kafka_mock_cluster_t *mcluster,
                                            rd_kafka_mock_connection_t *mconn);
-
+rd_kafka_mock_request_t *
+rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp);
+void rd_kafka_mock_request_free(void *mreq);
 
 /**
  *@}


### PR DESCRIPTION
Adds a method to fetch the requests.

Usage, with the example of tests/0009:

```C
        rd_kafka_destroy(c);
        rd_kafka_destroy(p);

        size_t sz;
        rd_kafka_mock_request_t **reqs =
            rd_kafka_mock_get_requests(mcluster, &sz);
        fprintf(stderr, "requests while testing:\n");
        for (size_t i = 0; i < sz; i++) {
                rd_kafka_mock_request_t *req = reqs[i];
                fprintf(stderr,
                        "\t{ id = %d, timestamp = %ld, api_key = %d }\n",
                        rd_kafka_mock_request_id(req),
                        rd_kafka_mock_request_timestamp(req),
                        rd_kafka_mock_request_api_key(req));
        }

        test_mock_cluster_destroy(mcluster);
```