### PR TITLE
Fix timeout for rd_kafka_query_watermark_offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ librdkafka v2.3.0 is a feature release:
  * [KIP-430](https://cwiki.apache.org/confluence/display/KAFKA/KIP-430+-+Return+Authorized+Operations+in+Describe+Responses):
    Return authorized operations in Describe Responses.
    (#4240, @jainruchir).
- * [KIP-580](https://cwiki.apache.org/confluence/display/KAFKA/KIP-580%3A+Exponential+Backoff+for+Kafka+Clients): Added Exponential Backoff mechanism for  
+ * [KIP-580](https://cwiki.apache.org/confluence/display/KAFKA/KIP-580%3A+Exponential+Backoff+for+Kafka+Clients): Added Exponential Backoff mechanism for
    retriable requests with `retry.backoff.ms` as minimum backoff and `retry.backoff.max.ms` as the
    maximum backoff, with 20% jitter(#4422).
  * Fixed ListConsumerGroupOffsets not fetching offsets for all the topics in a group with Apache Kafka version below 2.4.0.
@@ -34,6 +34,7 @@ librdkafka v2.3.0 is a feature release:
  * Fix to ensure max.poll.interval.ms is reset when rd_kafka_poll is called with
    consume_cb (#4431).
  * Fix for idempotent producer fatal errors, triggered after a possibly persisted message state (#4438).
+ * Fix `rd_kafka_query_watermark_offsets` hanging forever (#4460).
 
 
 ## Upgrade considerations
@@ -42,7 +43,7 @@ librdkafka v2.3.0 is a feature release:
    If it is set greater than `retry.backoff.max.ms` which has the default value of 1000 ms then it is assumes the value of `retry.backoff.max.ms`.
    To change this behaviour make sure that `retry.backoff.ms` is always less than `retry.backoff.max.ms`.
    If equal then the backoff will be linear instead of exponential.
-   
+
  * `topic.metadata.refresh.fast.interval.ms`:
    If it is set greater than `retry.backoff.max.ms` which has the default value of 1000 ms then it is assumes the value of `retry.backoff.max.ms`.
    To change this behaviour make sure that `topic.metadata.refresh.fast.interval.ms` is always less than `retry.backoff.max.ms`.
@@ -56,6 +57,9 @@ librdkafka v2.3.0 is a feature release:
  * An assertion failed with insufficient buffer size when allocating
    rack information on 32bit architectures.
    Solved by aligning all allocations to the maximum allowed word size (#4449).
+ * The timeout for `rd_kafka_query_watermark_offsets` was not checked after
+   making the necessary ListOffsets requests, and thus, it never timed out in
+   case of broker/network issues. Fixed by checking timeout expiry (#4460).
 
 ### Idempotent producer fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ librdkafka v2.3.0 is a feature release:
  * Fix to ensure max.poll.interval.ms is reset when rd_kafka_poll is called with
    consume_cb (#4431).
  * Fix for idempotent producer fatal errors, triggered after a possibly persisted message state (#4438).
- * Fix `rd_kafka_query_watermark_offsets` hanging forever (#4460).
+ * Fix `rd_kafka_query_watermark_offsets` continuing beyond timeout expiry (#4460).
 
 
 ## Upgrade considerations

--- a/tests/0031-get_offsets.c
+++ b/tests/0031-get_offsets.c
@@ -38,7 +38,7 @@
 /**
  * Verify that rd_kafka_(query|get)_watermark_offsets() works.
  */
-void do_test_query_then_get_offsets(void) {
+static void do_test_query_then_get_offsets(void) {
         const char *topic = test_mk_topic_name(__FUNCTION__, 1);
         const int msgcnt  = test_quick ? 10 : 100;
         rd_kafka_t *rk;

--- a/tests/0031-get_offsets.c
+++ b/tests/0031-get_offsets.c
@@ -38,7 +38,9 @@
 /**
  * Verify that rd_kafka_(query|get)_watermark_offsets() works.
  */
-static void do_test_query_then_get_offsets(void) {
+
+
+int main_0031_get_offsets(int argc, char **argv) {
         const char *topic = test_mk_topic_name(__FUNCTION__, 1);
         const int msgcnt  = test_quick ? 10 : 100;
         rd_kafka_t *rk;
@@ -48,11 +50,6 @@ static void do_test_query_then_get_offsets(void) {
         rd_kafka_resp_err_t err;
         test_timing_t t_qry, t_get;
         uint64_t testid;
-
-        if (test_quick)
-                SUB_TEST_QUICK();
-        else
-                SUB_TEST();
 
         /* Produce messages */
         testid = test_produce_msgs_easy(topic, 0, 0, msgcnt);
@@ -119,14 +116,14 @@ static void do_test_query_then_get_offsets(void) {
         rd_kafka_topic_destroy(rkt);
         rd_kafka_destroy(rk);
 
-        SUB_TEST_PASS();
+        return 0;
 }
 
 /*
  * Verify that rd_kafka_query_watermark_offsets times out in case we're unable
  * to fetch offsets within the timeout (Issue #2588).
  */
-static void do_test_query_offsets_timeout_mock(void) {
+int main_0031_get_offsets_mock(int argc, char **argv) {
         int64_t qry_low, qry_high;
         rd_kafka_resp_err_t err;
         const char *topic = test_mk_topic_name(__FUNCTION__, 1);
@@ -136,11 +133,9 @@ static void do_test_query_offsets_timeout_mock(void) {
         const char *bootstraps;
         const int timeout_ms = 1000;
 
-        SUB_TEST_QUICK();
-
         if (test_needs_auth()) {
-                SUB_TEST_SKIP("Mock cluster does not support SSL/SASL\n");
-                return;
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
         }
 
         mcluster = test_mock_cluster_new(1, &bootstraps);
@@ -166,12 +161,5 @@ static void do_test_query_offsets_timeout_mock(void) {
         rd_kafka_destroy(rk);
         test_mock_cluster_destroy(mcluster);
 
-        SUB_TEST_PASS();
-}
-
-
-int main_0031_get_offsets(int argc, char **argv) {
-        do_test_query_then_get_offsets();
-        do_test_query_offsets_timeout_mock();
         return 0;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -134,6 +134,7 @@ _TEST_DECL(0028_long_topicnames);
 _TEST_DECL(0029_assign_offset);
 _TEST_DECL(0030_offset_commit);
 _TEST_DECL(0031_get_offsets);
+_TEST_DECL(0031_get_offsets_mock);
 _TEST_DECL(0033_regex_subscribe);
 _TEST_DECL(0033_regex_subscribe_local);
 _TEST_DECL(0034_offset_reset);
@@ -334,6 +335,7 @@ struct test tests[] = {
           /* Loops over committed() until timeout */
           _THRES(.ucpu = 10.0, .scpu = 5.0)),
     _TEST(0031_get_offsets, 0),
+    _TEST(0031_get_offsets_mock, TEST_F_LOCAL),
     _TEST(0033_regex_subscribe, 0, TEST_BRKVER(0, 9, 0, 0)),
     _TEST(0033_regex_subscribe_local, TEST_F_LOCAL),
     _TEST(0034_offset_reset, 0),


### PR DESCRIPTION
`rd_kafka_query_watermark_offsets` hangs forever if say, the broker is down, and exceeds the timeout in case the RTT > timeout, see the linked issue.

This PR adds a failing test, and then fixes the issue.

This also changes the fact the return value of `rd_kafka_q_serve` was being compared to RD_KAFKA_OP_RES_YIELD, which doesn't make sense to me, since it returns the count of served ops, and RD_KAFKA_OP_RES_YIELD is a positive constant.

Fixes #2588. 