### PR TITLE
ssl: support libssls with no ENGINE implementation

### DIFF
--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -34,7 +34,7 @@
 #include "rdkafka_cert.h"
 
 #if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10100000 &&                        \
-    !defined(OPENSSL_IS_BORINGSSL)
+    !defined(OPENSSL_NO_ENGINE)
 #define WITH_SSL_ENGINE 1
 /* Deprecated in OpenSSL 3 */
 #include <openssl/engine.h>


### PR DESCRIPTION
OpenSSL can be built without ENGINE support, and some libssl-compatible forks (e.g. BoringSSL) don't contain any ENGINE implementation at all - guard all references to the ENGINE API using OPENSSL_NO_ENGINE so these libssls can be used with librdkafka.

The definition of WITH_SSL_ENGINE incorrectly assumes that libssl is always built with support for the ENGINE API if it is provided by OpenSSL >= 1.1.0 or LibreSSL. OPENSSL_NO_ENGINE is defined by OpenSSL and all of its forks if the ENGINE API was disabled at compile-time - ensure that the definition of OPENSSL_NO_ENGINE is taken into account
when defining WITH_SSL_ENGINE.

Without this PR, it might impact some linux users to adopt librdkafka project because some Linux distros are removing openssl engines support from their openssl package (ex: [fedora](https://discussion.fedoraproject.org/t/f41-change-proposal-disable-openssl-engine-support-system-wide/107511)).

Note: This PR is from https://github.com/confluentinc/librdkafka/pull/3535 (which had approved by @edenhill) , since the change log version is out-dated, and the original author is not working on it anymore.

Co-authored-by: Chris Novakovic <chris@chrisn.me.uk>