### PR TITLE
[WIP] Strip a trailing . when present in name - Address confluentinc/librdkafka#4348

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -468,7 +468,25 @@ static int rd_kafka_transport_ssl_set_endpoint_id(rd_kafka_transport_t *rktrans,
                 return 0;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(OPENSSL_IS_BORINGSSL)
-        if (!SSL_set1_host(rktrans->rktrans_ssl, name))
+        char *token, *hostname;
+        token = strtok(name, ":");
+        int ctr = 0;
+        while (token != NULL) {
+                if (ctr >= 2) {
+                        hostname = &name;
+                        break;
+                }
+                token = strtok(NULL, ":");
+                last_char = strlen(token) - 1
+                if (last_char > 0 && token[last_char] == '.') {
+                        token[last_char] = '\0';
+                        hostname = strncat(hostname, token, last_char);
+                } else {
+                        hostname = strncat(hostname, token, strlen(token));
+                }
+                ctr += 1;
+        }
+        if (!SSL_set1_host(rktrans->rktrans_ssl, hostname))
                 goto fail;
 #elif OPENSSL_VERSION_NUMBER >= 0x1000200fL /* 1.0.2 */
         {


### PR DESCRIPTION
This is a very poor attempt at addressing the issue mentioned here: https://github.com/confluentinc/librdkafka/issues/4348, which is caused by https://github.com/openssl/openssl/issues/11560#issuecomment-1619143823 

If this is the wrong place to be attempting to address the issue, I would love guidance on how to properly tackle the problem. I don't use librdkafka directly, but rely on a ruby wrapping library. ([karafka](https://github.com/karafka/karafka)).

What I'm attempting here is to transform
`my.kafka.domain.com.:9093` -> `my.kafka.domain.com:9093` 
by splitting on ":" and replacing trailing "." with "\0"