### PR TITLE
Fix BoringSSL by supplying string length to `X509_VERIFY_PARAM_set1_host` explicitly

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -476,7 +476,7 @@ static int rd_kafka_transport_ssl_set_endpoint_id(rd_kafka_transport_t *rktrans,
 
                 param = SSL_get0_param(rktrans->rktrans_ssl);
 
-                if (!X509_VERIFY_PARAM_set1_host(param, name, 0))
+                if (!X509_VERIFY_PARAM_set1_host(param, name, strnlen(name, sizeof(name))))
                         goto fail;
         }
 #else


### PR DESCRIPTION
BoringSSL requires the calls to `X509_VERIFY_PARAM_set1_host` to provide explicit string length, see:

```
  if (name == NULL || namelen == 0) {
    // Unlike OpenSSL, we reject trying to set or add an empty name.
    return 0;
  }
```

https://github.com/google/boringssl/blob/39cc892c73d6c3faf2e604c44509f132c232f24c/crypto/x509/x509_vpm.c#L83-L86

This (trivial) PR fixes this issue, and allows BoringSSL to be used with librdkafka.