### PR TITLE
Metadata cache by topic id and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ librdkafka v2.3.1 is a maintenance release:
  * Fix pipeline inclusion of static binaries (#4666)
  * Fix to main loop timeout calculation leading to a tight loop for a
    max period of 1 ms (#4671).
+ * [KIP-516](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers)
+   Continue partial implementation by adding a metadata cache by topic id
+   and updating the topic id corresponding to the partition name (#4660)
+ * Fixes to metadata cache expiration, metadata refresh interruption and
+   to avoid usage of stale metadata (#4660).
 
 
 ## Fixes
@@ -26,6 +31,21 @@ librdkafka v2.3.1 is a maintenance release:
    before the expiration of a timeout, it was serving with a zero timeout,
    leading to increased CPU usage until the timeout was reached.
    Happening since 1.x (#4671).
+ * Metadata cache was cleared on full metadata refresh, leading to unnecessary
+   refreshes and occasional `UNKNOWN_TOPIC_OR_PART` errors. Solved by updating
+   cache for existing or hinted entries instead of clearing them.
+   Happening since 2.1.0 (#4660).
+ * A metadata call before member joins consumer group,
+   could lead to an `UNKNOWN_TOPIC_OR_PART` error. Solved by updating
+   the consumer group following a metadata refresh only in safe states.
+   Happening since 2.1.0 (#4660).
+ * Metadata refreshes without partition leader change could lead to a loop of
+   metadata calls at fixed intervals. Solved by stopping metadata refresh when
+   all existing metadata is non-stale. Happening since 2.3.0 (#4660).
+ * A partition migration could happen, using stale metadata, when the partition
+   was undergoing a validation and being retried because of an error.
+   Solved by doing a partition migration only with a non-stale leader epoch.
+   Happening since 2.1.0 (#4660).
 
 
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -1507,7 +1507,7 @@ rd_kafka_admin_MetadataRequest(rd_kafka_broker_t *rkb,
                                rd_kafka_replyq_t replyq,
                                void *opaque) {
         return rd_kafka_MetadataRequest_resp_cb(
-            rkb, topics, reason,
+            rkb, topics, NULL, reason,
             rd_false /* No admin operation requires topic creation. */,
             include_cluster_authorized_operations,
             include_topic_authorized_operations,

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -474,12 +474,14 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         rd_kafka_metadata_internal_t *mdi = NULL;
         rd_kafka_metadata_t *md           = NULL;
         size_t rkb_namelen;
-        const int log_decode_errors = LOG_ERR;
-        rd_list_t *missing_topics   = NULL;
+        const int log_decode_errors  = LOG_ERR;
+        rd_list_t *missing_topics    = NULL;
+        rd_list_t *missing_topic_ids = NULL;
 
-        const rd_list_t *requested_topics = request_topics;
-        rd_bool_t all_topics              = rd_false;
-        rd_bool_t cgrp_update             = rd_false;
+        const rd_list_t *requested_topics    = request_topics;
+        const rd_list_t *requested_topic_ids = NULL;
+        rd_bool_t all_topics                 = rd_false;
+        rd_bool_t cgrp_update                = rd_false;
         rd_bool_t has_reliable_leader_epochs =
             rd_kafka_has_reliable_leader_epochs(rkb);
         int ApiVersion             = rkbuf->rkbuf_reqhdr.ApiVersion;
@@ -488,7 +490,7 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         rd_kafka_resp_err_t err    = RD_KAFKA_RESP_ERR_NO_ERROR;
         int broker_changes         = 0;
         int cache_changes          = 0;
-        rd_ts_t ts_start           = rd_clock();
+
         /* If client rack is present, the metadata cache (topic or full) needs
          * to contain the partition to rack map. */
         rd_bool_t has_client_rack = rk->rk_conf.client_rack &&
@@ -496,8 +498,9 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         rd_bool_t compute_racks = has_client_rack;
 
         if (request) {
-                requested_topics = request->rkbuf_u.Metadata.topics;
-                all_topics       = request->rkbuf_u.Metadata.all_topics;
+                requested_topics    = request->rkbuf_u.Metadata.topics;
+                requested_topic_ids = request->rkbuf_u.Metadata.topic_ids;
+                all_topics          = request->rkbuf_u.Metadata.all_topics;
                 cgrp_update =
                     request->rkbuf_u.Metadata.cgrp_update && rk->rk_cgrp;
                 compute_racks |= request->rkbuf_u.Metadata.force_racks;
@@ -519,6 +522,9 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         if (requested_topics)
                 missing_topics =
                     rd_list_copy(requested_topics, rd_list_string_copy, NULL);
+        if (requested_topic_ids)
+                missing_topic_ids =
+                    rd_list_copy(requested_topic_ids, rd_list_Uuid_copy, NULL);
 
         rd_kafka_broker_lock(rkb);
         rkb_namelen = strlen(rkb->rkb_name) + 1;
@@ -833,34 +839,37 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                 rd_kafka_parse_Metadata_update_topic(rkb, &md->topics[i],
                                                      &mdi->topics[i]);
 
-                // TODO: Should be done for requested_topic_ids as well.
-                if (requested_topics) {
+                if (requested_topics)
                         rd_list_free_cb(missing_topics,
                                         rd_list_remove_cmp(missing_topics,
                                                            md->topics[i].topic,
                                                            (void *)strcmp));
-                        if (!all_topics) {
-                                /* Only update cache when not asking
-                                 * for all topics. */
-
-                                rd_kafka_wrlock(rk);
-                                rd_kafka_metadata_cache_topic_update(
-                                    rk, &md->topics[i], &mdi->topics[i],
-                                    rd_false /*propagate later*/,
-                                    /* use has_client_rack rather than
-                                       compute_racks. We need cached rack ids
-                                       only in case we need to rejoin the group
-                                       if they change and client.rack is set
-                                       (KIP-881). */
-                                    has_client_rack, mdi->brokers,
-                                    md->broker_cnt);
-                                cache_changes++;
-                                rd_kafka_wrunlock(rk);
-                        }
-                }
+                if (requested_topic_ids)
+                        rd_list_free_cb(
+                            missing_topic_ids,
+                            rd_list_remove_cmp(missing_topic_ids,
+                                               &mdi->topics[i].topic_id,
+                                               (void *)rd_kafka_Uuid_ptr_cmp));
+                /* Only update cache when not asking
+                 * for all topics or cache entry
+                 * already exists. */
+                rd_kafka_wrlock(rk);
+                cache_changes +=
+                rd_kafka_metadata_cache_topic_update(
+                        rk, &md->topics[i], &mdi->topics[i],
+                        rd_false /*propagate later*/,
+                        /* use has_client_rack rather than
+                        compute_racks. We need cached rack ids
+                        only in case we need to rejoin the group
+                        if they change and client.rack is set
+                        (KIP-881). */
+                        has_client_rack, mdi->brokers,
+                        md->broker_cnt,
+                        all_topics /*cache entry needs to exist
+                                    *if all_topics*/);
+                rd_kafka_wrunlock(rk);
         }
 
-        // TODO: Should be done for missing_topic_ids as well.
         /* Requested topics not seen in metadata? Propogate to topic code. */
         if (missing_topics) {
                 char *topic;
@@ -877,6 +886,41 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
 
                         rkt =
                             rd_kafka_topic_find(rkb->rkb_rk, topic, 1 /*lock*/);
+                        if (rkt) {
+                                /* Received metadata response contained no
+                                 * information about topic 'rkt' and thus
+                                 * indicates the topic is not available in the
+                                 *  cluster.
+                                 * Mark the topic as non-existent */
+                                rd_kafka_topic_wrlock(rkt);
+                                rd_kafka_topic_set_notexists(
+                                    rkt, RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC);
+                                rd_kafka_topic_wrunlock(rkt);
+
+                                rd_kafka_topic_destroy0(rkt);
+                        }
+                }
+        }
+        if (missing_topic_ids) {
+                rd_kafka_Uuid_t *topic_id;
+                rd_rkb_dbg(rkb, TOPIC, "METADATA",
+                           "%d/%d requested topic(s) seen in metadata",
+                           rd_list_cnt(requested_topic_ids) -
+                               rd_list_cnt(missing_topic_ids),
+                           rd_list_cnt(requested_topic_ids));
+                for (i = 0; i < rd_list_cnt(missing_topic_ids); i++) {
+                        rd_kafka_Uuid_t *missing_topic_id =
+                            missing_topic_ids->rl_elems[i];
+                        rd_rkb_dbg(rkb, TOPIC, "METADATA", "wanted %s",
+                                   rd_kafka_Uuid_base64str(missing_topic_id));
+                }
+                RD_LIST_FOREACH(topic_id, missing_topic_ids, i) {
+                        rd_kafka_topic_t *rkt;
+
+                        rd_kafka_rdlock(rk);
+                        rkt = rd_kafka_topic_find_by_topic_id(rkb->rkb_rk,
+                                                              *topic_id);
+                        rd_kafka_rdunlock(rk);
                         if (rkt) {
                                 /* Received metadata response contained no
                                  * information about topic 'rkt' and thus
@@ -934,9 +978,10 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         }
 
         if (all_topics) {
-                /* Expire all cache entries that were not updated. */
-                rd_kafka_metadata_cache_evict_by_age(rkb->rkb_rk, ts_start);
-
+                /* All hints have been replaced by the corresponding entry.
+                 * Rest of hints can be removed as topics aren't present
+                 * in full metadata. */
+                rd_kafka_metadata_cache_purge_all_hints(rkb->rkb_rk);
                 if (rkb->rkb_rk->rk_full_metadata)
                         rd_kafka_metadata_destroy(
                             &rkb->rkb_rk->rk_full_metadata->metadata);
@@ -956,17 +1001,17 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                            "Caching full metadata with "
                            "%d broker(s) and %d topic(s): %s",
                            md->broker_cnt, md->topic_cnt, reason);
-        } else {
-                if (cache_changes)
-                        rd_kafka_metadata_cache_propagate_changes(rk);
-                rd_kafka_metadata_cache_expiry_start(rk);
         }
-
-
-        // TODO: Should be done for requested_topic_ids as well.
         /* Remove cache hints for the originally requested topics. */
         if (requested_topics)
                 rd_kafka_metadata_cache_purge_hints(rk, requested_topics);
+        if (requested_topic_ids)
+                rd_kafka_metadata_cache_purge_hints(rk, requested_topic_ids);
+
+        if (cache_changes) {
+                rd_kafka_metadata_cache_propagate_changes(rk);
+                rd_kafka_metadata_cache_expiry_start(rk);
+        }
 
         rd_kafka_wrunlock(rkb->rkb_rk);
 
@@ -982,7 +1027,8 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
          * which may contain only a sub-set of the subscribed topics (namely
          * the effective subscription of available topics) as to not
          * propagate non-included topics as non-existent. */
-        if (cgrp_update && (requested_topics || all_topics))
+        if (cgrp_update &&
+            (requested_topics || requested_topic_ids || all_topics))
                 rd_kafka_cgrp_metadata_update_check(rkb->rkb_rk->rk_cgrp,
                                                     rd_true /*do join*/);
 
@@ -995,10 +1041,10 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         }
 
 done:
-
-        // TODO: Should be done for requested_topic_ids as well.
         if (missing_topics)
                 rd_list_destroy(missing_topics);
+        if (missing_topic_ids)
+                rd_list_destroy(missing_topic_ids);
 
         /* This metadata request was triggered by someone wanting
          * the metadata information back as a reply, so send that reply now.
@@ -1013,7 +1059,6 @@ done:
 err_parse:
         err = rkbuf->rkbuf_err;
 err:
-        // TODO: Should be done for requested_topic_ids as well.
         if (requested_topics) {
                 /* Failed requests shall purge cache hints for
                  * the requested topics. */
@@ -1021,10 +1066,19 @@ err:
                 rd_kafka_metadata_cache_purge_hints(rk, requested_topics);
                 rd_kafka_wrunlock(rkb->rkb_rk);
         }
+        if (requested_topic_ids) {
+                /* Failed requests shall purge cache hints for
+                 * the requested topics. */
+                rd_kafka_wrlock(rkb->rkb_rk);
+                rd_kafka_metadata_cache_purge_hints_by_id(rk,
+                                                          requested_topic_ids);
+                rd_kafka_wrunlock(rkb->rkb_rk);
+        }
 
-        // TODO: Should be done for requested_topic_ids as well.
         if (missing_topics)
                 rd_list_destroy(missing_topics);
+        if (missing_topic_ids)
+                rd_list_destroy(missing_topic_ids);
         rd_tmpabuf_destroy(&tbuf);
 
         return err;

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -874,7 +874,8 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         if (missing_topics) {
                 char *topic;
                 rd_rkb_dbg(rkb, TOPIC, "METADATA",
-                           "%d/%d requested topic(s) seen in metadata",
+                           "%d/%d requested topic(s) seen in metadata"
+                           " (lookup by name)",
                            rd_list_cnt(requested_topics) -
                                rd_list_cnt(missing_topics),
                            rd_list_cnt(requested_topics));
@@ -904,7 +905,8 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         if (missing_topic_ids) {
                 rd_kafka_Uuid_t *topic_id;
                 rd_rkb_dbg(rkb, TOPIC, "METADATA",
-                           "%d/%d requested topic(s) seen in metadata",
+                           "%d/%d requested topic(s) seen in metadata"
+                           " (lookup by id)",
                            rd_list_cnt(requested_topic_ids) -
                                rd_list_cnt(missing_topic_ids),
                            rd_list_cnt(requested_topic_ids));
@@ -1006,7 +1008,8 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         if (requested_topics)
                 rd_kafka_metadata_cache_purge_hints(rk, requested_topics);
         if (requested_topic_ids)
-                rd_kafka_metadata_cache_purge_hints(rk, requested_topic_ids);
+                rd_kafka_metadata_cache_purge_hints_by_id(rk,
+                                                          requested_topic_ids);
 
         if (cache_changes) {
                 rd_kafka_metadata_cache_propagate_changes(rk);

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -635,6 +635,8 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
 
                 if (ApiVersion >= 10) {
                         rd_kafka_buf_read_uuid(rkbuf, &mdi->topics[i].topic_id);
+                } else {
+                        mdi->topics[i].topic_id = RD_KAFKA_UUID_ZERO;
                 }
 
                 if (ApiVersion >= 1)

--- a/src/rdkafka_metadata.h
+++ b/src/rdkafka_metadata.h
@@ -271,6 +271,8 @@ struct rd_kafka_metadata_cache {
 
 
 int rd_kafka_metadata_cache_delete_by_name(rd_kafka_t *rk, const char *topic);
+int rd_kafka_metadata_cache_delete_by_topic_id(rd_kafka_t *rk,
+                                               const rd_kafka_Uuid_t topic_id);
 void rd_kafka_metadata_cache_expiry_start(rd_kafka_t *rk);
 int rd_kafka_metadata_cache_purge_all_hints(rd_kafka_t *rk);
 int rd_kafka_metadata_cache_topic_update(

--- a/src/rdkafka_metadata.h
+++ b/src/rdkafka_metadata.h
@@ -219,7 +219,8 @@ rd_kafka_metadata_new_topic_with_partition_replicas_mock(int replication_factor,
  */
 
 struct rd_kafka_metadata_cache_entry {
-        rd_avl_node_t rkmce_avlnode;                           /* rkmc_avl */
+        rd_avl_node_t rkmce_avlnode;       /* rkmc_avl */
+        rd_avl_node_t rkmce_avlnode_by_id; /* rkmc_avl_by_id */
         TAILQ_ENTRY(rd_kafka_metadata_cache_entry) rkmce_link; /* rkmc_expiry */
         rd_ts_t rkmce_ts_expires;                              /* Expire time */
         rd_ts_t rkmce_ts_insert;                               /* Insert time */
@@ -243,6 +244,7 @@ struct rd_kafka_metadata_cache_entry {
 
 struct rd_kafka_metadata_cache {
         rd_avl_t rkmc_avl;
+        rd_avl_t rkmc_avl_by_id;
         TAILQ_HEAD(, rd_kafka_metadata_cache_entry) rkmc_expiry;
         rd_kafka_timer_t rkmc_expiry_tmr;
         int rkmc_cnt;
@@ -270,20 +272,27 @@ struct rd_kafka_metadata_cache {
 
 int rd_kafka_metadata_cache_delete_by_name(rd_kafka_t *rk, const char *topic);
 void rd_kafka_metadata_cache_expiry_start(rd_kafka_t *rk);
-int rd_kafka_metadata_cache_evict_by_age(rd_kafka_t *rk, rd_ts_t ts);
-void rd_kafka_metadata_cache_topic_update(
+int rd_kafka_metadata_cache_purge_all_hints(rd_kafka_t *rk);
+int rd_kafka_metadata_cache_topic_update(
     rd_kafka_t *rk,
-    const rd_kafka_metadata_topic_t *mdt,
+    rd_kafka_metadata_topic_t *mdt,
     const rd_kafka_metadata_topic_internal_t *mdit,
     rd_bool_t propagate,
     rd_bool_t include_metadata,
     rd_kafka_metadata_broker_internal_t *brokers,
-    size_t broker_cnt);
+    size_t broker_cnt,
+    rd_bool_t only_existing);
 void rd_kafka_metadata_cache_propagate_changes(rd_kafka_t *rk);
 struct rd_kafka_metadata_cache_entry *
 rd_kafka_metadata_cache_find(rd_kafka_t *rk, const char *topic, int valid);
+struct rd_kafka_metadata_cache_entry *
+rd_kafka_metadata_cache_find_by_id(rd_kafka_t *rk,
+                                   const rd_kafka_Uuid_t,
+                                   int valid);
 void rd_kafka_metadata_cache_purge_hints(rd_kafka_t *rk,
                                          const rd_list_t *topics);
+void rd_kafka_metadata_cache_purge_hints_by_id(rd_kafka_t *rk,
+                                               const rd_list_t *topics);
 int rd_kafka_metadata_cache_hint(rd_kafka_t *rk,
                                  const rd_list_t *topics,
                                  rd_list_t *dst,

--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -80,8 +80,14 @@ static RD_INLINE void
 rd_kafka_metadata_cache_delete(rd_kafka_t *rk,
                                struct rd_kafka_metadata_cache_entry *rkmce,
                                int unlink_avl) {
-        if (unlink_avl)
+        if (unlink_avl) {
                 RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl, rkmce);
+                if (!RD_KAFKA_UUID_IS_ZERO(
+                        rkmce->rkmce_metadata_internal_topic.topic_id)) {
+                        RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl_by_id,
+                                          rkmce);
+                }
+        }
         TAILQ_REMOVE(&rk->rk_metadata_cache.rkmc_expiry, rkmce, rkmce_link);
         rd_kafka_assert(NULL, rk->rk_metadata_cache.rkmc_cnt > 0);
         rk->rk_metadata_cache.rkmc_cnt--;
@@ -161,44 +167,26 @@ static int rd_kafka_metadata_cache_evict(rd_kafka_t *rk) {
 
 
 /**
- * @brief Evict timed out entries from cache based on their insert/update time
- *        rather than expiry time. Any entries older than \p ts will be evicted.
+ * @brief Remove all cache hints,.
+ *        This is done when the Metadata response has been parsed and
+ *        replaced hints with existing topic information, thus this will
+ *        only remove unmatched topics from the cache.
  *
- * @returns the number of entries evicted.
+ * @returns the number of purged hints
  *
  * @locks_required rd_kafka_wrlock()
  */
-int rd_kafka_metadata_cache_evict_by_age(rd_kafka_t *rk, rd_ts_t ts) {
+int rd_kafka_metadata_cache_purge_all_hints(rd_kafka_t *rk) {
         int cnt = 0;
         struct rd_kafka_metadata_cache_entry *rkmce, *tmp;
 
         TAILQ_FOREACH_SAFE(rkmce, &rk->rk_metadata_cache.rkmc_expiry,
                            rkmce_link, tmp) {
-                if (rkmce->rkmce_ts_insert <= ts) {
+                if (!RD_KAFKA_METADATA_CACHE_VALID(rkmce)) {
                         rd_kafka_metadata_cache_delete(rk, rkmce, 1);
                         cnt++;
                 }
         }
-
-        /* Update expiry timer */
-        rkmce = TAILQ_FIRST(&rk->rk_metadata_cache.rkmc_expiry);
-        if (rkmce)
-                rd_kafka_timer_start(&rk->rk_timers,
-                                     &rk->rk_metadata_cache.rkmc_expiry_tmr,
-                                     rkmce->rkmce_ts_expires - rd_clock(),
-                                     rd_kafka_metadata_cache_evict_tmr_cb, rk);
-        else
-                rd_kafka_timer_stop(&rk->rk_timers,
-                                    &rk->rk_metadata_cache.rkmc_expiry_tmr, 1);
-
-        rd_kafka_dbg(rk, METADATA, "METADATA",
-                     "Expired %d entries older than %dms from metadata cache "
-                     "(%d entries remain)",
-                     cnt, (int)((rd_clock() - ts) / 1000),
-                     rk->rk_metadata_cache.rkmc_cnt);
-
-        if (cnt)
-                rd_kafka_metadata_cache_propagate_changes(rk);
 
         return cnt;
 }
@@ -216,6 +204,25 @@ rd_kafka_metadata_cache_find(rd_kafka_t *rk, const char *topic, int valid) {
         struct rd_kafka_metadata_cache_entry skel, *rkmce;
         skel.rkmce_mtopic.topic = (char *)topic;
         rkmce = RD_AVL_FIND(&rk->rk_metadata_cache.rkmc_avl, &skel);
+        if (rkmce && (!valid || RD_KAFKA_METADATA_CACHE_VALID(rkmce)))
+                return rkmce;
+        return NULL;
+}
+
+/**
+ * @brief Find cache entry by topic id
+ *
+ * @param valid: entry must be valid (not hint)
+ *
+ * @locks rd_kafka_*lock()
+ */
+struct rd_kafka_metadata_cache_entry *
+rd_kafka_metadata_cache_find_by_id(rd_kafka_t *rk,
+                                   const rd_kafka_Uuid_t topic_id,
+                                   int valid) {
+        struct rd_kafka_metadata_cache_entry skel, *rkmce;
+        skel.rkmce_metadata_internal_topic.topic_id = topic_id;
+        rkmce = RD_AVL_FIND(&rk->rk_metadata_cache.rkmc_avl_by_id, &skel);
         if (rkmce && (!valid || RD_KAFKA_METADATA_CACHE_VALID(rkmce)))
                 return rkmce;
         return NULL;
@@ -247,7 +254,7 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
     rd_bool_t include_racks,
     rd_kafka_metadata_broker_internal_t *brokers_internal,
     size_t broker_cnt) {
-        struct rd_kafka_metadata_cache_entry *rkmce, *old;
+        struct rd_kafka_metadata_cache_entry *rkmce, *old, *old_by_id = NULL;
         rd_tmpabuf_t tbuf;
         int i;
 
@@ -350,8 +357,28 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
         /* Insert (and replace existing) entry. */
         old = RD_AVL_INSERT(&rk->rk_metadata_cache.rkmc_avl, rkmce,
                             rkmce_avlnode);
-        if (old)
+        /* Insert (and replace existing) entry into the AVL tree sorted
+         * by topic id. */
+        if (!RD_KAFKA_UUID_IS_ZERO(
+                rkmce->rkmce_metadata_internal_topic.topic_id)) {
+                /* If topic id isn't zero insert cache entry into this tree */
+                old_by_id = RD_AVL_INSERT(&rk->rk_metadata_cache.rkmc_avl_by_id,
+                                          rkmce, rkmce_avlnode_by_id);
+        } else if (old && !RD_KAFKA_UUID_IS_ZERO(
+                              old->rkmce_metadata_internal_topic.topic_id)) {
+                /* If it had a topic id, remove it from the tree */
+                RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl_by_id, old);
+        }
+        if (old) {
+                /* Delete and free old cache entry */
                 rd_kafka_metadata_cache_delete(rk, old, 0);
+        }
+        if (old_by_id && old_by_id != old) {
+                /* If there was a different cache entry in this tree,
+                 * remove and free it. */
+                RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl, old_by_id);
+                rd_kafka_metadata_cache_delete(rk, old_by_id, 0);
+        }
 
         /* Explicitly not freeing the tmpabuf since rkmce points to its
          * memory. */
@@ -414,22 +441,41 @@ void rd_kafka_metadata_cache_expiry_start(rd_kafka_t *rk) {
  * For permanent errors (authorization failures), we keep
  * the entry cached for metadata.max.age.ms.
  *
+ * @return 1 on metadata change, 0 when no change was applied
+ *
  * @remark The cache expiry timer will not be updated/started,
  *         call rd_kafka_metadata_cache_expiry_start() instead.
  *
  * @locks rd_kafka_wrlock()
  */
-void rd_kafka_metadata_cache_topic_update(
+int rd_kafka_metadata_cache_topic_update(
     rd_kafka_t *rk,
-    const rd_kafka_metadata_topic_t *mdt,
+    rd_kafka_metadata_topic_t *mdt,
     const rd_kafka_metadata_topic_internal_t *mdit,
     rd_bool_t propagate,
     rd_bool_t include_racks,
     rd_kafka_metadata_broker_internal_t *brokers,
-    size_t broker_cnt) {
-        rd_ts_t now        = rd_clock();
+    size_t broker_cnt,
+    rd_bool_t only_existing) {
+        struct rd_kafka_metadata_cache_entry *rkmce = NULL;
+        rd_ts_t now                                 = rd_clock();
         rd_ts_t ts_expires = now + (rk->rk_conf.metadata_max_age_ms * 1000);
         int changed        = 1;
+        if (!mdt->topic) {
+                rkmce =
+                    rd_kafka_metadata_cache_find_by_id(rk, mdit->topic_id, 1);
+                if (!rkmce)
+                        return 0;
+
+                /* Borrowed pointer from rkmce tmpabuf */
+                mdt->topic = rkmce->rkmce_mtopic.topic;
+        }
+        if (unlikely(mdt->topic && !rkmce && only_existing)) {
+                rkmce = rd_kafka_metadata_cache_find(rk, mdt->topic, 0);
+        }
+        if (unlikely(!mdt->topic || (only_existing && !rkmce))) {
+                return 0;
+        }
 
         /* Cache unknown topics for a short while (100ms) to allow the cgrp
          * logic to find negative cache hits. */
@@ -448,6 +494,8 @@ void rd_kafka_metadata_cache_topic_update(
 
         if (changed && propagate)
                 rd_kafka_metadata_cache_propagate_changes(rk);
+
+        return changed;
 }
 
 
@@ -481,6 +529,40 @@ void rd_kafka_metadata_cache_purge_hints(rd_kafka_t *rk,
                 rd_kafka_dbg(rk, METADATA, "METADATA",
                              "Purged %d/%d cached topic hint(s)", cnt,
                              rd_list_cnt(topics));
+                rd_kafka_metadata_cache_propagate_changes(rk);
+        }
+}
+
+/**
+ * @brief Remove cache hints for topic ids in \p topic_ids
+ *        This is done when the Metadata response has been parsed and
+ *        replaced hints with existing topic information, thus this will
+ *        only remove unmatched topics from the cache.
+ *
+ * @locks rd_kafka_wrlock()
+ */
+void rd_kafka_metadata_cache_purge_hints_by_id(rd_kafka_t *rk,
+                                               const rd_list_t *topic_ids) {
+        const rd_kafka_Uuid_t *topic_id;
+        int i;
+        int cnt = 0;
+
+        RD_LIST_FOREACH(topic_id, topic_ids, i) {
+                struct rd_kafka_metadata_cache_entry *rkmce;
+
+                if (!(rkmce = rd_kafka_metadata_cache_find_by_id(rk, *topic_id,
+                                                                 0 /*any*/)) ||
+                    RD_KAFKA_METADATA_CACHE_VALID(rkmce))
+                        continue;
+
+                rd_kafka_metadata_cache_delete(rk, rkmce, 1 /*unlink avl*/);
+                cnt++;
+        }
+
+        if (cnt > 0) {
+                rd_kafka_dbg(rk, METADATA, "METADATA",
+                             "Purged %d/%d cached topic hint(s)", cnt,
+                             rd_list_cnt(topic_ids));
                 rd_kafka_metadata_cache_propagate_changes(rk);
         }
 }
@@ -589,6 +671,16 @@ static int rd_kafka_metadata_cache_entry_cmp(const void *_a, const void *_b) {
         return strcmp(a->rkmce_mtopic.topic, b->rkmce_mtopic.topic);
 }
 
+/**
+ * @brief Cache entry comparator (on topic id)
+ */
+static int rd_kafka_metadata_cache_entry_by_id_cmp(const void *_a,
+                                                   const void *_b) {
+        const struct rd_kafka_metadata_cache_entry *a = _a, *b = _b;
+        return rd_kafka_Uuid_cmp(a->rkmce_metadata_internal_topic.topic_id,
+                                 b->rkmce_metadata_internal_topic.topic_id);
+}
+
 
 /**
  * @brief Initialize the metadata cache
@@ -598,6 +690,8 @@ static int rd_kafka_metadata_cache_entry_cmp(const void *_a, const void *_b) {
 void rd_kafka_metadata_cache_init(rd_kafka_t *rk) {
         rd_avl_init(&rk->rk_metadata_cache.rkmc_avl,
                     rd_kafka_metadata_cache_entry_cmp, 0);
+        rd_avl_init(&rk->rk_metadata_cache.rkmc_avl_by_id,
+                    rd_kafka_metadata_cache_entry_by_id_cmp, 0);
         TAILQ_INIT(&rk->rk_metadata_cache.rkmc_expiry);
         mtx_init(&rk->rk_metadata_cache.rkmc_full_lock, mtx_plain);
         mtx_init(&rk->rk_metadata_cache.rkmc_cnd_lock, mtx_plain);
@@ -620,6 +714,7 @@ void rd_kafka_metadata_cache_destroy(rd_kafka_t *rk) {
         mtx_destroy(&rk->rk_metadata_cache.rkmc_cnd_lock);
         cnd_destroy(&rk->rk_metadata_cache.rkmc_cnd);
         rd_avl_destroy(&rk->rk_metadata_cache.rkmc_avl);
+        rd_avl_destroy(&rk->rk_metadata_cache.rkmc_avl_by_id);
 }
 
 

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -469,7 +469,39 @@ rd_kafka_mock_partition_assign_replicas(rd_kafka_mock_partition_t *mpart,
             mpart, mpart->replicas[rd_jitter(0, replica_cnt - 1)]);
 }
 
+/**
+ * @brief Push a partition leader response to passed \p mpart .
+ */
+static void
+rd_kafka_mock_partition_push_leader_response0(rd_kafka_mock_partition_t *mpart,
+                                              int32_t leader_id,
+                                              int32_t leader_epoch) {
+        rd_kafka_mock_partition_leader_t *leader_response;
 
+        leader_response               = rd_calloc(1, sizeof(*leader_response));
+        leader_response->leader_id    = leader_id;
+        leader_response->leader_epoch = leader_epoch;
+        TAILQ_INSERT_TAIL(&mpart->leader_responses, leader_response, link);
+}
+
+/**
+ * @brief Return the first mocked partition leader response in \p mpart ,
+ *        if available.
+ */
+rd_kafka_mock_partition_leader_t *
+rd_kafka_mock_partition_next_leader_response(rd_kafka_mock_partition_t *mpart) {
+        return TAILQ_FIRST(&mpart->leader_responses);
+}
+
+/**
+ * @brief Unlink and destroy a partition leader response
+ */
+void rd_kafka_mock_partition_leader_destroy(
+    rd_kafka_mock_partition_t *mpart,
+    rd_kafka_mock_partition_leader_t *mpart_leader) {
+        TAILQ_REMOVE(&mpart->leader_responses, mpart_leader, link);
+        rd_free(mpart_leader);
+}
 
 /**
  * @brief Unlink and destroy committed offset
@@ -546,12 +578,17 @@ rd_kafka_mock_commit_offset(rd_kafka_mock_partition_t *mpart,
 static void rd_kafka_mock_partition_destroy(rd_kafka_mock_partition_t *mpart) {
         rd_kafka_mock_msgset_t *mset, *tmp;
         rd_kafka_mock_committed_offset_t *coff, *tmpcoff;
+        rd_kafka_mock_partition_leader_t *mpart_leader, *tmp_mpart_leader;
 
         TAILQ_FOREACH_SAFE(mset, &mpart->msgsets, link, tmp)
         rd_kafka_mock_msgset_destroy(mpart, mset);
 
         TAILQ_FOREACH_SAFE(coff, &mpart->committed_offsets, link, tmpcoff)
         rd_kafka_mock_committed_offset_destroy(mpart, coff);
+
+        TAILQ_FOREACH_SAFE(mpart_leader, &mpart->leader_responses, link,
+                           tmp_mpart_leader)
+        rd_kafka_mock_partition_leader_destroy(mpart, mpart_leader);
 
         rd_list_destroy(&mpart->pidstates);
 
@@ -579,6 +616,7 @@ static void rd_kafka_mock_partition_init(rd_kafka_mock_topic_t *mtopic,
         mpart->update_follower_end_offset   = rd_true;
 
         TAILQ_INIT(&mpart->committed_offsets);
+        TAILQ_INIT(&mpart->leader_responses);
 
         rd_list_init(&mpart->pidstates, 0, rd_free);
 
@@ -2097,6 +2135,23 @@ rd_kafka_mock_partition_set_follower_wmarks(rd_kafka_mock_cluster_t *mcluster,
 }
 
 rd_kafka_resp_err_t
+rd_kafka_mock_partition_push_leader_response(rd_kafka_mock_cluster_t *mcluster,
+                                             const char *topic,
+                                             int partition,
+                                             int32_t leader_id,
+                                             int32_t leader_epoch) {
+        rd_kafka_op_t *rko        = rd_kafka_op_new(RD_KAFKA_OP_MOCK);
+        rko->rko_u.mock.name      = rd_strdup(topic);
+        rko->rko_u.mock.cmd       = RD_KAFKA_MOCK_CMD_PART_PUSH_LEADER_RESPONSE;
+        rko->rko_u.mock.partition = partition;
+        rko->rko_u.mock.leader_id = leader_id;
+        rko->rko_u.mock.leader_epoch = leader_epoch;
+
+        return rd_kafka_op_err_destroy(
+            rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
+}
+
+rd_kafka_resp_err_t
 rd_kafka_mock_broker_set_down(rd_kafka_mock_cluster_t *mcluster,
                               int32_t broker_id) {
         rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_MOCK);
@@ -2378,6 +2433,23 @@ rd_kafka_mock_cluster_cmd(rd_kafka_mock_cluster_t *mcluster,
                         mpart->follower_end_offset        = rko->rko_u.mock.hi;
                         mpart->update_follower_end_offset = rd_false;
                 }
+                break;
+        case RD_KAFKA_MOCK_CMD_PART_PUSH_LEADER_RESPONSE:
+                mpart = rd_kafka_mock_partition_get(
+                    mcluster, rko->rko_u.mock.name, rko->rko_u.mock.partition);
+                if (!mpart)
+                        return RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+
+                rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
+                             "Push %s [%" PRId32 "] leader response: (%" PRId32
+                             ", %" PRId32 ")",
+                             rko->rko_u.mock.name, rko->rko_u.mock.partition,
+                             rko->rko_u.mock.leader_id,
+                             rko->rko_u.mock.leader_epoch);
+
+                rd_kafka_mock_partition_push_leader_response0(
+                    mpart, rko->rko_u.mock.leader_id,
+                    rko->rko_u.mock.leader_epoch);
                 break;
 
                 /* Broker commands */
@@ -2673,8 +2745,16 @@ rd_kafka_mock_request_copy(rd_kafka_mock_request_t *mrequest) {
         return request;
 }
 
-void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *element) {
-        rd_free(element);
+void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *mrequest) {
+        rd_free(mrequest);
+}
+
+void rd_kafka_mock_request_destroy_array(rd_kafka_mock_request_t **mrequests,
+                                         size_t mrequest_cnt) {
+        size_t i;
+        for (i = 0; i < mrequest_cnt; i++)
+                rd_kafka_mock_request_destroy(mrequests[i]);
+        rd_free(mrequests);
 }
 
 static void rd_kafka_mock_request_free(void *element) {

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2019-2022, Magnus Edenhill
+ *               2023, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -281,6 +282,24 @@ rd_kafka_mock_partition_set_follower_wmarks(rd_kafka_mock_cluster_t *mcluster,
                                             int64_t lo,
                                             int64_t hi);
 
+/**
+ * @brief Push \p cnt Metadata leader response
+ *        onto the cluster's stack for the given \p topic and \p partition.
+ *
+ * @param topic Topic to change
+ * @param partition  Partition to change in \p topic
+ * @param leader_id Broker id of the leader node
+ * @param leader_epoch Leader epoch corresponding to the given \p leader_id
+ *
+ * @return Push operation error code
+ */
+RD_EXPORT
+rd_kafka_resp_err_t
+rd_kafka_mock_partition_push_leader_response(rd_kafka_mock_cluster_t *mcluster,
+                                             const char *topic,
+                                             int partition,
+                                             int32_t leader_id,
+                                             int32_t leader_epoch);
 
 /**
  * @brief Disconnects the broker and disallows any new connections.
@@ -387,6 +406,13 @@ typedef struct rd_kafka_mock_request_s rd_kafka_mock_request_t;
  * @brief Destroy a rd_kafka_mock_request_t * and deallocate memory.
  */
 RD_EXPORT void rd_kafka_mock_request_destroy(rd_kafka_mock_request_t *mreq);
+
+/**
+ * @brief Destroy a rd_kafka_mock_request_t * array and deallocate it.
+ */
+RD_EXPORT void
+rd_kafka_mock_request_destroy_array(rd_kafka_mock_request_t **mreqs,
+                                    size_t mreq_cnt);
 
 /**
  * @brief Get the broker id to which \p mreq was sent.

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -235,6 +235,16 @@ typedef struct rd_kafka_mock_committed_offset_s {
         rd_kafkap_str_t *metadata; /**< Metadata, allocated separately */
 } rd_kafka_mock_committed_offset_t;
 
+/**
+ * @struct Leader id and epoch to return in a Metadata call.
+ */
+typedef struct rd_kafka_mock_partition_leader_s {
+        /**< Link to prev/next entries */
+        TAILQ_ENTRY(rd_kafka_mock_partition_leader_s) link;
+        int32_t leader_id;    /**< Leader id */
+        int32_t leader_epoch; /**< Leader epoch */
+} rd_kafka_mock_partition_leader_t;
+
 
 TAILQ_HEAD(rd_kafka_mock_msgset_tailq_s, rd_kafka_mock_msgset_s);
 
@@ -276,6 +286,10 @@ typedef struct rd_kafka_mock_partition_s {
         int32_t follower_id; /**< Preferred replica/follower */
 
         struct rd_kafka_mock_topic_s *topic;
+
+        /**< Leader responses */
+        TAILQ_HEAD(, rd_kafka_mock_partition_leader_s)
+        leader_responses;
 } rd_kafka_mock_partition_t;
 
 
@@ -476,6 +490,13 @@ rd_kafka_resp_err_t rd_kafka_mock_partition_leader_epoch_check(
 int64_t rd_kafka_mock_partition_offset_for_leader_epoch(
     const rd_kafka_mock_partition_t *mpart,
     int32_t leader_epoch);
+
+rd_kafka_mock_partition_leader_t *
+rd_kafka_mock_partition_next_leader_response(rd_kafka_mock_partition_t *mpart);
+
+void rd_kafka_mock_partition_leader_destroy(
+    rd_kafka_mock_partition_t *mpart,
+    rd_kafka_mock_partition_leader_t *mpart_leader);
 
 
 /**

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -564,6 +564,7 @@ struct rd_kafka_op_s {
                                RD_KAFKA_MOCK_CMD_PART_SET_LEADER,
                                RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER,
                                RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER_WMARKS,
+                               RD_KAFKA_MOCK_CMD_PART_PUSH_LEADER_RESPONSE,
                                RD_KAFKA_MOCK_CMD_BROKER_SET_UPDOWN,
                                RD_KAFKA_MOCK_CMD_BROKER_SET_RTT,
                                RD_KAFKA_MOCK_CMD_BROKER_SET_RACK,
@@ -579,7 +580,9 @@ struct rd_kafka_op_s {
                                                   *    PART_SET_FOLLOWER
                                                   *    PART_SET_FOLLOWER_WMARKS
                                                   *    BROKER_SET_RACK
-                                                  *    COORD_SET (key_type) */
+                                                  *    COORD_SET (key_type)
+                                                  *    PART_PUSH_LEADER_RESPONSE
+                                                  */
                         char *str;               /**< For:
                                                   *    COORD_SET (key) */
                         int32_t partition;       /**< For:
@@ -587,6 +590,7 @@ struct rd_kafka_op_s {
                                                   *    PART_SET_FOLLOWER_WMARKS
                                                   *    PART_SET_LEADER
                                                   *    APIVERSION_SET (ApiKey)
+                                                  *    PART_PUSH_LEADER_RESPONSE
                                                   */
                         int32_t broker_id;       /**< For:
                                                   *    PART_SET_FOLLOWER
@@ -605,6 +609,12 @@ struct rd_kafka_op_s {
                                                   *    TOPIC_CREATE (repl fact)
                                                   *    PART_SET_FOLLOWER_WMARKS
                                                   *    APIVERSION_SET (maxver)
+                                                  */
+                        int32_t leader_id;       /**< Leader id, for:
+                                                  *   PART_PUSH_LEADER_RESPONSE
+                                                  */
+                        int32_t leader_epoch;    /**< Leader epoch, for:
+                                                  *   PART_PUSH_LEADER_RESPONSE
                                                   */
                 } mock;
 

--- a/src/rdkafka_proto.h
+++ b/src/rdkafka_proto.h
@@ -597,19 +597,22 @@ typedef struct rd_kafka_Uuid_s {
                 0, 1, ""                                                       \
         }
 
-/**
- * Initialize given UUID to zero UUID.
- *
- * @param uuid UUID to initialize.
- */
-static RD_INLINE RD_UNUSED void rd_kafka_Uuid_init(rd_kafka_Uuid_t *uuid) {
-        memset(uuid, 0, sizeof(*uuid));
-}
-
 static RD_INLINE RD_UNUSED int rd_kafka_Uuid_cmp(rd_kafka_Uuid_t a,
                                                  rd_kafka_Uuid_t b) {
-        return (a.most_significant_bits - b.most_significant_bits) ||
-               (a.least_significant_bits - b.least_significant_bits);
+        if (a.most_significant_bits < b.most_significant_bits)
+                return -1;
+        if (a.most_significant_bits > b.most_significant_bits)
+                return 1;
+        if (a.least_significant_bits < b.least_significant_bits)
+                return -1;
+        if (a.least_significant_bits > b.least_significant_bits)
+                return 1;
+        return 0;
+}
+
+static RD_INLINE RD_UNUSED int rd_kafka_Uuid_ptr_cmp(void *a, void *b) {
+        rd_kafka_Uuid_t *a_uuid = a, *b_uuid = b;
+        return rd_kafka_Uuid_cmp(*a_uuid, *b_uuid);
 }
 
 rd_kafka_Uuid_t rd_kafka_Uuid_random();

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2532,31 +2532,63 @@ done:
                 rd_kafka_op_destroy(rko);
 }
 
-
 /**
- * @brief Internal implementation of MetadataRequest (does not send).
+ * @brief Internal implementation of MetadataRequest.
  *
- * @param force - rd_true: force a full request (including all topics and
- *                         brokers) even if there is such a request already
- *                         in flight.
- *              - rd_false: check if there are multiple outstanding full
- *                          requests, and don't send one if there is already
- *                          one present. (See note below.)
+ *        - !topics && !topic_ids: only request brokers (if supported by
+ *          broker, else all topics)
+ *        - topics.cnt == 0 || topic_ids.cnt == 0: all topics in cluster
+ *          are requested
+ *        - topics.cnt > 0 || topic_ids.cnt > 0: only specified topics
+ *          are requested
  *
- * If full metadata for all topics is requested (or
- * all brokers, which results in all-topics on older brokers) and there is
- * already a full request in transit then this function will return
- * RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS otherwise RD_KAFKA_RESP_ERR_NO_ERROR.
- * If \p rko is non-NULL or if \p force is true, the request is sent regardless.
+ * @param topics A list of topic names (char *) to request.
+ * @param topic_ids A list of topic ids (rd_kafka_Uuid_t *) to request.
+ * @param reason Metadata request reason
+ * @param allow_auto_create_topics Allow broker-side auto topic creation.
+ *                                 This is best-effort, depending on broker
+ *                                 config and version.
+ * @param include_cluster_authorized_operations Request for cluster
+ *                                              authorized operations.
+ * @param include_topic_authorized_operations Request for topic
+ *                                            authorized operations.
+ * @param cgrp_update Update cgrp in parse_Metadata (see comment there).
+ * @param force_racks Force partition to rack mapping computation in
+ *                    parse_Metadata (see comment there).
+ * @param rko         (optional) rko with replyq for handling response.
+ *                    Specifying an rko forces a metadata request even if
+ *                    there is already a matching one in-transit.
+ * @param resp_cb Callback to be used for handling response.
+ * @param replyq replyq on which response is handled.
+ * @param force rd_true: force a full request (including all topics and
+ *                       brokers) even if there is such a request already
+ *                       in flight.
+ *              rd_false: check if there are multiple outstanding full
+ *                        requests, and don't send one if there is already
+ *                        one present. (See note below.)
+ * @param opaque (optional) parameter to be passed to resp_cb.
  *
- * \p include_cluster_authorized_operations should not be set unless this
- * MetadataRequest is for an admin operation. \sa
- * rd_kafka_MetadataRequest_admin().
+ * @return Error code:
+ *         If full metadata for all topics is requested (or
+ *         all brokers, which results in all-topics on older brokers) and
+ *         there is already a full request in transit then this function
+ *         will return  RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS,
+ *         otherwise RD_KAFKA_RESP_ERR_NO_ERROR.
+ *
+ * @remark Either \p topics or \p topic_ids must be set, but not both.
+ *         If \p rko is specified, \p resp_cb, \p replyq, \p force, \p opaque
+ *         should be NULL or rd_false.
+ * @remark \p include_cluster_authorized_operations and
+ *         \p include_topic_authorized_operations should not be set unless this
+ *         MetadataRequest is for an admin operation.
+ *
+ * @sa rd_kafka_MetadataRequest().
+ * @sa rd_kafka_MetadataRequest_resp_cb().
  */
 static rd_kafka_resp_err_t
 rd_kafka_MetadataRequest0(rd_kafka_broker_t *rkb,
                           const rd_list_t *topics,
-                          rd_list_t *topic_ids,
+                          const rd_list_t *topic_ids,
                           const char *reason,
                           rd_bool_t allow_auto_create_topics,
                           rd_bool_t include_cluster_authorized_operations,
@@ -2790,27 +2822,52 @@ rd_kafka_MetadataRequest0(rd_kafka_broker_t *rkb,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
-
 /**
- * @brief Construct a MetadataRequest which uses an optional rko, and the
- * default handler callback.
- * @sa rd_kafka_MetadataRequest.
+ * @brief Construct and enqueue a MetadataRequest
+ *
+ *        - !topics && !topic_ids: only request brokers (if supported by
+ *          broker, else all topics)
+ *        - topics.cnt == 0 || topic_ids.cnt == 0: all topics in cluster
+ *          are requested
+ *        - topics.cnt > 0 || topic_ids.cnt > 0: only specified topics
+ *          are requested
+ *
+ * @param topics A list of topic names (char *) to request.
+ * @param topic_ids A list of topic ids (rd_kafka_Uuid_t *) to request.
+ * @param reason    - metadata request reason
+ * @param allow_auto_create_topics - allow broker-side auto topic creation.
+ *                                   This is best-effort, depending on broker
+ *                                   config and version.
+ * @param cgrp_update - Update cgrp in parse_Metadata (see comment there).
+ * @param force_racks - Force partition to rack mapping computation in
+ *                      parse_Metadata (see comment there).
+ * @param rko       - (optional) rko with replyq for handling response.
+ *                    Specifying an rko forces a metadata request even if
+ *                    there is already a matching one in-transit.
+ *
+ * @return Error code:
+ *         If full metadata for all topics is requested (or
+ *         all brokers, which results in all-topics on older brokers) and
+ *         there is already a full request in transit then this function
+ *         will return  RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS,
+ *         otherwise RD_KAFKA_RESP_ERR_NO_ERROR.
+ *         If \p rko is non-NULL, the request is sent regardless.
+ *
+ * @remark Either \p topics or \p topic_ids must be set, but not both.
  */
-static rd_kafka_resp_err_t
-rd_kafka_MetadataRequest_op(rd_kafka_broker_t *rkb,
-                            const rd_list_t *topics,
-                            rd_list_t *topic_ids,
-                            const char *reason,
-                            rd_bool_t allow_auto_create_topics,
-                            rd_bool_t include_cluster_authorized_operations,
-                            rd_bool_t include_topic_authorized_operations,
-                            rd_bool_t cgrp_update,
-                            rd_bool_t force_racks,
-                            rd_kafka_op_t *rko) {
+rd_kafka_resp_err_t rd_kafka_MetadataRequest(rd_kafka_broker_t *rkb,
+                                             const rd_list_t *topics,
+                                             rd_list_t *topic_ids,
+                                             const char *reason,
+                                             rd_bool_t allow_auto_create_topics,
+                                             rd_bool_t cgrp_update,
+                                             rd_bool_t force_racks,
+                                             rd_kafka_op_t *rko) {
         return rd_kafka_MetadataRequest0(
             rkb, topics, topic_ids, reason, allow_auto_create_topics,
-            include_cluster_authorized_operations,
-            include_topic_authorized_operations, cgrp_update, force_racks, rko,
+            rd_false /*don't include cluster authorized operations*/,
+            rd_false /*don't include topic authorized operations*/, cgrp_update,
+            force_racks, rko,
             /* We use the default rd_kafka_handle_Metadata rather than a custom
                resp_cb */
             NULL,
@@ -2823,75 +2880,47 @@ rd_kafka_MetadataRequest_op(rd_kafka_broker_t *rkb,
 }
 
 /**
- * @brief Construct MetadataRequest (does not send)
+ * @brief Construct and enqueue a MetadataRequest which use
+ *        response callback \p resp_cb instead of a rko.
  *
- * \p topics is a list of topic names (char *) to request.
+ *        - !topics && !topic_ids: only request brokers (if supported by
+ *          broker, else all topics)
+ *        - topics.cnt == 0 || topic_ids.cnt == 0: all topics in cluster
+ *          are requested
+ *        - topics.cnt > 0 || topic_ids.cnt > 0: only specified topics
+ *          are requested
  *
- * !topics          - only request brokers (if supported by broker, else
- *                    all topics)
- *  topics.cnt==0   - all topics in cluster are requested
- *  topics.cnt >0   - only specified topics are requested
+ * @param topics A list of topic names (char *) to request.
+ * @param topic_ids A list of topic ids (rd_kafka_Uuid_t *) to request.
+ * @param reason Metadata request reason
+ * @param allow_auto_create_topics Allow broker-side auto topic creation.
+ *                                 This is best-effort, depending on broker
+ *                                 config and version.
+ * @param include_cluster_authorized_operations Request for cluster
+ *                                              authorized operations.
+ * @param include_topic_authorized_operations Request for topic
+ *                                            authorized operations.
+ * @param cgrp_update Update cgrp in parse_Metadata (see comment there).
+ * @param force_racks Force partition to rack mapping computation in
+ *                    parse_Metadata (see comment there).
+ * @param resp_cb Callback to be used for handling response.
+ * @param replyq replyq on which response is handled.
+ * @param force Force request even if in progress.
+ * @param opaque (optional) parameter to be passed to resp_cb.
  *
- * @param reason    - metadata request reason
- * @param allow_auto_create_topics - allow broker-side auto topic creation.
- *                                   This is best-effort, depending on broker
- *                                   config and version.
- * @param cgrp_update - Update cgrp in parse_Metadata (see comment there).
- * @param force_racks - Force partition to rack mapping computation in
- *                      parse_Metadata (see comment there).
- * @param rko       - (optional) rko with replyq for handling response.
- *                    Specifying an rko forces a metadata request even if
- *                    there is already a matching one in-transit.
+ * @return Error code:
+ *         If full metadata for all topics is requested (or
+ *         all brokers, which results in all-topics on older brokers) and
+ *         there is already a full request in transit then this function
+ *         will return  RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS,
+ *         otherwise RD_KAFKA_RESP_ERR_NO_ERROR.
  *
- * If full metadata for all topics is requested (or
- * all brokers, which results in all-topics on older brokers) and there is
- * already a full request in transit then this function will return
- * RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS otherwise RD_KAFKA_RESP_ERR_NO_ERROR.
- * If \p rko is non-NULL, the request is sent regardless.
- */
-rd_kafka_resp_err_t rd_kafka_MetadataRequest(rd_kafka_broker_t *rkb,
-                                             const rd_list_t *topics,
-                                             rd_list_t *topic_ids,
-                                             const char *reason,
-                                             rd_bool_t allow_auto_create_topics,
-                                             rd_bool_t cgrp_update,
-                                             rd_bool_t force_racks,
-                                             rd_kafka_op_t *rko) {
-        return rd_kafka_MetadataRequest_op(
-            rkb, topics, topic_ids, reason, allow_auto_create_topics,
-            /* Cluster and Topic authorized operations are used by admin
-             * operations only. For non-admin operation cases, NEVER set them to
-             * true, since it changes the metadata max version to be 10, until
-             * KIP-700 can be implemented. */
-            rd_false, rd_false, cgrp_update, force_racks, rko);
-}
-
-
-/**
- * @brief Construct MetadataRequest for use with AdminAPI (does not send).
- *
- * \p topics is a list of topic names (char *) to request.
- *
- * !topics          - only request brokers (if supported by broker, else
- *                    all topics)
- *  topics.cnt==0   - all topics in cluster are requested
- *  topics.cnt >0   - only specified topics are requested
- *
- * @param reason    - metadata request reason
- * @param include_cluster_authorized_operations - request for cluster
- *                      authorized operations.
- * @param include_topic_authorized_operations - request for topic authorized
- *                      operations.
- * @param cgrp_update - Update cgrp in parse_Metadata (see comment there).
- * @param force_racks - Force partition to rack mapping computation in
- *                      parse_Metadata (see comment there).
- * @param resp_cb - callback to be used for handling response.
- * @param replyq - replyq on which response is handled.
- * @param opaque - (optional) parameter to be passed to resp_cb.
+ *  @remark Either \p topics or \p topic_ids must be set, but not both.
  */
 rd_kafka_resp_err_t rd_kafka_MetadataRequest_resp_cb(
     rd_kafka_broker_t *rkb,
     const rd_list_t *topics,
+    const rd_list_t *topics_ids,
     const char *reason,
     rd_bool_t allow_auto_create_topics,
     rd_bool_t include_cluster_authorized_operations,
@@ -2903,11 +2932,10 @@ rd_kafka_resp_err_t rd_kafka_MetadataRequest_resp_cb(
     rd_bool_t force,
     void *opaque) {
         return rd_kafka_MetadataRequest0(
-            rkb, topics, NULL, reason, allow_auto_create_topics,
+            rkb, topics, topics_ids, reason, allow_auto_create_topics,
             include_cluster_authorized_operations,
             include_topic_authorized_operations, cgrp_update, force_racks,
-            NULL /* No op - using custom resp_cb. */, resp_cb, replyq,
-            rd_true /* Admin operation metadata requests are always forced. */,
+            NULL /* No op - using custom resp_cb. */, resp_cb, replyq, force,
             opaque);
 }
 

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -314,6 +314,7 @@ rd_kafka_resp_err_t rd_kafka_MetadataRequest(rd_kafka_broker_t *rkb,
 rd_kafka_resp_err_t rd_kafka_MetadataRequest_resp_cb(
     rd_kafka_broker_t *rkb,
     const rd_list_t *topics,
+    const rd_list_t *topic_ids,
     const char *reason,
     rd_bool_t allow_auto_create_topics,
     rd_bool_t include_cluster_authorized_operations,

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -662,8 +662,8 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                                          rd_kafka_broker_t *leader,
                                          int32_t leader_epoch) {
         rd_kafka_toppar_t *rktp;
-        rd_bool_t fetching_from_follower, need_epoch_validation = rd_false;
-        int r = 0;
+        rd_bool_t need_epoch_validation = rd_false;
+        int r                           = 0;
 
         rktp = rd_kafka_toppar_get(rkt, partition, 0);
         if (unlikely(!rktp)) {
@@ -691,14 +691,17 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                              rktp->rktp_rkt->rkt_topic->str,
                              rktp->rktp_partition, leader_epoch,
                              rktp->rktp_leader_epoch);
-                if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_ACTIVE) {
+                if (rktp->rktp_fetch_state !=
+                    RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT) {
                         rd_kafka_toppar_unlock(rktp);
                         rd_kafka_toppar_destroy(rktp); /* from get() */
                         return 0;
                 }
         }
 
-        if (leader_epoch > rktp->rktp_leader_epoch) {
+        if (rktp->rktp_leader_epoch == -1 ||
+            leader_epoch > rktp->rktp_leader_epoch) {
+                rd_bool_t fetching_from_follower;
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
                              "%s [%" PRId32 "]: leader %" PRId32
                              " epoch %" PRId32 " -> leader %" PRId32
@@ -706,44 +709,50 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                              rktp->rktp_rkt->rkt_topic->str,
                              rktp->rktp_partition, rktp->rktp_leader_id,
                              rktp->rktp_leader_epoch, leader_id, leader_epoch);
-                rktp->rktp_leader_epoch = leader_epoch;
-                need_epoch_validation   = rd_true;
+                if (leader_epoch > rktp->rktp_leader_epoch)
+                        rktp->rktp_leader_epoch = leader_epoch;
+                need_epoch_validation = rd_true;
+
+
+                fetching_from_follower =
+                    leader != NULL && rktp->rktp_broker != NULL &&
+                    rktp->rktp_broker->rkb_source != RD_KAFKA_INTERNAL &&
+                    rktp->rktp_broker != leader;
+
+                if (fetching_from_follower &&
+                    rktp->rktp_leader_id == leader_id) {
+                        rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
+                                     "Topic %s [%" PRId32 "]: leader %" PRId32
+                                     " unchanged, "
+                                     "not migrating away from preferred "
+                                     "replica %" PRId32,
+                                     rktp->rktp_rkt->rkt_topic->str,
+                                     rktp->rktp_partition, leader_id,
+                                     rktp->rktp_broker_id);
+                        r = 0;
+
+                } else {
+
+                        if (rktp->rktp_leader_id != leader_id ||
+                            rktp->rktp_leader != leader) {
+                                /* Update leader if it has changed */
+                                rktp->rktp_leader_id = leader_id;
+                                if (rktp->rktp_leader)
+                                        rd_kafka_broker_destroy(
+                                            rktp->rktp_leader);
+                                if (leader)
+                                        rd_kafka_broker_keep(leader);
+                                rktp->rktp_leader = leader;
+                        }
+
+                        /* Update handling broker */
+                        r = rd_kafka_toppar_broker_update(
+                            rktp, leader_id, leader, "leader updated");
+                }
+
         } else if (rktp->rktp_fetch_state ==
                    RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT)
                 need_epoch_validation = rd_true;
-
-        fetching_from_follower =
-            leader != NULL && rktp->rktp_broker != NULL &&
-            rktp->rktp_broker->rkb_source != RD_KAFKA_INTERNAL &&
-            rktp->rktp_broker != leader;
-
-        if (fetching_from_follower && rktp->rktp_leader_id == leader_id) {
-                rd_kafka_dbg(
-                    rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
-                    "Topic %s [%" PRId32 "]: leader %" PRId32
-                    " unchanged, "
-                    "not migrating away from preferred replica %" PRId32,
-                    rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
-                    leader_id, rktp->rktp_broker_id);
-                r = 0;
-
-        } else {
-
-                if (rktp->rktp_leader_id != leader_id ||
-                    rktp->rktp_leader != leader) {
-                        /* Update leader if it has changed */
-                        rktp->rktp_leader_id = leader_id;
-                        if (rktp->rktp_leader)
-                                rd_kafka_broker_destroy(rktp->rktp_leader);
-                        if (leader)
-                                rd_kafka_broker_keep(leader);
-                        rktp->rktp_leader = leader;
-                }
-
-                /* Update handling broker */
-                r = rd_kafka_toppar_broker_update(rktp, leader_id, leader,
-                                                  "leader updated");
-        }
 
         if (need_epoch_validation) {
                 /* Set offset validation position,
@@ -1277,8 +1286,8 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         rd_kafka_broker_t **partbrokers;
         int leader_cnt = 0;
         int old_state;
-        rd_bool_t partition_exists_with_no_leader_epoch      = rd_false;
-        rd_bool_t partition_exists_with_updated_leader_epoch = rd_false;
+        rd_bool_t partition_exists_with_no_leader_epoch    = rd_false;
+        rd_bool_t partition_exists_with_stale_leader_epoch = rd_false;
 
         if (mdt->err != RD_KAFKA_RESP_ERR_NO_ERROR)
                 rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_METADATA, "METADATA",
@@ -1328,8 +1337,17 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         if (mdt->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
                 upd += rd_kafka_topic_partition_cnt_update(rkt,
                                                            mdt->partition_cnt);
-                if (rd_kafka_Uuid_cmp(mdit->topic_id, RD_KAFKA_UUID_ZERO))
+                if (rd_kafka_Uuid_cmp(mdit->topic_id, RD_KAFKA_UUID_ZERO)) {
+                        /* FIXME: an offset reset must be triggered.
+                         * when rkt_topic_id wasn't zero.
+                         * There are no problems
+                         * in test 0107_topic_recreate if offsets in new
+                         * topic are lower than in previous one,
+                         * causing an out of range and an offset reset,
+                         * but the rarer case where they're higher needs
+                         * to be checked. */
                         rkt->rkt_topic_id = mdit->topic_id;
+                }
                 /* If the metadata times out for a topic (because all brokers
                  * are down) the state will transition to S_UNKNOWN.
                  * When updated metadata is eventually received there might
@@ -1343,7 +1361,7 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
 
         /* Update leader for each partition */
         for (j = 0; j < mdt->partition_cnt; j++) {
-                int r;
+                int r = 0;
                 rd_kafka_broker_t *leader;
                 int32_t leader_epoch = mdit->partitions[j].leader_epoch;
                 rd_kafka_toppar_t *rktp =
@@ -1362,8 +1380,8 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
                  * set to -1, we assume that metadata is not stale. */
                 if (leader_epoch == -1)
                         partition_exists_with_no_leader_epoch = rd_true;
-                else if (rktp->rktp_leader_epoch < leader_epoch)
-                        partition_exists_with_updated_leader_epoch = rd_true;
+                else if (leader_epoch < rktp->rktp_leader_epoch)
+                        partition_exists_with_stale_leader_epoch = rd_true;
 
 
                 /* Update leader for partition */
@@ -1386,7 +1404,7 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
          * stale, we can turn off fast leader query. */
         if (mdt->partition_cnt > 0 && leader_cnt == mdt->partition_cnt &&
             (partition_exists_with_no_leader_epoch ||
-             partition_exists_with_updated_leader_epoch))
+             !partition_exists_with_stale_leader_epoch))
                 rkt->rkt_flags &= ~RD_KAFKA_TOPIC_F_LEADER_UNAVAIL;
 
         if (mdt->err != RD_KAFKA_RESP_ERR_NO_ERROR && rkt->rkt_partition_cnt) {
@@ -2046,7 +2064,7 @@ void rd_ut_kafka_topic_set_topic_exists(rd_kafka_topic_t *rkt,
 
         rd_kafka_wrlock(rkt->rkt_rk);
         rd_kafka_metadata_cache_topic_update(rkt->rkt_rk, &mdt, &mdit, rd_true,
-                                             rd_false, NULL, 0);
+                                             rd_false, NULL, 0, rd_false);
         rd_kafka_topic_metadata_update(rkt, &mdt, &mdit, rd_clock());
         rd_kafka_wrunlock(rkt->rkt_rk);
         rd_free(partitions);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1328,7 +1328,7 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         if (mdt->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
                 upd += rd_kafka_topic_partition_cnt_update(rkt,
                                                            mdt->partition_cnt);
-                if (!rd_kafka_Uuid_cmp(rkt->rkt_topic_id, RD_KAFKA_UUID_ZERO))
+                if (rd_kafka_Uuid_cmp(mdit->topic_id, RD_KAFKA_UUID_ZERO))
                         rkt->rkt_topic_id = mdit->topic_id;
                 /* If the metadata times out for a topic (because all brokers
                  * are down) the state will transition to S_UNKNOWN.

--- a/tests/0143-exponential_backoff_mock.c
+++ b/tests/0143-exponential_backoff_mock.c
@@ -33,13 +33,6 @@
 const int32_t retry_ms     = 100;
 const int32_t retry_max_ms = 1000;
 
-static void free_mock_requests(rd_kafka_mock_request_t **requests,
-                               size_t request_cnt) {
-        size_t i;
-        for (i = 0; i < request_cnt; i++)
-                rd_kafka_mock_request_destroy(requests[i]);
-        rd_free(requests);
-}
 /**
  * @brief find_coordinator test
  * We fail the request with RD_KAFKA_RESP_ERR_GROUP_COORDINATOR_NOT_AVAILABLE,
@@ -112,7 +105,7 @@ static void test_find_coordinator(rd_kafka_mock_cluster_t *mcluster,
                     rd_kafka_mock_request_timestamp(requests[i]);
         }
         rd_kafka_destroy(consumer);
-        free_mock_requests(requests, request_cnt);
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
         rd_kafka_mock_clear_requests(mcluster);
         SUB_TEST_PASS();
 }
@@ -166,7 +159,7 @@ static void helper_exponential_backoff(rd_kafka_mock_cluster_t *mcluster,
                 previous_request_ts =
                     rd_kafka_mock_request_timestamp(requests[i]);
         }
-        free_mock_requests(requests, request_cnt);
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
 }
 /**
  * @brief offset_commit test
@@ -297,7 +290,7 @@ static void helper_find_coordinator_trigger(rd_kafka_mock_cluster_t *mcluster,
                         }
                 }
         }
-        free_mock_requests(requests, request_cnt);
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
         if (num_request != 1)
                 TEST_FAIL("No request was made.");
 }
@@ -451,7 +444,7 @@ static void test_produce_fast_leader_query(rd_kafka_mock_cluster_t *mcluster,
         }
         rd_kafka_topic_destroy(rkt);
         rd_kafka_destroy(producer);
-        free_mock_requests(requests, request_cnt);
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
         rd_kafka_mock_clear_requests(mcluster);
         SUB_TEST_PASS();
 }
@@ -511,7 +504,7 @@ static void test_fetch_fast_leader_query(rd_kafka_mock_cluster_t *mcluster,
                         previous_request_was_Fetch = rd_false;
         }
         rd_kafka_destroy(consumer);
-        free_mock_requests(requests, request_cnt);
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
         rd_kafka_mock_clear_requests(mcluster);
         TEST_ASSERT(
             Metadata_after_Fetch,

--- a/tests/0146-metadata_mock.c
+++ b/tests/0146-metadata_mock.c
@@ -1,0 +1,274 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2024, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#include "../src/rdkafka_proto.h"
+
+static rd_bool_t is_metadata_request(rd_kafka_mock_request_t *request,
+                                     void *opaque) {
+        return rd_kafka_mock_request_api_key(request) == RD_KAFKAP_Metadata;
+}
+
+static rd_bool_t is_fetch_request(rd_kafka_mock_request_t *request,
+                                  void *opaque) {
+        return rd_kafka_mock_request_api_key(request) == RD_KAFKAP_Fetch;
+}
+
+/**
+ * @brief Metadata should persists in cache after
+ *        a full metadata refresh.
+ *
+ * @param assignor Assignor to use
+ */
+static void do_test_metadata_persists_in_cache(const char *assignor) {
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        rd_kafka_conf_t *conf;
+        rd_kafka_topic_t *rkt;
+        const rd_kafka_metadata_t *md;
+        rd_kafka_topic_partition_list_t *subscription;
+
+        SUB_TEST_QUICK("%s", assignor);
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        test_conf_init(&conf, NULL, 10);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "partition.assignment.strategy", assignor);
+        test_conf_set(conf, "group.id", topic);
+
+        rk = test_create_handle(RD_KAFKA_CONSUMER, conf);
+
+        subscription = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subscription, topic, 0);
+
+        rkt = test_create_consumer_topic(rk, topic);
+
+        /* Metadata for topic is available */
+        TEST_CALL_ERR__(rd_kafka_metadata(rk, 0, rkt, &md, 1000));
+        rd_kafka_metadata_destroy(md);
+        md = NULL;
+
+        /* Subscribe to same topic */
+        TEST_CALL_ERR__(rd_kafka_subscribe(rk, subscription));
+
+        /* Request full metadata */
+        TEST_CALL_ERR__(rd_kafka_metadata(rk, 1, NULL, &md, 1000));
+        rd_kafka_metadata_destroy(md);
+        md = NULL;
+
+        /* Subscribing shouldn't give UNKNOWN_TOPIC_OR_PART err  */
+        TEST_CALL_ERR__(rd_kafka_subscribe(rk, subscription));
+        TEST_CALL_ERR__(rd_kafka_unsubscribe(rk));
+
+        /* Verify no error was returned  */
+        test_consumer_poll_no_msgs("no error", rk, 0, 100);
+
+        rd_kafka_topic_partition_list_destroy(subscription);
+        rd_kafka_topic_destroy(rkt);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief No loop of metadata requests should be started
+ *        when a metadata request is made without leader epoch change.
+ *        See issue #4577
+ */
+static void do_test_fast_metadata_refresh_stops(void) {
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        rd_kafka_conf_t *conf;
+        int metadata_requests;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        test_conf_init(&conf, NULL, 10);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", topic);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        /* This error triggers a metadata refresh but no leader change
+         * happened */
+        rd_kafka_mock_push_request_errors(
+            mcluster, RD_KAFKAP_Produce, 1,
+            RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR);
+
+        rd_kafka_mock_start_request_tracking(mcluster);
+        test_produce_msgs2(rk, topic, 0, 0, 0, 1, NULL, 5);
+
+        /* First call is for getting initial metadata,
+         * second one happens after the error,
+         * it should stop refreshing metadata after that. */
+        metadata_requests = test_mock_wait_maching_requests(
+            mcluster, 2, 500, is_metadata_request, NULL);
+        TEST_ASSERT(metadata_requests == 2,
+                    "Expected 2 metadata request, got %d", metadata_requests);
+        rd_kafka_mock_stop_request_tracking(mcluster);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief A stale leader received while validating shouldn't
+ *        migrate back the partition to that stale broker.
+ */
+static void do_test_stale_metadata_doesnt_migrate_partition(void) {
+        int i, fetch_requests;
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        rd_kafka_conf_t *conf;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 3);
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 1);
+
+        test_conf_init(&conf, NULL, 10);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", topic);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "fetch.error.backoff.ms", "10");
+        test_conf_set(conf, "fetch.wait.max.ms", "10");
+
+        rk = test_create_handle(RD_KAFKA_CONSUMER, conf);
+
+        test_consumer_subscribe(rk, topic);
+
+        /* Produce and consume to leader 1 */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, 1, 0, "bootstrap.servers",
+                                 bootstraps, NULL);
+        test_consumer_poll_exact("read first", rk, 0, 0, 0, 1, rd_true, NULL);
+
+        /* Change leader to 2, Fetch fails, refreshes metadata. */
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 2);
+
+        for (i = 0; i < 5; i++) {
+                /* Validation fails, metadata refreshed again */
+                rd_kafka_mock_broker_push_request_error_rtts(
+                    mcluster, 2, RD_KAFKAP_OffsetForLeaderEpoch, 1,
+                    RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR, 1000);
+        }
+
+        /* Wait partition migrates to broker 2 */
+        rd_usleep(100 * 1000, 0);
+
+        /* Return stale metadata */
+        for (i = 0; i < 10; i++) {
+                rd_kafka_mock_partition_push_leader_response(
+                    mcluster, topic, 0, 1 /*leader id*/, 0 /*leader epoch*/);
+        }
+
+        /* Partition doesn't have to migrate back to broker 1 */
+        rd_usleep(1500 * 1000, 0);
+        rd_kafka_mock_start_request_tracking(mcluster);
+        fetch_requests = test_mock_wait_maching_requests(
+            mcluster, 0, 500, is_fetch_request, NULL);
+        TEST_ASSERT(fetch_requests == 0,
+                    "No fetch request should be received by broker 1, got %d",
+                    fetch_requests);
+        rd_kafka_mock_stop_request_tracking(mcluster);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief A metadata call for an existing topic, just after subscription,
+ *        must not cause a UNKNOWN_TOPIC_OR_PART error.
+ *        See issue #4589.
+ */
+static void do_test_metadata_call_before_join(void) {
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        rd_kafka_conf_t *conf;
+        const struct rd_kafka_metadata *metadata;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 3);
+
+        test_conf_init(&conf, NULL, 10);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", topic);
+
+        rk = test_create_handle(RD_KAFKA_CONSUMER, conf);
+
+        test_consumer_subscribe(rk, topic);
+
+        TEST_CALL_ERR__(rd_kafka_metadata(rk, 1, 0, &metadata, 5000));
+        rd_kafka_metadata_destroy(metadata);
+
+        test_consumer_poll_no_msgs("no errors", rk, 0, 1000);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0146_metadata_mock(int argc, char **argv) {
+        TEST_SKIP_MOCK_CLUSTER(0);
+
+        do_test_metadata_persists_in_cache("range");
+
+        do_test_metadata_persists_in_cache("cooperative-sticky");
+
+        do_test_fast_metadata_refresh_stops();
+
+        do_test_stale_metadata_doesnt_migrate_partition();
+
+        do_test_metadata_call_before_join();
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ set(
     0142-reauthentication.c
     0143-exponential_backoff_mock.c
     0144-idempotence_mock.c
+    0146-metadata_mock.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -9,7 +9,7 @@
 
 from trivup.trivup import Cluster
 from trivup.apps.ZookeeperApp import ZookeeperApp
-from trivup.apps.KafkaBrokerApp import KafkaBrokerApp as KafkaBrokerAppOrig
+from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
 from trivup.apps.SslApp import SslApp
 from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
@@ -33,15 +33,6 @@ def read_scenario_conf(scenario):
     parser = JsonComment(json)
     with open(os.path.join('scenarios', scenario + '.json'), 'r') as f:
         return parser.load(f)
-
-
-# FIXME: merge in trivup
-class KafkaBrokerApp(KafkaBrokerAppOrig):
-    def _add_simple_authorizer(self, conf_blob):
-        conf_blob.append(
-            'authorizer.class.name=' +
-            'org.apache.kafka.metadata.authorizer.StandardAuthorizer')
-        conf_blob.append('super.users=User:ANONYMOUS')
 
 
 class LibrdkafkaTestCluster(Cluster):

--- a/tests/test.h
+++ b/tests/test.h
@@ -859,8 +859,12 @@ rd_kafka_resp_err_t test_delete_all_test_topics(int timeout_ms);
 void test_mock_cluster_destroy(rd_kafka_mock_cluster_t *mcluster);
 rd_kafka_mock_cluster_t *test_mock_cluster_new(int broker_cnt,
                                                const char **bootstraps);
-
-
+int test_mock_wait_maching_requests(
+    rd_kafka_mock_cluster_t *mcluster,
+    int num,
+    int confidence_interval_ms,
+    rd_bool_t (*match)(rd_kafka_mock_request_t *request, void *opaque),
+    void *opaque);
 
 int test_error_is_not_fatal_cb(rd_kafka_t *rk,
                                rd_kafka_resp_err_t err,

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -225,6 +225,7 @@
     <ClCompile Include="..\..\tests\0142-reauthentication.c" />
     <ClCompile Include="..\..\tests\0143-exponential_backoff_mock.c" />
     <ClCompile Include="..\..\tests\0144-idempotence_mock.c" />
+    <ClCompile Include="..\..\tests\0146-metadata_mock.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
Metadata cache by topic id is added, with an AVL tree having a Uuid as key and the same struct as value.

### General fixes

 * Metadata cache was cleared on full metadata refresh, leading to unnecessary
   refreshes and occasional `UNKNOWN_TOPIC_OR_PART` errors. Solved by updating
   cache for existing or hinted entries instead of clearing them.
   Happening since 2.1.0.
 * A metadata call before member joins consumer group,
   could lead to an `UNKNOWN_TOPIC_OR_PART` error. Solved by updating
   the consumer group following a metadata refresh only in safe states.
   Happening since 2.1.0.
 * Metadata refreshes without partition leader change could lead to a loop of
   metadata calls at fixed intervals. Solved by stopping metadata refresh when
   all existing metadata is non-stale. Happening since 2.3.0.
 * A partition migration could happen, using stale metadata, when the partition
   was undergoing a validation and being retried because of an error.
   Solved by doing a partition migration only with a non-stale leader epoch.
   Happening since 2.1.0.