### PR TITLE
[KIP-460] Remove duplicate ElectLeaders result type

### DIFF
--- a/examples/elect_leaders.c
+++ b/examples/elect_leaders.c
@@ -123,11 +123,8 @@ print_elect_leaders_result(const rd_kafka_ElectLeaders_result_t *result) {
         const rd_kafka_topic_partition_result_t **results;
         size_t results_cnt;
         size_t i;
-        const rd_kafka_ElectLeadersResult_t *res;
 
-        res = rd_kafka_ElectLeaders_result(result);
-
-        results = rd_kafka_ElectLeadersResult_partitions(res, &results_cnt);
+        results = rd_kafka_ElectLeaders_result_partitions(result, &results_cnt);
         printf("ElectLeaders response has %zu partition(s):\n", results_cnt);
         for (i = 0; i < results_cnt; i++) {
                 const rd_kafka_topic_partition_t *partition =

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -10040,21 +10040,6 @@ RD_EXPORT void rd_kafka_ElectLeaders(rd_kafka_t *rk,
                                      rd_kafka_queue_t *rkqu);
 
 /**
- * @brief  A struct representing result of elect leaders admin operation.
- */
-typedef struct rd_kafka_ElectLeadersResult_s rd_kafka_ElectLeadersResult_t;
-
-/**
- * @brief Get the elect leaders result from the elect leaders result event.
- *
- * @param result The elect leaders result event.
- *
- * @returns the elect leaders result from the elect leaders result event.
- */
-RD_EXPORT const rd_kafka_ElectLeadersResult_t *
-rd_kafka_ElectLeaders_result(const rd_kafka_ElectLeaders_result_t *result);
-
-/**
  * @brief Get the array of topic partition result objects from the
  *        elect leaders result event and populates the size of the
  *        array in \p cntp.
@@ -10066,17 +10051,9 @@ rd_kafka_ElectLeaders_result(const rd_kafka_ElectLeaders_result_t *result);
  *          elect leaders result event.
  */
 RD_EXPORT const rd_kafka_topic_partition_result_t **
-rd_kafka_ElectLeadersResult_partitions(
-    const rd_kafka_ElectLeadersResult_t *result,
+rd_kafka_ElectLeaders_result_partitions(
+    const rd_kafka_ElectLeaders_result_t *result,
     size_t *cntp);
-
-/**
- * @brief Destroy and free a rd_kafka_ElectLeadersResult_t object.
- *
- * @param result The rd_kafka_ElectLeadersResult_t object to be destroyed.
- */
-RD_EXPORT void
-rd_kafka_ElectLeadersResult_destroy(rd_kafka_ElectLeadersResult_t *result);
 
 /**@}*/
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -9187,13 +9187,7 @@ rd_kafka_ElectLeadersResult_new(rd_list_t *partitions) {
         return result;
 }
 
-const rd_kafka_ElectLeadersResult_t *
-rd_kafka_ElectLeaders_result(const rd_kafka_ElectLeaders_result_t *result) {
-        return (const rd_kafka_ElectLeadersResult_t *)rd_list_elem(
-            &result->rko_u.admin_result.results, 0);
-}
-
-const rd_kafka_topic_partition_result_t **
+static const rd_kafka_topic_partition_result_t **
 rd_kafka_ElectLeadersResult_partitions(
     const rd_kafka_ElectLeadersResult_t *result,
     size_t *cntp) {
@@ -9202,14 +9196,28 @@ rd_kafka_ElectLeadersResult_partitions(
             result->partitions.rl_elems;
 }
 
-void rd_kafka_ElectLeadersResult_destroy(
-    rd_kafka_ElectLeadersResult_t *result) {
+static void
+rd_kafka_ElectLeadersResult_destroy(rd_kafka_ElectLeadersResult_t *result) {
         rd_list_destroy(&result->partitions);
         rd_free(result);
 }
 
 static void rd_kafka_ElectLeadersResult_free(void *ptr) {
         rd_kafka_ElectLeadersResult_destroy(ptr);
+}
+
+static const rd_kafka_ElectLeadersResult_t *rd_kafka_ElectLeaders_result_result(
+    const rd_kafka_ElectLeaders_result_t *result) {
+        return (const rd_kafka_ElectLeadersResult_t *)rd_list_elem(
+            &result->rko_u.admin_result.results, 0);
+}
+
+const rd_kafka_topic_partition_result_t **
+rd_kafka_ElectLeaders_result_partitions(
+    const rd_kafka_ElectLeaders_result_t *result,
+    size_t *cntp) {
+        return rd_kafka_ElectLeadersResult_partitions(
+            rd_kafka_ElectLeaders_result_result(result), cntp);
 }
 
 /**

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -610,9 +610,9 @@ struct rd_kafka_ElectLeaders_s {
 /**
  * @struct ElectLeaders result object
  */
-struct rd_kafka_ElectLeadersResult_s {
+typedef struct rd_kafka_ElectLeadersResult_s {
         rd_list_t partitions; /**< Type (rd_kafka_topic_partition_result_t *) */
-};
+} rd_kafka_ElectLeadersResult_t;
 
 /**@}*/
 


### PR DESCRIPTION
from external API and avoid exposing internal destructor