### PR TITLE
SASL/SCRAM authentication fix: avoid concatenating client side nonce once more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,19 @@ librdkafka v2.6.1 is a maintenance release:
 * Upgrade Linux dependencies: OpenSSL 3.0.15, CURL 8.10.1 (#4875).
 * Upgrade Windows dependencies: MSVC runtime to 14.40.338160.0,
   zstd 1.5.6, zlib 1.3.1, OpenSSL 3.3.2, CURL 8.10.1 (#4872).
+* SASL/SCRAM authentication fix: avoid concatenating
+  client side nonce once more, as it's already prepended in server sent nonce (#4895).
 
 
 ## Fixes
+
+### General fixes
+
+* SASL/SCRAM authentication fix: avoid concatenating
+  client side nonce once more, as it's already prepended in 
+  server sent nonce.
+  librdkafka was incorrectly concatenating the client side nonce again, leading to [this fix](https://github.com/apache/kafka/commit/0a004562b8475d48a9961d6dab3a6aa24021c47f) being made on AK side, released with 3.8.1, with `endsWith` instead of `equals`.
+  Happening since v0.0.99 (#4895).
 
 ### Consumer fixes
 

--- a/src/rdkafka_sasl_scram.c
+++ b/src/rdkafka_sasl_scram.c
@@ -253,10 +253,9 @@ static char *rd_kafka_sasl_safe_string(const char *str) {
  * @brief Build client-final-message-without-proof
  * @remark out->ptr will be allocated and must be freed.
  */
-static void rd_kafka_sasl_scram_build_client_final_message_wo_proof(
-    struct rd_kafka_sasl_scram_state *state,
-    const char *snonce,
-    rd_chariov_t *out) {
+static void
+rd_kafka_sasl_scram_build_client_final_message_wo_proof(const char *snonce,
+                                                        rd_chariov_t *out) {
         const char *attr_c = "biws"; /* base64 encode of "n,," */
 
         /*
@@ -264,11 +263,9 @@ static void rd_kafka_sasl_scram_build_client_final_message_wo_proof(
          *            channel-binding "," nonce [","
          *            extensions]
          */
-        out->size = strlen("c=,r=") + strlen(attr_c) + state->cnonce.size +
-                    strlen(snonce);
-        out->ptr = rd_malloc(out->size + 1);
-        rd_snprintf(out->ptr, out->size + 1, "c=%s,r=%.*s%s", attr_c,
-                    (int)state->cnonce.size, state->cnonce.ptr, snonce);
+        out->size = strlen("c=,r=") + strlen(attr_c) + strlen(snonce);
+        out->ptr  = rd_malloc(out->size + 1);
+        rd_snprintf(out->ptr, out->size + 1, "c=%s,r=%s", attr_c, snonce);
 }
 
 
@@ -338,7 +335,7 @@ static int rd_kafka_sasl_scram_build_client_final_message(
 
         /* client-final-message-without-proof */
         rd_kafka_sasl_scram_build_client_final_message_wo_proof(
-            state, server_nonce, &client_final_msg_wo_proof);
+            server_nonce, &client_final_msg_wo_proof);
 
         /* AuthMessage     := client-first-message-bare + "," +
          *                    server-first-message + "," +


### PR DESCRIPTION
as it's already prepended in server sent nonce.
librdkafka was incorrectly concatenating the client side nonce again, leading to [this fix](https://github.com/apache/kafka/commit/0a004562b8475d48a9961d6dab3a6aa24021c47f) being made on AK side, released with 3.8.1, with `endsWith` instead of `equals`.
Happening since v0.0.99

Tested with trivup started with `--sasl SCRAM-SHA-512` parameter and test 0135