### PR TITLE
Bump openssl version partially to 3.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# librdkafka v2.4.0
+# librdkafka v2.3.1
 
 librdkafka v2.3.1 is a feature release:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# librdkafka v2.4.0
+
+librdkafka v2.3.0 is a feature release:
+
+ * Upgrade OpenSSL to v3.0.12 (while building from source) with various security fixes,
+   check the [release notes](https://www.openssl.org/news/cl30.txt).
+
+
 # librdkafka v2.3.0
 
 librdkafka v2.3.0 is a feature release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # librdkafka v2.4.0
 
-librdkafka v2.3.0 is a feature release:
+librdkafka v2.3.1 is a feature release:
 
  * Upgrade OpenSSL to v3.0.12 (while building from source) with various security fixes,
    check the [release notes](https://www.openssl.org/news/cl30.txt).

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -91,8 +91,8 @@ function manual_checks {
 function libcrypto_install_source {
     local name=$1
     local destdir=$2
-    local ver=3.0.11
-    local checksum="b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55"
+    local ver=3.0.12
+    local checksum="f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61"
     local url=https://www.openssl.org/source/openssl-${ver}.tar.gz
 
     local conf_args="--prefix=/usr --openssldir=/usr/lib/ssl no-shared no-zlib"


### PR DESCRIPTION
We will stick to 3.0.x with this PR (LTS version)

vcpkg doesn't yet have anything greater than 3.0.8, so this is only a partial upgrade.