### PR TITLE
remove the old id from the cache

### DIFF
--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -379,7 +379,8 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
                 /* If topic id isn't zero insert cache entry into this tree */
                 old_by_id = RD_AVL_INSERT(&rk->rk_metadata_cache.rkmc_avl_by_id,
                                           rkmce, rkmce_avlnode_by_id);
-        } else if (old && !RD_KAFKA_UUID_IS_ZERO(
+        } 
+        if (old && !RD_KAFKA_UUID_IS_ZERO(
                               old->rkmce_metadata_internal_topic.topic_id)) {
                 /* If it had a topic id, remove it from the tree */
                 RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl_by_id, old);


### PR DESCRIPTION
Fixes https://github.com/confluentinc/librdkafka/issues/4778

This PR addresses a subtle issue in handling topic IDs during metadata cache insertion. Separating this condition ensures that old entries with non-zero topic IDs are always properly removed from the metadata cache.
Removing the entity from the `rkmc_avl` tree but not removing the old entry with non-zero topic IDs from the `rkmc_avl_by_id` tree led to an inconsistent cache state. Eventually, it led to memory corruption ("use after free" errors).

### Testing
My test application re-creates (deletes and creates) three thousand topics. Then it immediately starts producer and consumer threads. Before the fix, the app crashed most of the time, after the fix crashes do not happen anymore.
