### PR TITLE
Support rd_kafka_queue_yield() in C++ queue wrapper

### DIFF
--- a/src-cpp/QueueImpl.cpp
+++ b/src-cpp/QueueImpl.cpp
@@ -68,3 +68,7 @@ void RdKafka::QueueImpl::io_event_enable(int fd,
                                          size_t size) {
   rd_kafka_queue_io_event_enable(queue_, fd, payload, size);
 }
+
+void RdKafka::QueueImpl::yield() {
+  rd_kafka_queue_yield(queue_);
+}

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2595,6 +2595,16 @@ class RD_EXPORT Queue {
    *         on the final forwarded-to (destination) queue.
    */
   virtual void io_event_enable(int fd, const void *payload, size_t size) = 0;
+
+  /**
+   * @brief Cancels the current rd_kafka_queue_poll() and rd_kafka_consume_callback()
+   * on the queue.
+   *
+   * An application may use this from another thread to force an immediate
+   * return to the calling code (caller of rd_kafka_queue_poll()). Must not
+   * be used from signal handlers since that may cause deadlocks.
+   */
+  virtual void yield() = 0;
 };
 
 /**@}*/

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -246,6 +246,7 @@ class QueueImpl : virtual public Queue {
   Message *consume(int timeout_ms);
   int poll(int timeout_ms);
   void io_event_enable(int fd, const void *payload, size_t size);
+  void yield();
 
   rd_kafka_queue_t *queue_;
 };


### PR DESCRIPTION
Add queue `yield()` support in the C++ queue wrapper class 