### PR TITLE
Client cert callback to check if trusted certificate authorities match with client certificate chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ librdkafka v2.6.2 is a maintenance release:
 * Socket options are now all set before connection (#4893).
 * Client certificate chain is now sent when using `ssl.certificate.pem`
   or `ssl_certificate` or `ssl.keystore.location` (#4894).
+* Avoid sending client certificates whose chain doesn't match with broker
+  trusted root certificates (#4900).
 
 
 ## Fixes

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -1070,6 +1070,7 @@ static int rd_kafka_ssl_cert_issuer_match(STACK_OF(X509_NAME) * ca_dns,
  * `ssl.client.auth=requested`.
  */
 static int rd_kafka_ssl_cert_callback(SSL *ssl, void *arg) {
+        rd_kafka_t *rk = arg;
         STACK_OF(X509_NAME) * ca_list;
         STACK_OF(X509) *certs = NULL;
         X509 *cert;
@@ -1113,6 +1114,10 @@ static int rd_kafka_ssl_cert_callback(SSL *ssl, void *arg) {
         /* No match is found, which means they would almost certainly be
          * rejected by the peer.
          * We decide to send no certificates. */
+        rd_kafka_log(rk, LOG_WARNING, "SSL",
+                     "No matching issuer found in "
+                     "server trusted certificate authorities, "
+                     "not sending any client certificates");
         SSL_certs_clear(ssl);
         return 1;
 }


### PR DESCRIPTION
in Java this selection is happening in [X509KeyManagerImpl.getAliases]( https://github.com/openjdk/jdk/blob/d8430efb5e159b8e08d2cac66b46cb4ff1112927/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java#L717)

The field that is checked is `certificate_authorities` extension in TLS 1.3, that was present in `CertificateRequest` in previous versions in TLS and SSL.