### PR TITLE
Added Public API rd_kafka_ElectLeaders for Preferred/Unclean Leader Election on Topic Partitions

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -22,3 +22,4 @@ alter_consumer_group_offsets
 incremental_alter_configs
 user_scram
 list_offsets
+elect_leaders

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,6 +62,9 @@ target_link_libraries(describe_cluster PUBLIC rdkafka)
 add_executable(list_offsets list_offsets.c ${win32_sources})
 target_link_libraries(list_offsets PUBLIC rdkafka)
 
+add_executable(elect_leaders elect_leaders.c ${win32_sources})
+target_link_libraries(elect_leaders PUBLIC rdkafka)
+
 # The targets below has Unix include dirs and do not compile on Windows.
 if(NOT WIN32)
     add_executable(rdkafka_example rdkafka_example.c)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,6 +13,7 @@ EXAMPLES ?= rdkafka_example rdkafka_performance rdkafka_example_cpp \
 	incremental_alter_configs \
 	user_scram \
 	list_offsets \
+	elect_leaders \
 	misc
 
 all: $(EXAMPLES)
@@ -150,6 +151,10 @@ user_scram: ../src/librdkafka.a user_scram.c
 		../src/librdkafka.a $(LIBS)
 
 list_offsets: ../src/librdkafka.a list_offsets.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
+		../src/librdkafka.a $(LIBS)
+
+elect_leaders: ../src/librdkafka.a elect_leaders.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
 		../src/librdkafka.a $(LIBS)
 

--- a/examples/elect_leaders.c
+++ b/examples/elect_leaders.c
@@ -1,0 +1,329 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2024, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SH THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Example utility that shows how to use Elect Leaders (AdminAPI)
+ * to trigger preffered or unclean elections for
+ * one or more topic partitions.
+ */
+
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#ifdef _WIN32
+#include "../win32/wingetopt.h"
+#else
+#include <getopt.h>
+#endif
+
+
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is builtin from within the librdkafka source tree and thus differs. */
+#include "rdkafka.h"
+
+
+const char *argv0;
+
+static rd_kafka_queue_t *queue = NULL; /** Admin result queue.
+                                        *  This is a global so we can
+                                        *  yield in stop() */
+static volatile sig_atomic_t run = 1;
+
+/**
+ * @brief Signal termination of program
+ */
+static void stop(int sig) {
+        if (!run) {
+                fprintf(stderr, "%% Forced termination\n");
+                exit(2);
+        }
+        run = 0;
+        if (queue)
+                rd_kafka_queue_yield(queue);
+}
+
+static void usage(const char *reason, ...) {
+
+        fprintf(stderr,
+                "Elect Leaders usage examples\n"
+                "\n"
+                "Usage: %s <options> <election_type( 0(Preffered)/ 1(Unclean))> "
+                "<topic1> <partition1> ...\n"
+                "\n"
+                "Options:\n"
+                "   -b <brokers>    Bootstrap server list to connect to.\n"
+                "   -X <prop=val>   Set librdkafka configuration property.\n"
+                "                   See CONFIGURATION.md for full list.\n"
+                "   -d <dbg,..>     Enable librdkafka debugging (%s).\n"
+                "\n",
+                argv0, rd_kafka_get_debug_contexts());
+
+        if (reason) {
+                va_list ap;
+                char reasonbuf[512];
+
+                va_start(ap, reason);
+                vsnprintf(reasonbuf, sizeof(reasonbuf), reason, ap);
+                va_end(ap);
+
+                fprintf(stderr, "ERROR: %s\n", reasonbuf);
+        }
+
+        exit(reason ? 1 : 0);
+}
+
+
+#define fatal(...)                                                             \
+        do {                                                                   \
+                fprintf(stderr, "ERROR: ");                                    \
+                fprintf(stderr, __VA_ARGS__);                                  \
+                fprintf(stderr, "\n");                                         \
+                exit(2);                                                       \
+        } while (0)
+
+
+/**
+ * @brief Set config property. Exit on failure.
+ */
+static void conf_set(rd_kafka_conf_t *conf, const char *name, const char *val) {
+        char errstr[512];
+
+        if (rd_kafka_conf_set(conf, name, val, errstr, sizeof(errstr)) !=
+            RD_KAFKA_CONF_OK)
+                fatal("Failed to set %s=%s: %s", name, val, errstr);
+}
+
+static int print_elect_leader_result(const rd_kafka_ElectLeader_result_t *result) {
+        rd_kafka_resp_err_t err;
+        const rd_kafka_topic_partition_result_t **results;
+        size_t results_cnt;
+        size_t i;
+        int retval = 0;
+
+        err = rd_kafka_ElectionResult_error(result);
+
+        results = rd_kafka_ElectionResult_partition(result, &results_cnt);
+
+        if(err){
+                printf("%% ElectLeader failed: %s\n", rd_kafka_err2str(err));
+                retval = 1;
+        } else {
+                for(i = 0; i < results_cnt; i++){
+                        if(rd_kafka_topic_partition_result_error(results[i])){
+                             printf("%% ElectLeader failed for %s [%" PRId32 "] : %s\n",
+                                rd_kafka_topic_partition_result_topic(results[i]),
+                                rd_kafka_topic_partition_result_partition(results[i]),
+                                rd_kafka_topic_partition_result_error_string(results[i]));
+                        }
+                        else{
+                                printf("%% ElectLeader succeeded for %s [%" PRId32 "]\n",
+                                        rd_kafka_topic_partition_result_topic(results[i]),
+                                        rd_kafka_topic_partition_result_partition(results[i]));
+                        }
+                }
+        }
+
+        return retval;
+}
+
+/**
+ * @brief Parse an integer or fail.
+ */
+int64_t parse_int(const char *what, const char *str) {
+        char *end;
+        unsigned long n = strtoull(str, &end, 0);
+
+        if (end != str + strlen(str)) {
+                fprintf(stderr, "%% Invalid input for %s: %s: not an integer\n",
+                        what, str);
+                exit(1);
+        }
+
+        return (int64_t)n;
+}
+
+static void cmd_elect_leader(rd_kafka_conf_t *conf, int argc, char **argv) {
+        rd_kafka_t *rk;
+        char errstr[512];
+        rd_kafka_AdminOptions_t *options;
+        rd_kafka_event_t *event = NULL;
+        rd_kafka_topic_partition_list_t *partitions;
+        rd_kafka_ElectionType_t election_type;
+        rd_kafka_ElectLeader_t *elect_leader;
+        int i;
+        int retval = 0;
+
+        if(argc < 3){
+                usage("Invalid number of arguments");
+        }
+        int etype = parse_int("election_type", argv[0]);
+        
+        if(etype == 0){
+                election_type = RD_KAFKA_ELECTION_TYPE_PREFERRED;
+        } else if(etype == 1){
+                election_type = RD_KAFKA_ELECTION_TYPE_UNCLEAN;
+        } else {
+                usage("Invalid election type");
+        }
+        argc--;
+        argv++;
+        partitions = rd_kafka_topic_partition_list_new(argc/2);
+        if(argc % 2 != 0){
+                usage("Invalid number of arguments");
+        }
+        for(i = 0; i < argc; i+=2){
+                rd_kafka_topic_partition_list_add(
+                    partitions, argv[i], parse_int("partition", argv[i+1]));
+        }
+
+        elect_leader = rd_kafka_ElectLeader_new(election_type, partitions);
+
+        /*
+         * Create consumer instance
+         * NOTE: rd_kafka_new() takes ownership of the conf object
+         *       and the application must not reference it again after
+         *       this call.
+         */
+        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        if (!rk) {
+                usage("Failed to create new consumer: %s", errstr);
+        }
+
+        /*
+         * Elect Leaders
+         */
+        queue = rd_kafka_queue_new(rk);
+
+        /* Signal handler for clean shutdown */
+        signal(SIGINT, stop);
+        
+
+        options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ELECTLEADER);
+
+        if (rd_kafka_AdminOptions_set_request_timeout(
+                options, 10 * 1000 /* 10s */, errstr, sizeof(errstr))) {
+                fprintf(stderr, "%% Failed to set timeout: %s\n", errstr);
+                goto exit;
+        }
+
+        if(rd_kafka_AdminOptions_set_operation_timeout(
+                options, 10 * 1000 /* 10s */, errstr, sizeof(errstr))) {
+                fprintf(stderr, "%% Failed to set operation timeout: %s\n", errstr);
+                goto exit;
+        }
+
+        rd_kafka_ElectLeader(rk, elect_leader, options, queue);
+        rd_kafka_ElectLeader_destroy(elect_leader);
+        rd_kafka_AdminOptions_destroy(options);
+        
+        
+        /* Wait for results */
+        event = rd_kafka_queue_poll(queue, -1 /* indefinitely but limited by
+                                               * the request timeout set
+                                               * above (10s) */);
+        
+        if (!event) {
+                /* User hit Ctrl-C,
+                 * see yield call in stop() signal handler */
+                fprintf(stderr, "%% Cancelled by user\n");
+
+        } else if (rd_kafka_event_error(event)) {
+                rd_kafka_resp_err_t err = rd_kafka_event_error(event);
+                /* ElectLeaders request failed */
+                fprintf(stderr, "%% ElectLeaders failed[%" PRId32 "]: %s\n", err,
+                        rd_kafka_event_error_string(event));
+                goto exit;
+        } else {
+                /* ElectLeaders request succeeded */
+                const rd_kafka_ElectLeader_result_t *result;
+                result = rd_kafka_event_ElectLeader_result(event);
+                retval = print_elect_leader_result(result);
+        }
+
+
+exit:
+        if (event)
+                rd_kafka_event_destroy(event);
+
+        rd_kafka_queue_destroy(queue);
+        /* Destroy the client instance */
+        rd_kafka_destroy(rk);
+
+        exit(retval);
+        
+}
+
+
+int main(int argc, char **argv) {
+        rd_kafka_conf_t *conf; /**< Client configuration object */
+        int opt;
+        argv0 = argv[0];
+
+        /*
+         * Create Kafka client configuration place-holder
+         */
+        conf = rd_kafka_conf_new();
+
+
+        /*
+         * Parse common options
+         */
+        while ((opt = getopt(argc, argv, "b:X:d:")) != -1) {
+                switch (opt) {
+                case 'b':
+                        conf_set(conf, "bootstrap.servers", optarg);
+                        break;
+
+                case 'X': {
+                        char *name = optarg, *val;
+
+                        if (!(val = strchr(name, '=')))
+                                fatal("-X expects a name=value argument");
+
+                        *val = '\0';
+                        val++;
+
+                        conf_set(conf, name, val);
+                        break;
+                }
+
+                case 'd':
+                        conf_set(conf, "debug", optarg);
+                        break;
+
+                default:
+                        usage("Unknown option %c", (char)opt);
+                }
+        }
+
+        cmd_elect_leader(conf, argc - optind, &argv[optind]);
+
+        return 0;
+}

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -1668,7 +1668,8 @@ static void rd_kafka_AdminOptions_init(rd_kafka_t *rk,
             options->for_api == RD_KAFKA_ADMIN_OP_DELETETOPICS ||
             options->for_api == RD_KAFKA_ADMIN_OP_CREATEPARTITIONS ||
             options->for_api == RD_KAFKA_ADMIN_OP_DELETERECORDS ||
-            options->for_api == RD_KAFKA_ADMIN_OP_LISTOFFSETS)
+            options->for_api == RD_KAFKA_ADMIN_OP_LISTOFFSETS  ||
+            options->for_api == RD_KAFKA_ADMIN_OP_ELECTLEADER)
                 rd_kafka_confval_init_int(&options->operation_timeout,
                                           "operation_timeout", -1, 3600 * 1000,
                                           rk->rk_conf.admin.request_timeout_ms);
@@ -4107,6 +4108,292 @@ rd_kafka_ListOffsetsResponse_parse(rd_kafka_op_t *rko_req,
         *rko_resultp = rko_result;
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
+
+/**@}*/
+
+/**
+ * @name ElectLeader
+ * @{
+ *
+ *
+ *
+ *
+ */
+
+
+/**
+ * @brief Creates a new rd_kafka_ListOffsets_t object with the given
+ *       \p topic_partitions and \p electionType.
+ 
+*/
+
+rd_kafka_ElectLeader_t *rd_kafka_ElectLeader_new(rd_kafka_ElectionType_t election_type,
+                                                 rd_kafka_topic_partition_list_t *partitions) {
+
+        rd_kafka_ElectLeader_t *elect_leader;
+
+        elect_leader = rd_calloc(1, sizeof(*elect_leader));
+        elect_leader->partitions =
+            rd_kafka_topic_partition_list_copy(partitions);
+        elect_leader->electionType = election_type;
+
+        return elect_leader;
+}
+
+/**
+ * @brief Copies the rd_kafka_ElectLeader_t object.
+ */
+
+rd_kafka_ElectLeader_t *rd_kafka_ElectLeader_copy(const rd_kafka_ElectLeader_t *elect_leader) {
+        return rd_kafka_ElectLeader_new(elect_leader->electionType, elect_leader->partitions);
+}
+
+/**
+ * @brief Returns the list of partitions in the rd_kafka_ElectLeader_t object.
+ */
+
+const rd_kafka_topic_partition_list_t *rd_kafka_ElectLeader_partitions(const rd_kafka_ElectLeader_t *elect_leader) {
+        return elect_leader->partitions;
+}
+
+/**
+ * @brief Returns the election type of the rd_kafka_ElectLeader_t object.
+ */
+
+rd_kafka_ElectionType_t rd_kafka_ElectLeader_election_type(const rd_kafka_ElectLeader_t *elect_leader) {
+        return elect_leader->electionType;
+}
+
+/**
+ * @brief Destroys the rd_kafka_ElectLeader_t object.
+*/
+void rd_kafka_ElectLeader_destroy(rd_kafka_ElectLeader_t *elect_leader) {
+        rd_kafka_topic_partition_list_destroy(elect_leader->partitions);
+        rd_free(elect_leader);
+}
+
+static void rd_kafka_ElectLeader_free(void *ptr) {
+        rd_kafka_ElectLeader_destroy(ptr);
+}
+
+/**
+ * @brief Creates a new rd_kafka_ElectLeaderResult_t object with the given
+ *       \p error.
+*/
+static rd_kafka_ElectLeaderResult_t *rd_kafka_ElectLeaderResult_new(
+         rd_kafka_resp_err_t err) {
+        
+        rd_kafka_ElectLeaderResult_t *result;
+        result = rd_calloc(1, sizeof(*result));
+
+        result->error_code = err;
+        rd_list_init(&result->partitions, 0, rd_kafka_topic_partition_result_free);
+        
+        return result;
+}
+
+/**
+ * @brief Returns the rd_kafka_ElectLeaderResult_t object from the
+ *        rd_kafka_ElectLeader_result_t object.
+*/
+
+static const rd_kafka_ElectLeaderResult_t *rd_kafka_ElectLeader_result(
+        const rd_kafka_ElectLeader_result_t *result) {
+        return (const rd_kafka_ElectLeaderResult_t *)rd_list_elem(&result->rko_u.admin_result.results, 0);
+}
+
+/**
+ * @brief Returns the error of the rd_kafka_ElectLeaderResult_t object.
+*/
+
+rd_kafka_resp_err_t rd_kafka_ElectionResult_error(
+        const rd_kafka_ElectLeader_result_t *result) {
+                const rd_kafka_ElectLeaderResult_t *res;
+                res = rd_kafka_ElectLeader_result(result);
+        return res->error_code;
+}
+
+/**
+ * @brief Returns the array of rd_kafka_topic_partition_result_t objects from the
+ *        rd_kafka_ElectLeader_result_t event and populate the size of the array in cntp.
+*/
+
+const rd_kafka_topic_partition_result_t **rd_kafka_ElectionResult_partition(
+        const rd_kafka_ElectLeader_result_t *result, 
+        size_t *cntp) {
+        
+        const rd_kafka_ElectLeaderResult_t *res;
+
+        res = rd_kafka_ElectLeader_result(result);
+        *cntp = rd_list_cnt(&res->partitions);
+
+        return (const rd_kafka_topic_partition_result_t **)res->partitions.rl_elems;
+}
+
+const rd_kafka_topic_partition_result_t *rd_kafka_ElectionResult_partition_by_idx(
+        const rd_kafka_topic_partition_result_t **result, 
+        size_t idx) {
+        return result[idx];
+}
+
+/**
+ * @brief Destroys the rd_kafka_ElectLeaderResult_t object.
+*/
+
+static void rd_kafka_ElectLeaderResult_destroy(rd_kafka_ElectLeaderResult_t *result) {
+        rd_list_destroy(&result->partitions);
+        rd_free(result);
+}
+
+static void rd_kafka_ElectLeaderResult_free(void *ptr) {
+        rd_kafka_ElectLeaderResult_destroy(ptr);
+}
+
+
+
+/**
+ * @brief Parse ElectLeaderResponse and create ADMIN_RESULT op.
+ * 
+ * @param rko_req The original request op.
+ * @param rko_resultp The resulting ADMIN_RESULT op.
+ * @param reply The response buffer.
+ * @param errstr The error string buffer.
+ * @param errstr_size The size of the error string buffer.
+*/
+static rd_kafka_resp_err_t rd_kafka_ElectLeaderResponse_parse(
+    rd_kafka_op_t *rko_req, 
+    rd_kafka_op_t **rko_resultp, 
+    rd_kafka_buf_t *reply,
+    char *errstr, 
+    size_t errstr_size) {
+        const int log_decode_errors = LOG_ERR;
+        rd_kafka_op_t *rko_result = NULL;
+        rd_kafka_ElectLeaderResult_t *result = NULL;
+        int16_t error_code = 0;
+        int32_t TopicArrayCnt;
+        int i;
+
+        rd_kafka_buf_read_throttle_time(reply);
+
+        if(rd_kafka_buf_ApiVersion(reply) >= 1){
+                rd_kafka_buf_read_i16(reply, &error_code);
+        }
+        
+        /* #partitions */
+        rd_kafka_buf_read_arraycnt(reply, &TopicArrayCnt, RD_KAFKAP_TOPICS_MAX);
+
+        result = rd_kafka_ElectLeaderResult_new(error_code);
+
+        for (i = 0; i < TopicArrayCnt; i++) {
+                rd_kafka_topic_partition_result_t *desc;
+                rd_kafkap_str_t ktopic;
+                char *topic = NULL;
+                int32_t partition = -1;
+                int16_t error_code = 0;
+                rd_kafkap_str_t error_msg;
+                char *this_errstr = NULL;
+                int32_t PartArrayCnt;
+
+                rd_kafka_buf_read_str(reply, &ktopic);
+                RD_KAFKAP_STR_DUPA(&topic, &ktopic);
+
+                rd_kafka_buf_read_arraycnt(reply, &PartArrayCnt, RD_KAFKAP_PARTITIONS_MAX);
+
+                while (PartArrayCnt-- > 0) {
+                        rd_kafka_buf_read_i32(reply, &partition);
+                        rd_kafka_buf_read_i16(reply, &error_code);
+                        rd_kafka_buf_read_str(reply, &error_msg);
+                        rd_kafka_buf_skip_tags(reply);
+
+                        if (error_code) {
+                                if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||
+                                    RD_KAFKAP_STR_LEN(&error_msg) == 0)
+                                        this_errstr =
+                                            (char *)rd_kafka_err2str(error_code);
+                                else
+                                        RD_KAFKAP_STR_DUPA(&this_errstr, &error_msg);
+                        }
+
+                        desc = rd_kafka_topic_partition_result_new(topic, partition,
+                                              error_code, this_errstr);
+                        
+                        rd_list_add(&result->partitions, desc);
+                }
+                rd_kafka_buf_skip_tags(reply);
+        }
+
+        rd_kafka_buf_skip_tags(reply);
+
+        rko_result = rd_kafka_admin_result_new(rko_req);
+
+        rd_list_init(&rko_result->rko_u.admin_result.results, 1,
+                     rd_kafka_ElectLeaderResult_free);
+
+        rd_list_add(&rko_result->rko_u.admin_result.results, result);
+
+        *rko_resultp = rko_result;
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+err_parse:
+
+        if (result)
+                rd_kafka_ElectLeaderResult_destroy(result);
+        if (rko_result)
+                rd_kafka_op_destroy(rko_result);
+
+        rd_snprintf(errstr, errstr_size,
+                    "ElectLeader response protocol parse failure: %s",
+                    rd_kafka_err2str(reply->rkbuf_err));
+
+        return reply->rkbuf_err;
+}
+
+void rd_kafka_ElectLeader(rd_kafka_t *rk,
+                          rd_kafka_ElectLeader_t *elect_leader,
+                          const rd_kafka_AdminOptions_t *options,
+                          rd_kafka_queue_t *rkqu) {
+        rd_kafka_op_t *rko;
+        rd_kafka_topic_partition_list_t *copied_partitions;
+
+        static const struct rd_kafka_admin_worker_cbs cbs = {
+            rd_kafka_ElectLeaderRequest,
+            rd_kafka_ElectLeaderResponse_parse,
+        };
+
+        rd_assert(rkqu);
+
+        rko = rd_kafka_admin_request_op_new(
+            rk, RD_KAFKA_OP_ELECTLEADER, RD_KAFKA_EVENT_ELECTLEADER_RESULT, &cbs,
+            options, rkqu->rkqu_q);
+
+        /* Non empty topic_partition_list should be present */
+        if(elect_leader->partitions->cnt == 0){
+                rd_kafka_admin_result_fail(rko, RD_KAFKA_RESP_ERR__INVALID_ARG,
+                                           "No partitions specified");
+                rd_kafka_admin_common_worker_destroy(rk, rko,
+                                                     rd_true /*destroy*/);
+                return;
+        }
+        
+        /* Duplicate topic partitions should not be present in the list */
+        copied_partitions = rd_kafka_topic_partition_list_copy(elect_leader->partitions);
+        if(rd_kafka_topic_partition_list_has_duplicates(copied_partitions,rd_false /* check partition*/)){
+                rd_kafka_admin_result_fail(rko, RD_KAFKA_RESP_ERR__INVALID_ARG,
+                                           "Duplicate partitions specified");
+                rd_kafka_admin_common_worker_destroy(rk, rko,
+                                                     rd_true /*destroy*/);
+                return;
+        }
+
+        rd_list_init(&rko->rko_u.admin_request.args, 1,
+                     rd_kafka_ElectLeader_free);
+
+        rd_list_add(&rko->rko_u.admin_request.args, rd_kafka_ElectLeader_copy(elect_leader));
+
+        rd_kafka_q_enq(rk->rk_ops, rko);
+}
+
+/**@}*/
 
 /**
  * @brief Should the received error code cause a metadata refresh?
@@ -7046,7 +7333,7 @@ void rd_kafka_ListConsumerGroupOffsets(
                                            "ListConsumerGroupOffsets must "
                                            "be passed");
                 goto fail;
-        }
+        } 
 
         if (list_grpoffsets[0]->partitions != NULL &&
             list_grpoffsets[0]->partitions->cnt == 0) {

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -430,6 +430,29 @@ struct rd_kafka_DeleteAcls_result_response_s {
         rd_list_t matching_acls; /**< Type (rd_kafka_AclBinding_t *) */
 };
 
+/**
+ * @name ElectLeader
+*/
+
+/**
+ * @struct ElectLeader request object
+*/
+
+struct rd_kafka_ElectLeader_s {
+        rd_kafka_ElectionType_t electionType;  /*Election Type*/
+        rd_kafka_topic_partition_list_t *partitions;  /*TopicPartitions for election*/
+};
+
+
+/**
+ * @struct ElectLeader result object
+ */
+
+typedef struct rd_kafka_ElectLeaderResult_s {
+        rd_kafka_resp_err_t error_code;
+        rd_list_t partitions; /**< Type (rd_kafka_topic_partition_error_t *) */
+} rd_kafka_ElectLeaderResult_t;
+
 /**@}*/
 
 /**

--- a/src/rdkafka_aux.c
+++ b/src/rdkafka_aux.c
@@ -332,3 +332,84 @@ uint16_t rd_kafka_Node_port(const rd_kafka_Node_t *node) {
 const char *rd_kafka_Node_rack(const rd_kafka_Node_t *node) {
         return node->rack;
 }
+
+/**
+ * @brief Creates a new rd_kafka_topic_partition_result_t object with the given
+ *       \p topic \p partition \p error and \p error string.
+*/
+
+rd_kafka_topic_partition_result_t *rd_kafka_topic_partition_result_new(const char *topic, 
+                                                                       int32_t partition, 
+                                                                       rd_kafka_resp_err_t err, 
+                                                                       const char *errstr) {
+
+        rd_kafka_topic_partition_result_t *desc;
+
+        desc = rd_calloc(1, sizeof(*desc));
+        desc->topic = rd_strdup(topic);
+        desc->partition = partition;
+        desc->err = err;
+        desc->errstr = rd_strdup(errstr);
+
+        return desc;
+}
+
+/**
+ * @brief Returns the topic of the rd_kafka_topic_partition_result_t object.
+*/
+
+const char* rd_kafka_topic_partition_result_topic(const rd_kafka_topic_partition_result_t *desc) {
+        return desc->topic;
+}
+
+/**
+ * @brief Returns the partition of the rd_kafka_topic_partition_result_t object.
+*/
+
+int32_t rd_kafka_topic_partition_result_partition(const rd_kafka_topic_partition_result_t *desc) {
+        return desc->partition;
+}
+
+/**
+ * @brief Returns the error of the rd_kafka_topic_partition_result_t object.
+*/
+
+rd_kafka_resp_err_t rd_kafka_topic_partition_result_error(const rd_kafka_topic_partition_result_t *desc) {
+        return desc->err;
+}
+
+/**
+ * @brief Returns the error string of the rd_kafka_topic_partition_result_t object.
+*/
+
+const char* rd_kafka_topic_partition_result_error_string(const rd_kafka_topic_partition_result_t *desc) {
+        return desc->errstr;
+}
+
+/**
+ * @brief Destroys the rd_kafka_topic_partition_result_t object.
+*/
+
+void rd_kafka_topic_partition_result_destroy(rd_kafka_topic_partition_result_t *desc) {
+        rd_free(desc->topic);
+        rd_free(desc->errstr);
+        rd_free(desc);
+}
+
+/**
+ * @brief Destroys the array of rd_kafka_topic_partition_result_t objects.
+*/
+
+void rd_kafka_topic_partition_result_destroy_array(
+    rd_kafka_topic_partition_result_t **descs,
+    int32_t desc_cnt) {
+        int32_t i;
+        for (i = 0; i < desc_cnt; i++){
+                rd_kafka_topic_partition_result_destroy(descs[i]);
+        }
+}
+
+void rd_kafka_topic_partition_result_free(void *ptr) {
+        rd_kafka_topic_partition_result_destroy(ptr);
+}
+

--- a/src/rdkafka_aux.h
+++ b/src/rdkafka_aux.h
@@ -128,4 +128,20 @@ void rd_kafka_Node_destroy(rd_kafka_Node_t *node);
 
 void rd_kafka_Node_free(void *node);
 
+/**
+ * @brief Topic + partition + ErrorCode + ErrorString
+ * 
+ * @remark Public Type
+*/
+struct rd_kafka_topic_partition_result_s {
+        char *topic;
+        int32_t partition;
+        rd_kafka_resp_err_t err;
+        char *errstr;
+};
+
+void rd_kafka_topic_partition_result_destroy(rd_kafka_topic_partition_result_t *desc);
+ 
+void rd_kafka_topic_partition_result_free(void *ptr);
+
 #endif /* _RDKAFKA_AUX_H_ */

--- a/src/rdkafka_event.c
+++ b/src/rdkafka_event.c
@@ -97,6 +97,8 @@ const char *rd_kafka_event_name(const rd_kafka_event_t *rkev) {
                 return "AlterUserScramCredentials";
         case RD_KAFKA_EVENT_LISTOFFSETS_RESULT:
                 return "ListOffsetsResult";
+        case RD_KAFKA_EVENT_ELECTLEADER_RESULT:
+                return "ElectLeaderResult";
         default:
                 return "?unknown?";
         }
@@ -489,4 +491,12 @@ rd_kafka_event_ListConsumerGroupOffsets_result(rd_kafka_event_t *rkev) {
                 return NULL;
         else
                 return (const rd_kafka_ListConsumerGroupOffsets_result_t *)rkev;
+}
+
+const rd_kafka_ElectLeader_result_t *
+rd_kafka_event_ElectLeader_result(rd_kafka_event_t *rkev) {
+        if (!rkev || rkev->rko_evtype != RD_KAFKA_EVENT_ELECTLEADER_RESULT)
+                return NULL;
+        else
+                return (const rd_kafka_ElectLeader_result_t *)rkev;
 }

--- a/src/rdkafka_event.h
+++ b/src/rdkafka_event.h
@@ -117,6 +117,7 @@ static RD_UNUSED RD_INLINE int rd_kafka_event_setup(rd_kafka_t *rk,
         case RD_KAFKA_EVENT_DESCRIBEUSERSCRAMCREDENTIALS_RESULT:
         case RD_KAFKA_EVENT_ALTERUSERSCRAMCREDENTIALS_RESULT:
         case RD_KAFKA_EVENT_LISTOFFSETS_RESULT:
+        case RD_KAFKA_EVENT_ELECTLEADER_RESULT:
                 return 1;
 
         default:

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -122,7 +122,7 @@ const char *rd_kafka_op2str(rd_kafka_op_type_t type) {
                 "REPLY:RD_KAFKA_OP_SET_TELEMETRY_BROKER",
             [RD_KAFKA_OP_TERMINATE_TELEMETRY] =
                 "REPLY:RD_KAFKA_OP_TERMINATE_TELEMETRY",
-
+            [RD_KAFKA_OP_ELECTLEADER] = "REPLY:ELECTLEADER",
         };
 
         if (type & RD_KAFKA_OP_REPLY)
@@ -286,6 +286,7 @@ rd_kafka_op_t *rd_kafka_op_new0(const char *source, rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_SET_TELEMETRY_BROKER] =
                 sizeof(rko->rko_u.telemetry_broker),
             [RD_KAFKA_OP_TERMINATE_TELEMETRY] = _RD_KAFKA_OP_EMPTY,
+            [RD_KAFKA_OP_ELECTLEADER] = sizeof(rko->rko_u.admin_request),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 
@@ -439,6 +440,7 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_ALTERUSERSCRAMCREDENTIALS:
         case RD_KAFKA_OP_DESCRIBEUSERSCRAMCREDENTIALS:
         case RD_KAFKA_OP_LISTOFFSETS:
+        case RD_KAFKA_OP_ELECTLEADER:
                 rd_kafka_replyq_destroy(&rko->rko_u.admin_request.replyq);
                 rd_list_destroy(&rko->rko_u.admin_request.args);
                 if (rko->rko_u.admin_request.options.match_consumer_group_states

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -162,6 +162,9 @@ typedef enum {
         RD_KAFKA_OP_LISTCONSUMERGROUPOFFSETS,  /**< Admin:
                                                 *   ListConsumerGroupOffsets
                                                 *   u.admin_request */
+        RD_KAFKA_OP_ELECTLEADER,               /**< Admin:
+                                                *   ElectLeader
+                                                *   u.admin_request */
         RD_KAFKA_OP_ADMIN_FANOUT,              /**< Admin: fanout request */
         RD_KAFKA_OP_ADMIN_RESULT,              /**< Admin API .._result_t */
         RD_KAFKA_OP_PURGE,                     /**< Purge queues */

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -619,6 +619,16 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
                            rd_kafka_resp_cb_t *resp_cb,
                            void *opaque);
 
+rd_kafka_resp_err_t 
+rd_kafka_ElectLeaderRequest(rd_kafka_broker_t *rkb,
+                            const rd_list_t *elect_leaders /*(rd_kafka_EleactLeader_t*)*/,
+                            rd_kafka_AdminOptions_t *options,
+                            char *errstr,
+                            size_t errstr_size,
+                            rd_kafka_replyq_t replyq,
+                            rd_kafka_resp_cb_t *resp_cb,
+                            void *opaque);
+
 void rd_kafkap_leader_discovery_tmpabuf_add_alloc_brokers(
     rd_tmpabuf_t *tbuf,
     rd_kafkap_NodeEndpoints_t *NodeEndpoints);

--- a/tests/0080-admin_ut.c
+++ b/tests/0080-admin_ut.c
@@ -2355,6 +2355,183 @@ static void do_test_AlterUserScramCredentials(const char *what,
         SUB_TEST_PASS();
 }
 
+static void do_test_ElectLeaders(const char* what, 
+                                 rd_kafka_t *rk,
+                                 rd_kafka_queue_t *useq, 
+                                 int with_options, 
+                                 int etype) {
+        rd_kafka_queue_t *q;
+        rd_kafka_AdminOptions_t *options = NULL;
+        rd_kafka_event_t *rkev;
+        rd_kafka_resp_err_t err;
+        const rd_kafka_ElectLeader_result_t *res;
+        rd_kafka_ElectLeader_t *empty_elect_leader;
+        rd_kafka_ElectLeader_t *duplicate_elect_leader;
+        rd_kafka_ElectLeader_t *elect_leader;
+        int exp_timeout = MY_SOCKET_TIMEOUT_MS;
+        test_timing_t timing;
+        rd_kafka_ElectionType_t election_type;
+        rd_kafka_topic_partition_list_t *partitions;
+        char errstr[512];
+        void *my_opaque = NULL, *opaque;
+
+        if(etype == 0){
+                election_type = RD_KAFKA_ELECTION_TYPE_PREFERRED;
+        }
+        else{
+                election_type = RD_KAFKA_ELECTION_TYPE_UNCLEAN;
+        }
+
+        SUB_TEST_QUICK("%s ElectLeader with %s, timeout %dms",
+                       rd_kafka_name(rk), what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        partitions = rd_kafka_topic_partition_list_new(3);
+        rd_kafka_topic_partition_list_add(partitions, "topic1", 9);
+        rd_kafka_topic_partition_list_add(partitions, "topic3", 15);
+        rd_kafka_topic_partition_list_add(partitions, "topic1", 1);
+        elect_leader = rd_kafka_ElectLeader_new(election_type, partitions);
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        partitions = rd_kafka_topic_partition_list_new(0);
+        empty_elect_leader = rd_kafka_ElectLeader_new(election_type, partitions);
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        partitions = rd_kafka_topic_partition_list_new(3);
+        rd_kafka_topic_partition_list_add(partitions, "topic1", 9);
+        rd_kafka_topic_partition_list_add(partitions, "topic3", 15);
+        rd_kafka_topic_partition_list_add(partitions, "topic1", 9);
+        duplicate_elect_leader = rd_kafka_ElectLeader_new(election_type, partitions);
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(
+                    rk, RD_KAFKA_ADMIN_OP_ELECTLEADER);
+
+                exp_timeout = MY_SOCKET_TIMEOUT_MS ;
+
+                err = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+                if(useq){
+                        my_opaque = (void *)99981;
+                        rd_kafka_AdminOptions_set_opaque(options, my_opaque);
+                }
+        }
+        
+        /*Empty topic-partition list*/
+        TIMING_START(&timing, "ElectLeaders");
+        TEST_SAY("Call ElectLeaders, timeout is %dms\n",
+                 exp_timeout);
+        rd_kafka_ElectLeader(rk, empty_elect_leader, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 10);
+        rd_kafka_ElectLeader_destroy(empty_elect_leader);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "ElectLeaders.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("ElectLeaders: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Convert event to proper result */
+        res = rd_kafka_event_ElectLeader_result(rkev);
+        TEST_ASSERT(res, "expected ElectLeader_result, not %s",
+                    rd_kafka_event_name(rkev));
+        /*Expecting error*/
+        err = rd_kafka_event_error(rkev);
+        const char *event_errstr_empty = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err, "expected ElectLeader to fail");
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected RD_KAFKA_RESP_ERR__INVALID_ARG, not %s",
+                    rd_kafka_err2name(err));
+        TEST_ASSERT(strcmp(event_errstr_empty,
+                           "No partitions specified") == 0,
+                        "expected \"No partitions specified\", not \"%s\"",
+                        event_errstr_empty);
+        rd_kafka_event_destroy(rkev);
+        
+        /*Duplicate topic-partition list*/
+        TIMING_START(&timing, "ElectLeaders");
+        TEST_SAY("Call ElectLeaders, timeout is %dms\n",
+                 exp_timeout);
+        rd_kafka_ElectLeader(rk, duplicate_elect_leader, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 10);
+        rd_kafka_ElectLeader_destroy(duplicate_elect_leader);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "ElectLeaders.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("ElectLeaders: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
+        
+        /* Convert event to proper result */
+        res = rd_kafka_event_ElectLeader_result(rkev);
+        TEST_ASSERT(res, "expected ElectLeader_result, not %s",
+                    rd_kafka_event_name(rkev));
+        /*Expecting error*/
+        err = rd_kafka_event_error(rkev);
+        const char *event_errstr_duplicate = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err, "expected ElectLeader to fail");
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected RD_KAFKA_RESP_ERR__INVALID_ARG, not %s",
+                    rd_kafka_err2name(err));
+        TEST_ASSERT(strcmp(event_errstr_duplicate, "Duplicate partitions specified") == 0,
+                    "expected \"Duplicate partitions specified\", not \"%s\"",
+                    event_errstr_duplicate);
+        rd_kafka_event_destroy(rkev);
+
+        /*Correct topic-partition list*/
+        TIMING_START(&timing, "ElectLeaders");
+        TEST_SAY("Call ElectLeaders, timeout is %dms\n",
+                 exp_timeout);
+        rd_kafka_ElectLeader(rk, elect_leader, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 10);
+        rd_kafka_ElectLeader_destroy(elect_leader);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "ElectLeaders.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("ElectLeaders: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
+        
+        /* Convert event to proper result */
+        res = rd_kafka_event_ElectLeader_result(rkev);
+        TEST_ASSERT(res, "expected ElectLeader_result, not %s",
+                    rd_kafka_event_name(rkev));
+        opaque = rd_kafka_event_opaque(rkev);
+        TEST_ASSERT(opaque == my_opaque, "expected opaque to be %p, not %p",
+                    my_opaque, opaque);
+        /*Expecting error*/
+        err = rd_kafka_event_error(rkev);
+        const char *event_err = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err, "expected ElectLeader to fail");
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected RD_KAFKA_RESP_ERR__TIMED_OUT, not %s",
+                    rd_kafka_err2name(err));
+        TEST_ASSERT(strcmp(event_err, 
+                          "Failed while waiting for controller: "
+                          "Local: Timed out") == 0,
+                        "expected \"Failed while waiting for controller: "
+                        "Local: Timed out\", not \"%s\"",
+                        event_err);
+        rd_kafka_event_destroy(rkev);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+        if(!useq)
+                rd_kafka_queue_destroy(q);
+        
+        SUB_TEST_PASS();
+}
+
 /**
  * @brief Test a mix of APIs using the same replyq.
  *
@@ -2612,6 +2789,7 @@ static void do_test_options(rd_kafka_t *rk) {
                     RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPOFFSETS,                \
                     RD_KAFKA_ADMIN_OP_ALTERCONSUMERGROUPOFFSETS,               \
                     RD_KAFKA_ADMIN_OP_DELETECONSUMERGROUPOFFSETS,              \
+                    RD_KAFKA_ADMIN_OP_ELECTLEADER,                             \
                     RD_KAFKA_ADMIN_OP_ANY /* Must be last */                   \
         }
         struct {
@@ -2622,7 +2800,8 @@ static void do_test_options(rd_kafka_t *rk) {
             {"operation_timeout",
              {RD_KAFKA_ADMIN_OP_CREATETOPICS, RD_KAFKA_ADMIN_OP_DELETETOPICS,
               RD_KAFKA_ADMIN_OP_CREATEPARTITIONS,
-              RD_KAFKA_ADMIN_OP_DELETERECORDS}},
+              RD_KAFKA_ADMIN_OP_DELETERECORDS,
+              RD_KAFKA_ADMIN_OP_ELECTLEADER}},
             {"validate_only",
              {RD_KAFKA_ADMIN_OP_CREATETOPICS,
               RD_KAFKA_ADMIN_OP_CREATEPARTITIONS,
@@ -2875,6 +3054,15 @@ static void do_test_apis(rd_kafka_type_t cltype) {
 
         do_test_AlterUserScramCredentials("main queue", rk, mainq);
         do_test_AlterUserScramCredentials("temp queue", rk, NULL);
+
+        do_test_ElectLeaders("main queue, options, Preffered Elections", rk, mainq, 1, 0);
+        do_test_ElectLeaders("main queue, options, Unclean Elections", rk, mainq, 1, 1);
+        do_test_ElectLeaders("main queue, no options, Preffered Elections", rk, mainq, 0, 0);
+        do_test_ElectLeaders("main queue, no options, Unclean Elections", rk, mainq, 0, 1);
+        do_test_ElectLeaders("temp queue, options, Preffered Elections", rk, NULL, 1, 0);
+        do_test_ElectLeaders("temp queue, options, Unclean Elections", rk, NULL, 1, 1);
+        do_test_ElectLeaders("temp queue, no options, Preffered Elections", rk, NULL, 0, 0);
+        do_test_ElectLeaders("temp queue, no options, Unclean Elections", rk, NULL, 0, 1);
 
         do_test_mix(rk, mainq);
 


### PR DESCRIPTION
This PR introduces the public API rd_kafka_ElectLeaders, enabling the execution of Preferred or Unclean leader election for specific topic partitions. Additionally, unit tests are also included.