### PR TITLE
Fix for an infinite loop in cooperative sticky assignor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 librdkafka v2.6.1 is a maintenance release:
 
- * Fix for a Fetch regression when connecting to Apache Kafka < 2.7 (#4871).
+* Fix for a Fetch regression when connecting to Apache Kafka < 2.7 (#4871).
+* Fix for an infinite loop happening with cooperative-sticky assignor
+  under some particular conditions (#4800).
 
 
 ## Fixes
 
 ### Consumer fixes
 
- * Issues: #4870
-   Fix for a Fetch regression when connecting to Apache Kafka < 2.7, causing
-   fetches to fail.
-   Happening since v2.6.0 (#4871)
+* Issues: #4870
+  Fix for a Fetch regression when connecting to Apache Kafka < 2.7, causing
+  fetches to fail.
+  Happening since v2.6.0 (#4871)
+* Issues: #4783.
+  A consumer configured with the `cooperative-sticky` partition assignment
+  strategy could get stuck in an infinite loop, with corresponding spike of
+  main thread CPU usage.
+  That happened with some particular orders of members and potential 
+  assignable partitions.
+  Solved by removing the infinite loop cause.
+  Happening since: 1.6.0 (#4800).
 
 
 

--- a/src/rdkafka_sticky_assignor.c
+++ b/src/rdkafka_sticky_assignor.c
@@ -819,6 +819,7 @@ isBalanced(rd_kafka_t *rk,
          *       currentAssignment's element we get both the consumer
          *       and partition list in elem here. */
         RD_LIST_FOREACH(elem, sortedCurrentSubscriptions, i) {
+                int j;
                 const char *consumer = (const char *)elem->key;
                 const rd_kafka_topic_partition_list_t *potentialTopicPartitions;
                 const rd_kafka_topic_partition_list_t *consumerPartitions;
@@ -836,9 +837,9 @@ isBalanced(rd_kafka_t *rk,
 
                 /* Otherwise make sure it can't get any more partitions */
 
-                for (i = 0; i < potentialTopicPartitions->cnt; i++) {
+                for (j = 0; j < potentialTopicPartitions->cnt; j++) {
                         const rd_kafka_topic_partition_t *partition =
-                            &potentialTopicPartitions->elems[i];
+                            &potentialTopicPartitions->elems[j];
                         const char *otherConsumer;
                         int otherConsumerPartitionCount;
 


### PR DESCRIPTION
when potential topic partitions are less than number of members.

Closes #4783