### PR TITLE
Fix for an idempotent producer error, with a message batch not reconstructed identically when retried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 librdkafka v2.5.0 is a feature release.
 
 * Fix segfault when using long client id because of erased segment when using flexver. (#4689)
+* Fix for an idempotent producer error, with a message batch not reconstructed
+  identically when retried (#)
 
 
 ## Enhancements
@@ -20,6 +22,15 @@ librdkafka v2.5.0 is a feature release.
    Fix segfault when a segment is erased and more data is written to the buffer.
    Happens since 1.x when a portion of the buffer (segment) is erased for flexver or compression.
    More likely to happen since 2.1.0, because of the upgrades to flexver, with certain string sizes like a long client id (#4689).
+
+### Idempotent producer fixes
+
+ * Issues: #4736
+   Fix for an idempotent producer error, with a message batch not reconstructed
+   identically when retried. Caused the error message "Local: Inconsistent state: Unable to reconstruct MessageSet".
+   Happening on large batches. Solved by using the same backoff baseline for all messages
+   in the batch.
+   Happens since 2.2.0 (#).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ librdkafka v2.5.0 is a feature release.
 
 * Fix segfault when using long client id because of erased segment when using flexver. (#4689)
 * Fix for an idempotent producer error, with a message batch not reconstructed
-  identically when retried (#)
+  identically when retried (#4750)
 
 
 ## Enhancements
@@ -30,7 +30,7 @@ librdkafka v2.5.0 is a feature release.
    identically when retried. Caused the error message "Local: Inconsistent state: Unable to reconstruct MessageSet".
    Happening on large batches. Solved by using the same backoff baseline for all messages
    in the batch.
-   Happens since 2.2.0 (#).
+   Happens since 2.2.0 (#4750).
 
 
 


### PR DESCRIPTION
Issues: #4736
Fix for an idempotent producer error, with a message batch not reconstructed identically when retried. Caused the error message "Local: Inconsistent state: Unable to reconstruct MessageSet". Happening on large batches. Solved by using the same backoff baseline for all messages in the batch.
Happens since 2.2.0