### PR TITLE
Handle overflow in rd_buf_write_remains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# vNext
+
+* Fix segfault when using long client id because of erased segment when using flexver. (#4689)
+
 # librdkafka v2.4.0
 
 librdkafka v2.4.0 is a feature release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,24 @@
 
 librdkafka v2.5.0 is a feature release.
 
+* Fix segfault when using long client id because of erased segment when using flexver. (#4689)
+
+
 ## Enhancements
 
   * Update bundled lz4 (used when `./configure --disable-lz4-ext`) to
     [v1.9.4](https://github.com/lz4/lz4/releases/tag/v1.9.4), which contains
     bugfixes and performance improvements (#4726).
 
+
 ## Fixes
 
 ### General fixes
 
-  * Fix segfault when using long client id because of erased segment when using flexver. (#4689)
+*  Issues: [confluentinc/confluent-kafka-dotnet#2084](https://github.com/confluentinc/confluent-kafka-dotnet/issues/2084)
+   Fix segfault when a segment is erased and more data is written to the buffer.
+   Happens since 1.x when a portion of the buffer (segment) is erased for flexver or compression.
+   More likely to happen since 2.1.0, because of the upgrades to flexver, with certain string sizes like a long client id (#4689).
 
 
 

--- a/src/rdbuf.c
+++ b/src/rdbuf.c
@@ -665,8 +665,10 @@ size_t rd_buf_erase(rd_buf_t *rbuf, size_t absof, size_t size) {
                 of += toerase;
 
                 /* If segment is now empty, remove it */
-                if (seg->seg_of == 0)
+                if (seg->seg_of == 0) {
                         rd_buf_destroy_segment(rbuf, seg);
+                        rbuf->rbuf_erased -= toerase;
+                }
         }
 
         /* Update absolute offset of remaining segments */

--- a/src/rdbuf.c
+++ b/src/rdbuf.c
@@ -667,8 +667,8 @@ size_t rd_buf_erase(rd_buf_t *rbuf, size_t absof, size_t size) {
 
                 /* If segment is now empty, remove it */
                 if (seg->seg_of == 0) {
+                        rbuf->rbuf_erased -= seg->seg_erased;
                         rd_buf_destroy_segment(rbuf, seg);
-                        rbuf->rbuf_erased -= toerase;
                 }
         }
 
@@ -712,8 +712,8 @@ int rd_buf_write_seek(rd_buf_t *rbuf, size_t absof) {
              next != seg;) {
                 rd_segment_t *this = next;
                 next = TAILQ_PREV(this, rd_segment_head, seg_link);
+                rbuf->rbuf_erased -= this->seg_erased;
                 rd_buf_destroy_segment(rbuf, this);
-                rbuf->rbuf_erased -= seg->seg_erased;
         }
 
         /* Update relative write offset */

--- a/src/rdbuf.c
+++ b/src/rdbuf.c
@@ -660,6 +660,7 @@ size_t rd_buf_erase(rd_buf_t *rbuf, size_t absof, size_t size) {
                                 segremains);
 
                 seg->seg_of -= toerase;
+                seg->seg_erased += toerase;
                 rbuf->rbuf_len -= toerase;
 
                 of += toerase;
@@ -712,6 +713,7 @@ int rd_buf_write_seek(rd_buf_t *rbuf, size_t absof) {
                 rd_segment_t *this = next;
                 next = TAILQ_PREV(this, rd_segment_head, seg_link);
                 rd_buf_destroy_segment(rbuf, this);
+                rbuf->rbuf_erased -= seg->seg_erased;
         }
 
         /* Update relative write offset */

--- a/src/rdbuf.h
+++ b/src/rdbuf.h
@@ -70,6 +70,8 @@ typedef struct rd_segment_s {
                                     *   beginning in the grand rd_buf_t */
         void (*seg_free)(void *p); /**< Optional free function for seg_p */
         int seg_flags;             /**< Segment flags */
+        size_t seg_erased;         /** Total number of bytes erased from
+                                    *   this segment. */
 #define RD_SEGMENT_F_RDONLY 0x1    /**< Read-only segment */
 #define RD_SEGMENT_F_FREE                                                      \
         0x2 /**< Free segment on destroy,                                      \

--- a/src/rdbuf.h
+++ b/src/rdbuf.h
@@ -147,11 +147,7 @@ static RD_INLINE RD_UNUSED size_t rd_buf_write_pos(const rd_buf_t *rbuf) {
  * @returns the number of bytes available for writing (before growing).
  */
 static RD_INLINE RD_UNUSED size_t rd_buf_write_remains(const rd_buf_t *rbuf) {
-        ssize_t remaining =
-            rbuf->rbuf_size - (rbuf->rbuf_len + rbuf->rbuf_erased);
-        if (remaining < 0)
-                return 0;
-        return remaining;
+        return rbuf->rbuf_size - (rbuf->rbuf_len + rbuf->rbuf_erased);
 }
 
 

--- a/src/rdbuf.h
+++ b/src/rdbuf.h
@@ -147,7 +147,11 @@ static RD_INLINE RD_UNUSED size_t rd_buf_write_pos(const rd_buf_t *rbuf) {
  * @returns the number of bytes available for writing (before growing).
  */
 static RD_INLINE RD_UNUSED size_t rd_buf_write_remains(const rd_buf_t *rbuf) {
-        return rbuf->rbuf_size - (rbuf->rbuf_len + rbuf->rbuf_erased);
+        ssize_t remaining =
+            rbuf->rbuf_size - (rbuf->rbuf_len + rbuf->rbuf_erased);
+        if (remaining < 0)
+                return 0;
+        return remaining;
 }
 
 

--- a/tests/0011-produce_batch.c
+++ b/tests/0011-produce_batch.c
@@ -90,8 +90,8 @@ static void test_single_partition(void) {
         int failcnt = 0;
         int i;
         rd_kafka_message_t *rkmessages;
-        const int topicSuffixLength = 56, clientIdLength = 239;
-        char *topicSuffix, *clientId;
+        const int topic_suffix_length = 56, client_id_length = 239;
+        char *topic_suffix, *client_id;
 
         SUB_TEST_QUICK();
 
@@ -99,12 +99,12 @@ static void test_single_partition(void) {
 
         test_conf_init(&conf, &topic_conf, 20);
 
-        clientId = (char *)malloc(clientIdLength + 1 * sizeof(char));
-        for (i = 0; i < clientIdLength; i++) {
-                clientId[i] = 'c';
+        client_id = malloc((client_id_length + 1) * sizeof(char));
+        for (i = 0; i < client_id_length; i++) {
+                client_id[i] = 'c';
         }
-        clientId[clientIdLength] = '\0';
-        rd_kafka_conf_set(conf, "client.id", clientId, NULL, 0);
+        client_id[client_id_length] = '\0';
+        rd_kafka_conf_set(conf, "client.id", client_id, NULL, 0);
 
         /* Set delivery report callback */
         rd_kafka_conf_set_dr_cb(conf, dr_single_partition_cb);
@@ -115,13 +115,13 @@ static void test_single_partition(void) {
         TEST_SAY("test_single_partition: Created kafka instance %s\n",
                  rd_kafka_name(rk));
 
-        topicSuffix = (char *)malloc(topicSuffixLength + 1 * sizeof(char));
-        for (i = 0; i < topicSuffixLength; i++) {
-                topicSuffix[i] = 'b';
+        topic_suffix = (char *)malloc(topic_suffix_length + 1 * sizeof(char));
+        for (i = 0; i < topic_suffix_length; i++) {
+                topic_suffix[i] = 'b';
         }
-        topicSuffix[topicSuffixLength] = '\0';
+        topic_suffix[topic_suffix_length] = '\0';
 
-        rkt = rd_kafka_topic_new(rk, test_mk_topic_name(topicSuffix, 0),
+        rkt = rd_kafka_topic_new(rk, test_mk_topic_name(topic_suffix, 0),
                                  topic_conf);
         if (!rkt)
                 TEST_FAIL("Failed to create topic: %s\n", rd_strerror(errno));
@@ -194,8 +194,8 @@ static void test_single_partition(void) {
         TEST_SAY("Destroying kafka instance %s\n", rd_kafka_name(rk));
         rd_kafka_destroy(rk);
 
-        free(clientId);
-        free(topicSuffix);
+        free(client_id);
+        free(topic_suffix);
 
         SUB_TEST_PASS();
 }

--- a/tests/0011-produce_batch.c
+++ b/tests/0011-produce_batch.c
@@ -90,8 +90,8 @@ static void test_single_partition(void) {
         int failcnt = 0;
         int i;
         rd_kafka_message_t *rkmessages;
-        const int topic_suffix_length = 56, client_id_length = 239;
-        char *topic_suffix, *client_id;
+        const int client_id_length = 239;
+        char *client_id;
 
         SUB_TEST_QUICK();
 
@@ -115,14 +115,7 @@ static void test_single_partition(void) {
         TEST_SAY("test_single_partition: Created kafka instance %s\n",
                  rd_kafka_name(rk));
 
-        topic_suffix = (char *)malloc(topic_suffix_length + 1 * sizeof(char));
-        for (i = 0; i < topic_suffix_length; i++) {
-                topic_suffix[i] = 'b';
-        }
-        topic_suffix[topic_suffix_length] = '\0';
-
-        rkt = rd_kafka_topic_new(rk, test_mk_topic_name(topic_suffix, 0),
-                                 topic_conf);
+        rkt = rd_kafka_topic_new(rk, test_mk_topic_name("0011", 0), topic_conf);
         if (!rkt)
                 TEST_FAIL("Failed to create topic: %s\n", rd_strerror(errno));
 
@@ -195,7 +188,6 @@ static void test_single_partition(void) {
         rd_kafka_destroy(rk);
 
         free(client_id);
-        free(topic_suffix);
 
         SUB_TEST_PASS();
 }


### PR DESCRIPTION
After the implementation of KIP-320, TopicCnt was sent as a varint in the metadata request. This change caused an overflow issue due to the use of `rd_buf_erase` to erase the remaining bytes. The overflow occurred in the calculation `rbuf->rbuf_size - (rbuf->rbuf_len + rbuf->rbuf_erased)` because `rbuf->rbuf_erased` was non-zero when the buffer was almost full, leading to an overflow condition.

As a result, for certain configurations that caused the buffer to be nearly full, the client was unable to send metadata requests, and it also caused crashes in the .NET client.