### PR TITLE
Make install dependent on libs to avoid errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ file-check: CONFIGURATION.md LICENSES.txt examples
 check: file-check
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d $@ || exit $?; done)
 
-install-subdirs:
+install-subdirs: libs
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d install || exit $?; done)
 
 install: install-subdirs doc-install

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -489,7 +489,7 @@ function mkl_dep_install_source {
     # Build and install
     mkl_dbg "Building $name from source in $sdir (func $func)"
 
-    $func $name "$ddir" >$ilog 2>&1
+    libdir="/usr/lib" $func $name "$ddir" >$ilog 2>&1
     retcode=$?
 
     mkl_popd # $sdir

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -489,7 +489,7 @@ function mkl_dep_install_source {
     # Build and install
     mkl_dbg "Building $name from source in $sdir (func $func)"
 
-    libdir="/lib" $func $name "$ddir" >$ilog 2>&1
+    $func $name "$ddir" >$ilog 2>&1
     retcode=$?
 
     mkl_popd # $sdir

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -489,7 +489,7 @@ function mkl_dep_install_source {
     # Build and install
     mkl_dbg "Building $name from source in $sdir (func $func)"
 
-    $func $name "$ddir" >$ilog 2>&1
+    libdir="/lib" $func $name "$ddir" >$ilog 2>&1
     retcode=$?
 
     mkl_popd # $sdir


### PR DESCRIPTION
using parallelism.
Don't use passed libdir for librdkafka static
dependencies built from source