### PR TITLE
Add documentation for disabling nagle for socket to review for reduci…

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -183,6 +183,7 @@ Setting `linger.ms` to 0 or 0.1 will make sure messages are sent as
 soon as possible.
 Lower buffering time leads to smaller batches and larger per-message overheads,
 increasing network, memory and CPU usage for producers, brokers and consumers.
+Also review socket settings - setting `socket.nagle.disable` can reduce RTT.
 
 See [How to decrease message latency](https://github.com/confluentinc/librdkafka/wiki/How-to-decrease-message-latency) for more info.
 


### PR DESCRIPTION
Add a quick note for disabling Nagle for socket to reduce overall latency.
For us this reduced broker RTT from 40ms to around 6ms