### PR TITLE
Fix for a Fetch regression when connecting to Apache Kafka < 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 librdkafka v2.6.1 is a maintenance release:
 
- * Fix for a Fetch regression when connecting to Apache Kafka < 2.7 (#).
+ * Fix for a Fetch regression when connecting to Apache Kafka < 2.7 (#4871).
 
 
 ## Fixes
@@ -12,7 +12,7 @@ librdkafka v2.6.1 is a maintenance release:
  * Issues: #4870
    Fix for a Fetch regression when connecting to Apache Kafka < 2.7, causing
    fetches to fail.
-   Happening since v2.6.0 (#)
+   Happening since v2.6.0 (#4871)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# librdkafka v2.6.1
+
+librdkafka v2.6.1 is a maintenance release:
+
+ * Fix for a Fetch regression when connecting to Apache Kafka < 2.7 (#).
+
+
+## Fixes
+
+### Consumer fixes
+
+ * Issues: #4870
+   Fix for a Fetch regression when connecting to Apache Kafka < 2.7, causing
+   fetches to fail.
+   Happening since v2.6.0 (#)
+
+
+
 # librdkafka v2.6.0
 
 librdkafka v2.6.0 is a feature release:

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -996,8 +996,8 @@ int rd_kafka_broker_fetch_toppars(rd_kafka_broker_t *rkb, rd_ts_t now) {
 
         /* Fallback to version 12 if topic id is null which can happen if
          * inter.broker.protocol.version is < 2.8 */
-        ApiVersion =
-            ApiVersion > 12 && can_use_topic_ids(rkb) ? ApiVersion : 12;
+        if (ApiVersion > 12 && !can_use_topic_ids(rkb))
+                ApiVersion = 12;
 
         rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_Fetch, 1,


### PR DESCRIPTION
AK 2.7 is the first version implementing Fetch 12, before that it shouldn't fallback to v12, neither check if topic IDs are supported.

Closes #4870