### PR TITLE
Add C++ support for the resolve and connect callbacks (and associated tests)

### DIFF
--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -301,7 +301,7 @@ void RdKafka::HandleImpl::set_common_config(const RdKafka::ConfImpl *confimpl) {
 
   if (confimpl->resolve_cb_) {
     rd_kafka_conf_set_resolve_cb(confimpl->rk_conf_,
-                                RdKafka::resolve_cb_trampoline);
+                                 RdKafka::resolve_cb_trampoline);
     resolve_cb_ = confimpl->resolve_cb_;
   }
 

--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -131,6 +131,16 @@ int RdKafka::socket_cb_trampoline(int domain,
   return handle->socket_cb_->socket_cb(domain, type, protocol);
 }
 
+int RdKafka::resolve_cb_trampoline(const char *node,
+                                   const char *service,
+                                   const struct addrinfo *hints,
+                                   struct addrinfo **res,
+                                   void *opaque) {
+  RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
+
+  return handle->resolve_cb_->resolve_cb(node, service, hints, res);
+}
+
 int RdKafka::open_cb_trampoline(const char *pathname,
                                 int flags,
                                 mode_t mode,
@@ -287,6 +297,12 @@ void RdKafka::HandleImpl::set_common_config(const RdKafka::ConfImpl *confimpl) {
     rd_kafka_conf_set_socket_cb(confimpl->rk_conf_,
                                 RdKafka::socket_cb_trampoline);
     socket_cb_ = confimpl->socket_cb_;
+  }
+
+  if (confimpl->resolve_cb_) {
+    rd_kafka_conf_set_resolve_cb(confimpl->rk_conf_,
+                                RdKafka::resolve_cb_trampoline);
+    resolve_cb_ = confimpl->resolve_cb_;
   }
 
   if (confimpl->ssl_cert_verify_cb_) {

--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -141,6 +141,16 @@ int RdKafka::resolve_cb_trampoline(const char *node,
   return handle->resolve_cb_->resolve_cb(node, service, hints, res);
 }
 
+int RdKafka::connect_cb_trampoline(int sockfd,
+                                   const struct sockaddr *addr,
+                                   int addrlen,
+                                   const char *id,
+                                   void *opaque) {
+  RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
+
+  return handle->connect_cb_->connect_cb(sockfd, addr, addrlen, id);
+}
+
 int RdKafka::open_cb_trampoline(const char *pathname,
                                 int flags,
                                 mode_t mode,
@@ -303,6 +313,12 @@ void RdKafka::HandleImpl::set_common_config(const RdKafka::ConfImpl *confimpl) {
     rd_kafka_conf_set_resolve_cb(confimpl->rk_conf_,
                                  RdKafka::resolve_cb_trampoline);
     resolve_cb_ = confimpl->resolve_cb_;
+  }
+
+  if (confimpl->connect_cb_) {
+    rd_kafka_conf_set_connect_cb(confimpl->rk_conf_,
+                                 RdKafka::connect_cb_trampoline);
+    connect_cb_ = confimpl->connect_cb_;
   }
 
   if (confimpl->ssl_cert_verify_cb_) {

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -80,6 +80,15 @@ typedef SSIZE_T ssize_t;
 #define RD_EXPORT
 #endif
 
+#ifndef _WIN32
+#include <netdb.h>
+#else
+#define WIN32_MEAN_AND_LEAN
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
+#endif
+
 /**@endcond*/
 
 extern "C" {
@@ -1146,6 +1155,29 @@ class RD_EXPORT SocketCb {
 
 
 /**
+ * @brief \b Portability: ResolveCb callback class
+ *
+ */
+class RD_EXPORT ResolveCb {
+ public:
+  /**
+   * @brief Resolve callback
+   *
+   * The resolve callback is responsible for resolving hostnames.
+   *
+   * It is typically not required to register an alternative resolve
+   * implementation
+   *
+   * @returns 0 if successful, or non-zero on error.
+   */
+  virtual int resolve_cb(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res) = 0;
+
+  virtual ~ResolveCb() {
+  }
+};
+
+
+/**
  * @brief \b Portability: OpenCb callback class
  *
  */
@@ -1273,6 +1305,11 @@ class RD_EXPORT Conf {
   /** @brief Use with \p name = \c \"socket_cb\" */
   virtual Conf::ConfResult set(const std::string &name,
                                SocketCb *socket_cb,
+                               std::string &errstr) = 0;
+
+  /** @brief Use with \p name = \c \"resolve_cb\" */
+  virtual Conf::ConfResult set(const std::string &name,
+                               ResolveCb *resolve_cb,
                                std::string &errstr) = 0;
 
   /** @brief Use with \p name = \c \"open_cb\" */

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1170,7 +1170,10 @@ class RD_EXPORT ResolveCb {
    *
    * @returns 0 if successful, or non-zero on error.
    */
-  virtual int resolve_cb(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res) = 0;
+  virtual int resolve_cb(const char *node,
+                         const char *service,
+                         const struct addrinfo *hints,
+                         struct addrinfo **res) = 0;
 
   virtual ~ResolveCb() {
   }

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -900,6 +900,7 @@ class ConfImpl : public Conf {
         name.compare("socket_cb") == 0 || name.compare("open_cb") == 0 ||
         name.compare("resolve_cb") == 0 || name.compare("rebalance_cb") == 0 ||
         name.compare("offset_commit_cb") == 0 ||
+        name.compare("connect_cb") == 0 ||
         name.compare("oauthbearer_token_refresh_cb") == 0 ||
         name.compare("ssl_cert_verify_cb") == 0 ||
         name.compare("set_engine_callback_data") == 0 ||

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -875,8 +875,7 @@ class ConfImpl : public Conf {
         name.compare("partitioner_cb") == 0 ||
         name.compare("partitioner_key_pointer_cb") == 0 ||
         name.compare("socket_cb") == 0 || name.compare("open_cb") == 0 ||
-        name.compare("resolve_cb") == 0 ||
-        name.compare("rebalance_cb") == 0 ||
+        name.compare("resolve_cb") == 0 || name.compare("rebalance_cb") == 0 ||
         name.compare("offset_commit_cb") == 0 ||
         name.compare("oauthbearer_token_refresh_cb") == 0 ||
         name.compare("ssl_cert_verify_cb") == 0 ||

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -76,6 +76,11 @@ int stats_cb_trampoline(rd_kafka_t *rk,
                         size_t json_len,
                         void *opaque);
 int socket_cb_trampoline(int domain, int type, int protocol, void *opaque);
+int resolve_cb_trampoline(const char *node,
+                          const char *service,
+                          const struct addrinfo *hints,
+                          struct addrinfo **res,
+                          void *opaque);
 int open_cb_trampoline(const char *pathname,
                        int flags,
                        mode_t mode,
@@ -582,6 +587,7 @@ class ConfImpl : public Conf {
       dr_cb_(NULL),
       event_cb_(NULL),
       socket_cb_(NULL),
+      resolve_cb_(NULL),
       open_cb_(NULL),
       partitioner_cb_(NULL),
       partitioner_kp_cb_(NULL),
@@ -728,6 +734,22 @@ class ConfImpl : public Conf {
     return Conf::CONF_OK;
   }
 
+  Conf::ConfResult set(const std::string &name,
+                       ResolveCb *resolve_cb,
+                       std::string &errstr) {
+    if (name != "resolve_cb") {
+      errstr = "Invalid value type, expected RdKafka::ResolveCb";
+      return Conf::CONF_INVALID;
+    }
+
+    if (!rk_conf_) {
+      errstr = "Requires RdKafka::Conf::CONF_GLOBAL object";
+      return Conf::CONF_INVALID;
+    }
+
+    resolve_cb_ = resolve_cb;
+    return Conf::CONF_OK;
+  }
 
   Conf::ConfResult set(const std::string &name,
                        OpenCb *open_cb,
@@ -853,6 +875,7 @@ class ConfImpl : public Conf {
         name.compare("partitioner_cb") == 0 ||
         name.compare("partitioner_key_pointer_cb") == 0 ||
         name.compare("socket_cb") == 0 || name.compare("open_cb") == 0 ||
+        name.compare("resolve_cb") == 0 ||
         name.compare("rebalance_cb") == 0 ||
         name.compare("offset_commit_cb") == 0 ||
         name.compare("oauthbearer_token_refresh_cb") == 0 ||
@@ -929,6 +952,13 @@ class ConfImpl : public Conf {
     return Conf::CONF_OK;
   }
 
+  Conf::ConfResult get(ResolveCb *&resolve_cb) const {
+    if (!rk_conf_)
+      return Conf::CONF_INVALID;
+    resolve_cb = this->resolve_cb_;
+    return Conf::CONF_OK;
+  }
+
   Conf::ConfResult get(OpenCb *&open_cb) const {
     if (!rk_conf_)
       return Conf::CONF_INVALID;
@@ -995,6 +1025,7 @@ class ConfImpl : public Conf {
   DeliveryReportCb *dr_cb_;
   EventCb *event_cb_;
   SocketCb *socket_cb_;
+  ResolveCb *resolve_cb_;
   OpenCb *open_cb_;
   PartitionerCb *partitioner_cb_;
   PartitionerKeyPointerCb *partitioner_kp_cb_;
@@ -1187,6 +1218,7 @@ class HandleImpl : virtual public Handle {
   ConsumeCb *consume_cb_;
   EventCb *event_cb_;
   SocketCb *socket_cb_;
+  ResolveCb *resolve_cb_;
   OpenCb *open_cb_;
   DeliveryReportCb *dr_cb_;
   PartitionerCb *partitioner_cb_;

--- a/tests/0150-test_resolve_connect_callbacks.cpp
+++ b/tests/0150-test_resolve_connect_callbacks.cpp
@@ -1,0 +1,126 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2019-2022, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include "testcpp.h"
+
+
+class testResolveCb : public RdKafka::ResolveCb {
+ public:
+  int resolve_cb(const char *node,
+                 const char *service,
+                 const struct addrinfo *hints,
+                 struct addrinfo **res) {
+    Test::Say("Invoked testResolveCb callback");
+
+    // If node and service are null, free the resources pointed to by res.
+    if ((!node && !service) && *res) {
+      delete (*res);
+      return 0;
+    }
+
+    TEST_ASSERT(strcmp("not.a.real.dns.name", node) == 0,
+                "resolver received an unexpected hostname: %s", node);
+
+    TEST_ASSERT(strcmp("9092", service) == 0,
+                "resolver received an unexpected port: %s", service);
+
+    // Construct a valid resolver response pointing to a bogus endpoint.
+    sockaddr_in *addr     = new sockaddr_in;
+    addr->sin_family      = AF_INET;
+    addr->sin_port        = htons(1234);
+    addr->sin_addr.s_addr = htonl(0x7f010203);  // 127.1.2.3
+
+    addrinfo *endpoint    = new addrinfo;
+    endpoint->ai_family   = AF_INET;
+    endpoint->ai_socktype = SOCK_STREAM;
+    endpoint->ai_protocol = IPPROTO_TCP;
+    endpoint->ai_addrlen  = sizeof(addr);
+    endpoint->ai_next     = nullptr;
+    endpoint->ai_addr     = reinterpret_cast<sockaddr *>(addr);
+
+    *res = endpoint;
+
+    return 0;
+  }
+};
+
+
+class testConnectCb : public RdKafka::ConnectCb {
+ public:
+  int connect_cb(int sockfd,
+                 const struct sockaddr *addr,
+                 int addrlen,
+                 const char *id) {
+    Test::Say("Invoked testConnectCb callback");
+
+    const struct sockaddr_in *addr_in = reinterpret_cast<const sockaddr_in *>(
+        reinterpret_cast<const void *>(addr));
+
+    // These assertions ensure we've received the expected resolver response.
+    TEST_ASSERT(addr_in->sin_addr.s_addr == htonl(0x7f010203),
+                "address has unexpected host: 0x%x",
+                ntohl(addr_in->sin_addr.s_addr));
+
+    TEST_ASSERT(addr_in->sin_port == htons(1234),
+                "address has unexpected port: %d", ntohs(addr_in->sin_port));
+
+    // Indicate a failure to connect, as we've already passed at this point.
+    return -1;
+  }
+};
+
+
+extern "C" {
+int main_0150_test_resolve_connect_callbacks(int argc, char **argv) {
+  RdKafka::Conf *conf;
+  std::string errstr;
+
+  Test::conf_init(&conf, NULL, 20);
+  /* Pass in an invalid broken name, as it will be unused */
+  Test::conf_set(conf, "bootstrap.servers", "not.a.real.dns.name");
+
+  testResolveCb pResolve = testResolveCb();
+  testConnectCb pConnect = testConnectCb();
+
+  if (conf->set("resolve_cb", &pResolve, errstr) != RdKafka::Conf::CONF_OK)
+    Test::Fail(errstr);
+  if (conf->set("connect_cb", &pConnect, errstr) != RdKafka::Conf::CONF_OK)
+    Test::Fail(errstr);
+
+  Test::Say("Test Producer Connection\n");
+
+  RdKafka::Producer *p = RdKafka::Producer::create(conf, errstr);
+  if (!p)
+    Test::Fail("Failed to create Producer: " + errstr);
+
+  delete p;
+
+  return 0;
+}
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -257,6 +257,7 @@ _TEST_DECL(0140_commit_metadata);
 _TEST_DECL(0142_reauthentication);
 _TEST_DECL(0143_exponential_backoff_mock);
 _TEST_DECL(0144_idempotence_mock);
+_TEST_DECL(0150_test_resolve_connect_callbacks);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -511,7 +512,7 @@ struct test tests[] = {
     _TEST(0142_reauthentication, 0, TEST_BRKVER(2, 2, 0, 0)),
     _TEST(0143_exponential_backoff_mock, TEST_F_LOCAL),
     _TEST(0144_idempotence_mock, TEST_F_LOCAL, TEST_BRKVER(0, 11, 0, 0)),
-
+    _TEST(0150_test_resolve_connect_callbacks, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),


### PR DESCRIPTION
This pull request adds C++ bindings to the existing "resolve_cb" and "connect_cb" callbacks provided in librdkafka.  We found use for these to hook the resolver calls for transparent proxy redirection, but using the C bindings directly in C++ alongside the existing C++ client doesn't expose the opaque pointer.

I also added a new set of tests (0150-test_resolve_connect_callbacks), which tests both the resolve and connect callbacks in a way similar to the existing C tests.

Thanks!
-Erik