### PR TITLE
Fix public API for mock requests

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -41,7 +41,11 @@
 #include "rdkafka_mock.h"
 #include <stdarg.h>
 
+typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
+
 static void rd_kafka_mock_cluster_destroy0(rd_kafka_mock_cluster_t *mcluster);
+static rd_kafka_mock_request_t *
+rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp);
 
 
 static rd_kafka_mock_broker_t *
@@ -2622,7 +2626,10 @@ struct rd_kafka_mock_request_s {
         rd_ts_t timestamp /**< Timestamp at which request was received */;
 };
 
-rd_kafka_mock_request_t *
+/**
+ * @brief Allocate and initialize a rd_kafka_mock_request_t *
+ */
+static rd_kafka_mock_request_t *
 rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp) {
         rd_kafka_mock_request_t *request;
         request            = rd_malloc(sizeof(*request));
@@ -2632,7 +2639,7 @@ rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp) {
         return request;
 }
 
-rd_kafka_mock_request_t *
+static rd_kafka_mock_request_t *
 rd_kafka_mock_request_copy(rd_kafka_mock_request_t *mrequest) {
         rd_kafka_mock_request_t *request;
         request            = rd_malloc(sizeof(*request));
@@ -2646,7 +2653,7 @@ void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *element) {
         rd_free(element);
 }
 
-void rd_kafka_mock_request_free(void *element) {
+static void rd_kafka_mock_request_free(void *element) {
         rd_kafka_mock_request_destroy(element);
 }
 

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -45,7 +45,7 @@ typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
 
 static void rd_kafka_mock_cluster_destroy0(rd_kafka_mock_cluster_t *mcluster);
 static rd_kafka_mock_request_t *
-rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp);
+rd_kafka_mock_request_new(int32_t id, int16_t api_key, int64_t timestamp_us);
 
 
 static rd_kafka_mock_broker_t *
@@ -2630,12 +2630,12 @@ struct rd_kafka_mock_request_s {
  * @brief Allocate and initialize a rd_kafka_mock_request_t *
  */
 static rd_kafka_mock_request_t *
-rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp) {
+rd_kafka_mock_request_new(int32_t id, int16_t api_key, int64_t timestamp_us) {
         rd_kafka_mock_request_t *request;
         request            = rd_malloc(sizeof(*request));
         request->id        = id;
         request->api_key   = api_key;
-        request->timestamp = timestamp;
+        request->timestamp = timestamp_us;
         return request;
 }
 

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -365,19 +365,23 @@ rd_kafka_mock_set_apiversion(rd_kafka_mock_cluster_t *mcluster,
                              int16_t MaxVersion);
 
 /**
- * @name Represents a request to the mock cluster along with a timestamp.
+ * @brief Start tracking RPC requests for this mock cluster.
+ * @sa rd_kafka_mock_get_requests to get the requests.
  */
-typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
-
-RD_EXPORT
-rd_kafka_mock_request_t *
-rd_kafka_mock_request_new(int32_t id, int16_t api_key, rd_ts_t timestamp);
-
 RD_EXPORT
 void rd_kafka_mock_start_request_tracking(rd_kafka_mock_cluster_t *mcluster);
 
+/**
+ * @brief Stop tracking RPC requests for this mock cluster.
+ *        Does not clear already tracked requests.
+ */
 RD_EXPORT
 void rd_kafka_mock_stop_request_tracking(rd_kafka_mock_cluster_t *mcluster);
+
+/**
+ * @name Represents a request to the mock cluster along with a timestamp.
+ */
+typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
 
 /**
  * @brief Destroy a rd_kafka_mock_request_t * and deallocate memory.
@@ -395,9 +399,9 @@ RD_EXPORT int32_t rd_kafka_mock_request_id(rd_kafka_mock_request_t *mreq);
 RD_EXPORT int16_t rd_kafka_mock_request_api_key(rd_kafka_mock_request_t *mreq);
 
 /**
- * @brief Get the timestamp at which \p mreq was sent.
+ * @brief Get the timestamp in micros at which \p mreq was sent.
  */
-RD_EXPORT rd_ts_t
+RD_EXPORT int64_t
 rd_kafka_mock_request_timestamp(rd_kafka_mock_request_t *mreq);
 
 /**
@@ -412,7 +416,8 @@ RD_EXPORT rd_kafka_mock_request_t **
 rd_kafka_mock_get_requests(rd_kafka_mock_cluster_t *mcluster, size_t *cntp);
 
 /**
- * @brief Clear the list of requests sent to this mock broker.
+ * @brief Clear the list of requests sent to this mock broker, in case request
+ *        tracking is/was turned on.
  */
 RD_EXPORT void rd_kafka_mock_clear_requests(rd_kafka_mock_cluster_t *mcluster);
 


### PR DESCRIPTION
We exposed accidentally rd_ts_t in the publicly exposed API for mock broker as a part of the KIP-580 commit.
Fixes that.
We didn't do a release for this, so public API guarantee is not broker. 

Additionally marks some file-local methods static.