### PR TITLE
Fix for brokers with different Ids but same host:port

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5236,6 +5236,8 @@ void rd_kafka_group_list_destroy(const struct rd_kafka_group_list *grplist);
 RD_EXPORT
 int rd_kafka_brokers_add(rd_kafka_t *rk, const char *brokerlist);
 
+RD_EXPORT
+int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp);
 
 
 /**

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2136,7 +2136,7 @@ rd_kafka_broker_reconnect_backoff(const rd_kafka_broker_t *rkb, rd_ts_t now) {
 static int rd_ut_reconnect_backoff(void) {
         rd_kafka_broker_t rkb = RD_ZERO_INIT;
         rd_kafka_conf_t conf  = {.reconnect_backoff_ms     = 10,
-                                .reconnect_backoff_max_ms = 90};
+                                 .reconnect_backoff_max_ms = 90};
         rd_ts_t now           = 1000000;
         int backoff;
 
@@ -5430,12 +5430,6 @@ void rd_kafka_broker_update(rd_kafka_t *rk,
                  * the hostname. */
                 if (strcmp(rkb->rkb_nodename, nodename))
                         needs_update = 1;
-        } else if ((rkb = rd_kafka_broker_find(rk, proto, mdb->host,
-                                               mdb->port))) {
-                /* Broker matched by hostname (but not by nodeid),
-                 * update the nodeid. */
-                needs_update = 1;
-
         } else if ((rkb = rd_kafka_broker_add(rk, RD_KAFKA_LEARNED, proto,
                                               mdb->host, mdb->port, mdb->id))) {
                 rd_kafka_broker_keep(rkb);
@@ -6008,6 +6002,34 @@ void rd_kafka_broker_start_reauth_cb(rd_kafka_timers_t *rkts, void *_rkb) {
         rd_dassert(rkb);
         rko = rd_kafka_op_new(RD_KAFKA_OP_SASL_REAUTH);
         rd_kafka_q_enq(rkb->rkb_ops, rko);
+}
+
+/**
+ * @brief Retrieve and return the learned broker ids.
+ *
+ * @param rk Instance to use.
+ * @param cntp Will be updated to the number of brokers returned.
+ *
+ * @returns a malloc:ed list of int32_t broker ids.
+ */
+int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
+        rd_kafka_broker_t *rkb;
+
+        size_t all_broker_cnt = rd_atomic32_get(&rk->rk_broker_cnt);
+        /* This over-allocates but simplifies the code. */
+        int32_t *ids = malloc(sizeof(*ids) * all_broker_cnt);
+        int32_t *p   = ids;
+
+        *cntp = 0;
+        TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (rkb->rkb_source != RD_KAFKA_LEARNED)
+                        continue;
+
+                *p++ = rkb->rkb_nodeid;
+                (*cntp)++;
+        }
+
+        return ids;
 }
 
 /**

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -2126,6 +2126,30 @@ rd_kafka_mock_broker_set_rack(rd_kafka_mock_cluster_t *mcluster,
             rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
 }
 
+void rd_kafka_mock_broker_set_host_port(rd_kafka_mock_cluster_t *cluster,
+                                        int32_t broker_id,
+                                        const char *host,
+                                        int port) {
+        rd_kafka_mock_broker_t *mrkb;
+
+        mtx_lock(&cluster->lock);
+        TAILQ_FOREACH(mrkb, &cluster->brokers, link) {
+                if (mrkb->id == broker_id) {
+                        rd_kafka_dbg(
+                            cluster->rk, MOCK, "MOCK",
+                            "Broker %" PRId32
+                            ": Setting advertised listener from %s:%d to %s:%d",
+                            broker_id, mrkb->advertised_listener, mrkb->port,
+                            host, port);
+                        rd_snprintf(mrkb->advertised_listener,
+                                    sizeof(mrkb->advertised_listener), "%s",
+                                    host);
+                        mrkb->port = port;
+                }
+        }
+        mtx_unlock(&cluster->lock);
+}
+
 rd_kafka_resp_err_t
 rd_kafka_mock_coordinator_set(rd_kafka_mock_cluster_t *mcluster,
                               const char *key_type,

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -293,6 +293,13 @@ RD_EXPORT rd_kafka_resp_err_t
 rd_kafka_mock_broker_set_down(rd_kafka_mock_cluster_t *mcluster,
                               int32_t broker_id);
 
+RD_EXPORT void
+rd_kafka_mock_broker_set_host_port(rd_kafka_mock_cluster_t *mcluster,
+                                   int32_t broker_id,
+                                   const char *host,
+                                   int port);
+
+
 /**
  * @brief Makes the broker accept connections again.
  *        This does NOT trigger leader change.

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -99,11 +99,12 @@ typedef struct rd_kafka_mock_cgrp_s {
         char *protocol_name;                     /**< Elected protocol name */
         int32_t generation_id;                   /**< Generation Id */
         int session_timeout_ms;                  /**< Session timeout */
-        enum { RD_KAFKA_MOCK_CGRP_STATE_EMPTY,   /* No members */
-               RD_KAFKA_MOCK_CGRP_STATE_JOINING, /* Members are joining */
-               RD_KAFKA_MOCK_CGRP_STATE_SYNCING, /* Syncing assignments */
-               RD_KAFKA_MOCK_CGRP_STATE_REBALANCING, /* Rebalance triggered */
-               RD_KAFKA_MOCK_CGRP_STATE_UP,          /* Group is operational */
+        enum {
+                RD_KAFKA_MOCK_CGRP_STATE_EMPTY,       /* No members */
+                RD_KAFKA_MOCK_CGRP_STATE_JOINING,     /* Members are joining */
+                RD_KAFKA_MOCK_CGRP_STATE_SYNCING,     /* Syncing assignments */
+                RD_KAFKA_MOCK_CGRP_STATE_REBALANCING, /* Rebalance triggered */
+                RD_KAFKA_MOCK_CGRP_STATE_UP,          /* Group is operational */
         } state;                        /**< Consumer group state */
         rd_kafka_timer_t session_tmr;   /**< Session timeout timer */
         rd_kafka_timer_t rebalance_tmr; /**< Rebalance state timer */
@@ -385,7 +386,7 @@ struct rd_kafka_mock_cluster_s {
         struct {
                 rd_kafka_mock_io_handler_t *cb; /**< Callback */
                 void *opaque;                   /**< Callbacks' opaque */
-        } * handlers;
+        } *handlers;
 
         /**< Per-protocol request error stack. */
         rd_kafka_mock_error_stack_head_t errstacks;

--- a/tests/0145-broker-same-host-port.c
+++ b/tests/0145-broker-same-host-port.c
@@ -1,0 +1,89 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Matt Fleming.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+
+int main_0145_broker_same_host_port(int argc, char **argv) {
+        rd_kafka_mock_cluster_t *cluster;
+        const char *bootstraps;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        const rd_kafka_metadata_t *md;
+        rd_kafka_resp_err_t err;
+        const size_t num_brokers = 3;
+        size_t cnt               = 0;
+        int32_t *ids;
+        size_t i;
+
+        if (test_needs_auth()) {
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
+        }
+
+        cluster = test_mock_cluster_new(num_brokers, &bootstraps);
+
+        for (i = 1; i <= num_brokers; i++) {
+                rd_kafka_mock_broker_set_host_port(cluster, i, "localhost",
+                                                   9092);
+        }
+
+        test_conf_init(&conf, NULL, 10);
+
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "debug", "mock,broker,metadata");
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        /* Trigger Metadata request which will update learned brokers. */
+        err = rd_kafka_metadata(rk, 0, NULL, &md, tmout_multip(5000));
+        rd_kafka_metadata_destroy(md);
+        TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+        ids = rd_kafka_broker_get_learned_ids(rk, &cnt);
+
+        TEST_ASSERT(cnt == num_brokers,
+                    "expected %" PRIusz " brokers in cache, not %" PRIusz,
+                    num_brokers, cnt);
+
+        for (i = 0; i < cnt; i++) {
+                /* Brokers are added at the head of the list. */
+                int32_t expected_id = cnt - i;
+
+                TEST_ASSERT(ids[i] == expected_id,
+                            "expected broker %d in cache, not %d", expected_id,
+                            ids[i]);
+        }
+
+        if (ids)
+                free(ids);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(cluster);
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ set(
     0142-reauthentication.c
     0143-exponential_backoff_mock.c
     0144-idempotence_mock.c
+    0145-brokers-same-host-port.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -257,6 +257,7 @@ _TEST_DECL(0140_commit_metadata);
 _TEST_DECL(0142_reauthentication);
 _TEST_DECL(0143_exponential_backoff_mock);
 _TEST_DECL(0144_idempotence_mock);
+_TEST_DECL(0145_broker_same_host_port);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -511,6 +512,7 @@ struct test tests[] = {
     _TEST(0142_reauthentication, 0, TEST_BRKVER(2, 2, 0, 0)),
     _TEST(0143_exponential_backoff_mock, TEST_F_LOCAL),
     _TEST(0144_idempotence_mock, TEST_F_LOCAL, TEST_BRKVER(0, 11, 0, 0)),
+    _TEST(0145_broker_same_host_port, 0),
 
 
     /* Manual tests */
@@ -983,7 +985,7 @@ static RD_INLINE unsigned int test_rand(void) {
 #ifdef _WIN32
         rand_s(&r);
 #else
-        r     = rand();
+        r = rand();
 #endif
         return r;
 }
@@ -1884,7 +1886,7 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
                 pcwd = _getcwd(cwd, sizeof(cwd) - 1);
 #else
-                pcwd   = getcwd(cwd, sizeof(cwd) - 1);
+                pcwd = getcwd(cwd, sizeof(cwd) - 1);
 #endif
                 if (pcwd)
                         TEST_SAY("Current directory: %s\n", cwd);
@@ -5452,7 +5454,8 @@ void test_headers_dump(const char *what,
 
 
 /**
- * @brief Retrieve and return the list of broker ids in the cluster.
+ * @brief Retrieve and return the list of broker ids in the cluster by
+ *        sending a Metadata request.
  *
  * @param rk Optional instance to use.
  * @param cntp Will be updated to the number of brokers returned.

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -225,6 +225,7 @@
     <ClCompile Include="..\..\tests\0142-reauthentication.c" />
     <ClCompile Include="..\..\tests\0143-exponential_backoff_mock.c" />
     <ClCompile Include="..\..\tests\0144-idempotence_mock.c" />
+    <ClCompile Include="..\..\tests\0145-brokers-same-host-port.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
The Kafka protocol allows for brokers to have multiple host:port pairs for a given node Id, e.g. see UpdateMetadata request which contains a live_brokers list where each broker Id has a list of host:port pairs. It follows from this that the thing that uniquely identifies a broker is its Id, and not the host:port.

The behaviour right now is that if we have multiple brokers with the same host:port but different Ids, the first broker in the list will be updated to have the Id of whatever broker we're looking at as we iterate through the brokers in the Metadata response in
rd_kafka_parse_Metadata0(), e.g.

 Step 1. Broker[0].id = Metadata.brokers[0].id
 Step 2. Broker[0].id = Metadata.brokers[1].id
 Step 3. Broker[0].id = Metadata.brokers[2].id

A typical situation where brokers have the same host:port pair but differ in their Id is if the brokers are behind a load balancer.

The NODE_UPDATE mechanism responsible for this was originally added in b09ff60c ("Handle broker name and nodeid updates (issue #343)") as a way to forcibly update a broker hostname if an Id is reused with a new host after the original one was decommissioned. But this isn't how the Java Kafka client works, so let's use the Metadata response as the source of truth instead of updating brokers if we can only match by their host:port.

Here's a screenshot of the traffic going to brokers sat behind a load balancer before (left) and after (right) this patch which illustrates that new connections are opened and the load is balanced correctly.
![Screenshot 2023-11-03 at 13 50 20](https://github.com/confluentinc/librdkafka/assets/94254/c830f236-55bc-474a-aae6-4fee8e00264e)
