### PR TITLE
remove useless const modifier

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -8221,7 +8221,7 @@ const rd_kafka_TopicPartitionInfo_t **rd_kafka_TopicDescription_partitions(
  * @return The partition id.
  */
 RD_EXPORT
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition);
 
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -8521,7 +8521,7 @@ static void rd_kafka_TopicDescription_free(void *ptr) {
         rd_kafka_TopicDescription_destroy(ptr);
 }
 
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition) {
         return partition->partition;
 }


### PR DESCRIPTION
The 'const' modifier in these functions serves no purpose. However, it will cause GCC or Clang to generate a warning in a file where rdkafka.h is included, which will result in a compilation failure if -Werror is enabled .