### PR TITLE
Fix flaky test because of consume returning before the timeout

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -112,7 +112,7 @@ namespace RdKafka {
  * @remark This value should only be used during compile time,
  *         for runtime checks of version use RdKafka::version()
  */
-#define RD_KAFKA_VERSION 0x020300ff
+#define RD_KAFKA_VERSION 0x020400ff
 
 /**
  * @brief Returns the librdkafka version as integer.

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2418,7 +2418,7 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                                         rd_kafka_log(
                                             rk, LOG_WARNING, "ASSIGNOR",
                                             "roundrobin assignor isn't "
-                                            "available"
+                                            "available "
                                             "with group protocol CONSUMER, "
                                             "using the \"uniform\" one. "
                                             "It's similar, "


### PR DESCRIPTION
C++ version fix