### PR TITLE
Add missing include due to RAND_priv_bytes

### DIFF
--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -34,7 +34,9 @@
 
 #include <stdarg.h>
 
-
+#if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10101000L
+#include <openssl/rand.h>
+#endif
 
 /** @brief Descriptive strings for rko_u.admin_request.state */
 static const char *rd_kafka_admin_state_desc[] = {


### PR DESCRIPTION
`RAND_priv_bytes()` requires including `openssl/rand.h` from the openssl library. Some compilers may not error out and treat it as a warning. In my case, on Fedora rawhide, the build is failing due to missing lib include.