### PR TITLE
Race in rd_kafka_fetch_pos2str

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -4567,7 +4567,7 @@ void rd_kafka_partition_leader_destroy_free(void *ptr) {
 
 const char *rd_kafka_fetch_pos2str(const rd_kafka_fetch_pos_t fetchpos) {
         static RD_TLS char ret[2][64];
-        static int idx;
+        static RD_TLS int idx;
 
         idx = (idx + 1) % 2;
 


### PR DESCRIPTION
If idx is calculated simultaneously by several threads, the result can be >1
The race is detected by thread sanitizer against ClickHouse integration tests.
