### PR TITLE
Don't block fatal thread-directed signals in newly created threads

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2451,13 +2451,21 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
         }
 
 #ifndef _WIN32
-        /* Block all signals in newly created threads.
-         * To avoid race condition we block all signals in the calling
+        /* Block all non-fatal signals in newly created threads.
+         * To avoid race condition we block the signals in the calling
          * thread, which the new thread will inherit its sigmask from,
          * and then restore the original sigmask of the calling thread when
-         * we're done creating the thread. */
+         * we're done creating the thread. By not blocking every signal we
+         * allow users to catch fatal thread-directed signals when needed. */
         sigemptyset(&oldset);
         sigfillset(&newset);
+        sigdelset(&newset, SIGABRT);
+        sigdelset(&newset, SIGBUS);
+        sigdelset(&newset, SIGFPE);
+        sigdelset(&newset, SIGILL);
+        sigdelset(&newset, SIGQUIT);
+        sigdelset(&newset, SIGSEGV);
+        sigdelset(&newset, SIGTRAP);
         if (rk->rk_conf.term_sig) {
                 struct sigaction sa_term = {.sa_handler =
                                                 rd_kafka_term_sig_handler};

--- a/src/rdkafka_background.c
+++ b/src/rdkafka_background.c
@@ -176,13 +176,21 @@ rd_kafka_resp_err_t rd_kafka_background_thread_create(rd_kafka_t *rk,
         rk->rk_init_wait_cnt++;
 
 #ifndef _WIN32
-        /* Block all signals in newly created threads.
-         * To avoid race condition we block all signals in the calling
+        /* Block all non-fatal signals in newly created threads.
+         * To avoid race condition we block the signals in the calling
          * thread, which the new thread will inherit its sigmask from,
          * and then restore the original sigmask of the calling thread when
-         * we're done creating the thread. */
+         * we're done creating the thread. By not blocking every signal we
+         * allow users to catch fatal thread-directed signals when needed. */
         sigemptyset(&oldset);
         sigfillset(&newset);
+        sigdelset(&newset, SIGABRT);
+        sigdelset(&newset, SIGBUS);
+        sigdelset(&newset, SIGFPE);
+        sigdelset(&newset, SIGILL);
+        sigdelset(&newset, SIGQUIT);
+        sigdelset(&newset, SIGSEGV);
+        sigdelset(&newset, SIGTRAP);
         if (rk->rk_conf.term_sig) {
                 struct sigaction sa_term = {.sa_handler =
                                                 rd_kafka_term_sig_handler};

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4845,15 +4845,23 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
         rd_interval_init(&rkb->rkb_suppress.fail_error);
 
 #ifndef _WIN32
-        /* Block all signals in newly created thread.
-         * To avoid race condition we block all signals in the calling
+        /* Block all non-fatal signals in newly created thread.
+         * To avoid race condition we block the signals in the calling
          * thread, which the new thread will inherit its sigmask from,
          * and then restore the original sigmask of the calling thread when
-         * we're done creating the thread.
+         * we're done creating the thread. By not blocking every signal we
+         * allow users to catch fatal thread-directed signals when needed.
          * NOTE: term_sig remains unblocked since we use it on termination
          *       to quickly interrupt system calls. */
         sigemptyset(&oldset);
         sigfillset(&newset);
+        sigdelset(&newset, SIGABRT);
+        sigdelset(&newset, SIGBUS);
+        sigdelset(&newset, SIGFPE);
+        sigdelset(&newset, SIGILL);
+        sigdelset(&newset, SIGQUIT);
+        sigdelset(&newset, SIGSEGV);
+        sigdelset(&newset, SIGTRAP);
         if (rkb->rkb_rk->rk_conf.term_sig)
                 sigdelset(&newset, rkb->rkb_rk->rk_conf.term_sig);
         pthread_sigmask(SIG_SETMASK, &newset, &oldset);


### PR DESCRIPTION
Some signals are sent synchronously to a thread and if blocked a user-installed signal handler will not be called.
This change allows users to install own signal handlers and catch fatal signals when `librdkafka` misbehave.

Tests have been run successfully, but please advice if there is an alternative place for a helper function.
I have seen `src/rdsignal.h` which could have been its home, but it seems not (yet) used.

Fixes #4437 