### PR TITLE
Fix a "return by const value" warning on Clang

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -8221,7 +8221,7 @@ const rd_kafka_TopicPartitionInfo_t **rd_kafka_TopicDescription_partitions(
  * @return The partition id.
  */
 RD_EXPORT
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition);
 
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -8521,7 +8521,7 @@ static void rd_kafka_TopicDescription_free(void *ptr) {
         rd_kafka_TopicDescription_destroy(ptr);
 }
 
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition) {
         return partition->partition;
 }


### PR DESCRIPTION
Commit efbb96681 (which was apparently massive) introduced this function returning "by const value". It's possible this indicates a deeper bug, but for now let's just fix the compiler diagnostic by removing the useless "const".