### PR TITLE
Add multiple kerberos authentication environment adaptation

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4884,7 +4884,11 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
         rkb->rkb_proto    = proto;
         rkb->rkb_port     = port;
         rkb->rkb_origname = rd_strdup(name);
-
+        if (rk->rk_conf.sasl.krb5_path) {
+                rkb->krb5_path  = rd_strdup(rk->rk_conf.sasl.krb5_path);
+        } else {
+                rkb->krb5_path  = NULL;
+        }
         mtx_init(&rkb->rkb_lock, mtx_plain);
         mtx_init(&rkb->rkb_logname_lock, mtx_plain);
         rkb->rkb_logname = rd_strdup(rkb->rkb_name);

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -354,6 +354,7 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
 
 
         rd_kafka_timer_t rkb_sasl_reauth_tmr;
+        char *krb5_path;
 };
 
 #define rd_kafka_broker_keep(rkb) rd_refcnt_add(&(rkb)->rkb_refcnt)

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -944,6 +944,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
      "`sasl.kerberos.kinit.cmd` as "
      "` ... -t \"%{sasl.kerberos.keytab}\"`.",
      _UNSUPPORTED_WIN32_GSSAPI},
+    {_RK_GLOBAL, "sasl.kerberos.krb5path", _RK_C_STR, _RK(sasl.krb5_path),
+     "Path of krb5 conf file. ",
+     _UNSUPPORTED_WIN32_GSSAPI},
     {_RK_GLOBAL, "sasl.kerberos.min.time.before.relogin", _RK_C_INT,
      _RK(sasl.relogin_min_time),
      "Minimum time in milliseconds between key refresh attempts. "

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -294,6 +294,7 @@ struct rd_kafka_conf_s {
                 mtx_t lock;
                 char *username;
                 char *password;
+                char *krb5_path;
 #if WITH_SASL_SCRAM
                 /* SCRAM EVP-wrapped hash function
                  * (return value from EVP_shaX()) */


### PR DESCRIPTION
Added a new configuration option sasl.kerberos.krb5path to adapt to the problem of using multiple krb5 files and different cache files when multiple different kerberos authentication environments are used