### PR TITLE
Handle Integer Overflow

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2854,7 +2854,7 @@ void rd_kafka_broker_buf_retry(rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
         /* In some cases, failed Produce requests do not increment the retry
          * count, see rd_kafka_handle_Produce_error. */
         if (rkbuf->rkbuf_retries > 0)
-                backoff = (1 << (rkbuf->rkbuf_retries - 1)) *
+                backoff = ((int64_t)1 << (rkbuf->rkbuf_retries - 1)) *
                           (rkb->rkb_rk->rk_conf.retry_backoff_ms);
         else
                 backoff = rkb->rkb_rk->rk_conf.retry_backoff_ms;


### PR DESCRIPTION
In this PR, the cast to int64_t ensures that the left shift operation is performed using 64-bit arithmetic, and the result will not overflow even if rkbuf_retries is equal to INT_MAX. The resulting value of the left shift operation is then multiplied by retry_backoff_ms, which is an int value. The result of the multiplication will be an int64_t value, which can hold the product of the two operands without overflow.

**More details here:** https://confluentinc.atlassian.net/browse/ASA-954