### PR TITLE
Upgrade linux dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ librdkafka v2.6.1 is a maintenance release:
   scenario, if such request is made to the follower (#4616, #4754, @kphelps).
 * Fix to remove fetch queue messages that blocked the destroy of rdkafka
   instances (#4724)
+* Upgrade Linux dependencies: OpenSSL 3.0.15, CURL 8.10.1 (#4875).
 
 
 ## Fixes

--- a/mklove/modules/configure.libcurl
+++ b/mklove/modules/configure.libcurl
@@ -86,7 +86,7 @@ function install_source {
 	--disable-manual \
 	--disable-ldap{,s} \
 	--disable-libcurl-option \
-        --without-{librtmp,libidn2,winidn,nghttp2,nghttp3,ngtcp2,quiche,brotli} &&
+	--without-{librtmp,libidn2,winidn,nghttp2,nghttp3,ngtcp2,quiche,brotli,libpsl} &&
 	time make CPPFLAGS="$CPPFLAGS" -j &&
 	make DESTDIR="${destdir}" prefix=/usr install
     local ret=$?

--- a/mklove/modules/configure.libcurl
+++ b/mklove/modules/configure.libcurl
@@ -45,8 +45,8 @@ void foo (void) {
 function install_source {
     local name=$1
     local destdir=$2
-    local ver=8.8.0
-    local checksum="77c0e1cd35ab5b45b659645a93b46d660224d0024f1185e8a95cdb27ae3d787d"
+    local ver=8.10.1
+    local checksum="d15ebab765d793e2e96db090f0e172d127859d78ca6f6391d7eafecfd894bbc0"
 
     echo "### Installing $name $ver from source to $destdir"
     if [[ ! -f Makefile ]]; then

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -91,8 +91,8 @@ function manual_checks {
 function libcrypto_install_source {
     local name=$1
     local destdir=$2
-    local ver=3.0.13
-    local checksum="88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313"
+    local ver=3.0.15
+    local checksum="23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533"
     local url=https://www.openssl.org/source/openssl-${ver}.tar.gz
 
     local conf_args="--prefix=/usr --openssldir=/usr/lib/ssl no-shared no-zlib"


### PR DESCRIPTION
Security upgrade for OpenSSL and Curl, CVEs fixed:

OpenSSL
- CVE-2024-2511
- CVE-2024-4603
- CVE-2024-4741
- CVE-2024-5535
- CVE-2024-6119

CURL
- CVE-2024-8096
- CVE-2024-7264
- CVE-2024-6874
- CVE-2024-6197

Closes #4853 