### PR TITLE
Add -lrt while building zstd for centos

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -139,8 +139,8 @@ blocks:
 
   - name: 'Linux x64: release artifact docker builds'
     dependencies: []
-    run:
-      when: "tag =~ '^v[0-9]\\.'"
+    # run:
+      # when: "tag =~ '^v[0-9]\\.'"
     task:
       agent:
         machine:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -139,8 +139,8 @@ blocks:
 
   - name: 'Linux x64: release artifact docker builds'
     dependencies: []
-    # run:
-      # when: "tag =~ '^v[0-9]\\.'"
+    run:
+      when: "tag =~ '^v[0-9]\\.'"
     task:
       agent:
         machine:

--- a/mklove/modules/configure.libzstd
+++ b/mklove/modules/configure.libzstd
@@ -53,6 +53,11 @@ function install_source {
             $checksum || return 1
     fi
 
-    time make -j DESTDIR="${destdir}" prefix=/usr install
+    local ldlibs=""
+    if [[ $MKL_DISTRO == centos ]]; then
+        ldlibs="-lrt"
+    fi
+
+    time LDLIBS="$ldlibs" make -j DESTDIR="${destdir}" prefix=/usr install
     return $?
 }


### PR DESCRIPTION
Later versions of zstd fail without -lrt, see https://github.com/facebook/zstd/issues/3558 .

This is WIP for checking semaphore result