### PR TITLE
Upgrade to macOS 13.5 Semaphore agents

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: 'librdkafka build and release artifact pipeline'
 agent:
   machine:
-    type: s1-prod-macos-arm64
+    type: s1-prod-macos-13-5-arm64
 execution_time_limit:
   hours: 3
 global_job_config:
@@ -17,7 +17,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-arm64
+          type: s1-prod-macos-13-5-arm64
       env_vars:
         - name: ARTIFACT_KEY
           value: p-librdkafka__plat-osx__arch-arm64__lnk-all
@@ -43,7 +43,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: ARTIFACT_KEY
           value: p-librdkafka__plat-osx__arch-x64__lnk-all


### PR DESCRIPTION
This changes the Semaphore pipeline to macOS 13.5 agents instead of 12.4