### PR TITLE
Skip Kerberos ticket refresh if unable to run kinit through system() (#4443)

### DIFF
--- a/configure.self
+++ b/configure.self
@@ -281,6 +281,16 @@ void foo (void) {
 }
 '
 
+    # See if system() is available.
+    mkl_compile_check "system" "HAVE_SYSTEM" disable CC "" \
+'
+#include <stdlib.h>
+
+void foo (void) {
+  system("true");
+}
+'
+
     # Figure out what tool to use for dumping public symbols.
     # We rely on configure.cc setting up $NM if it exists.
     if mkl_env_check "nm" "" cont "NM" ; then

--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -201,6 +201,7 @@ render_callback(const char *key, char *buf, size_t size, void *opaque) {
  * @locality rdkafka main thread
  */
 static int rd_kafka_sasl_cyrus_kinit_refresh(rd_kafka_t *rk) {
+#ifdef HAVE_SYSTEM
         rd_kafka_sasl_cyrus_handle_t *handle = rk->rk_sasl.handle;
         int r;
         char *cmd;
@@ -282,6 +283,12 @@ static int rd_kafka_sasl_cyrus_kinit_refresh(rd_kafka_t *rk) {
         rd_kafka_dbg(rk, SECURITY, "SASLREFRESH",
                      "Kerberos ticket refreshed in %dms", duration);
         return 0;
+#else
+        rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
+                     "Kerberos ticket refresh failed: "
+                     "system() is not available",
+        return -1;
+#endif
 }
 
 


### PR DESCRIPTION
`system()` is not available on certain platforms, like iOS. It's used to execute `kinit` to refresh Kerberos tickets. Add a check for this during configuration and disable the call if unavailable.

See #4443.