### PR TITLE
Allow to migrate partitions to leaders with same leader epoch or NULL leader epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ librdkafka v2.6.2 is a maintenance release:
   or `ssl_certificate` or `ssl.keystore.location` (#4894).
 * Avoid sending client certificates whose chain doesn't match with broker
   trusted root certificates (#4900).
+* Fixes to allow to migrate partitions to leaders with same leader epoch,
+  or NULL leader epoch (#4901).
 
 
 ## Fixes
@@ -24,6 +26,20 @@ librdkafka v2.6.2 is a maintenance release:
   authority certificate to its truststore to be able to accept client
   certificate.
   Happens since: 1.x (#4894).
+
+### Consumer fixes
+
+* Issues: #4796.
+  Fix to allow to migrate partitions to leaders with NULL leader epoch.
+  NULL leader epoch can happen during a cluster roll with an upgrade to a
+  version supporting KIP-320.
+  Happening since v2.1.0 (#4901).
+* Issues: #4804.
+  Fix to allow to migrate partitions to leaders with same leader epoch.
+  Same leader epoch can happen when partition is
+  temporarily migrated to the internal broker (#4804), or if broker implementation
+  never bumps it, as it's not needed to validate the offsets.
+  Happening since v2.4.0 (#4901).
 
 
 

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -2067,7 +2067,8 @@ rd_kafka_metadata_update_op(rd_kafka_t *rk, rd_kafka_metadata_internal_t *mdi) {
                                 .partitions[part]
                                 .leader_epoch;
 
-                        if (current_leader_epoch >= mdpi->leader_epoch) {
+                        if (mdpi->leader_epoch != -1 &&
+                            current_leader_epoch > mdpi->leader_epoch) {
                                 rd_kafka_broker_destroy(rkb);
                                 rd_kafka_dbg(
                                     rk, METADATA, "METADATAUPDATE",

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -290,13 +290,26 @@ void rd_kafka_mock_Fetch_reply_tags_partition_write(
     rd_kafka_mock_partition_t *mpart) {
         switch (tagtype) {
         case 1: /* CurrentLeader */
+        {
+                int32_t leader_id    = mpart->leader->id,
+                        leader_epoch = mpart->leader_epoch;
+                rd_kafka_mock_partition_leader_t *mpart_leader =
+                    rd_kafka_mock_partition_next_leader_response(mpart);
+                if (mpart_leader) {
+                        leader_id    = mpart_leader->leader_id;
+                        leader_epoch = mpart_leader->leader_epoch;
+                        rd_kafka_mock_partition_leader_destroy(mpart,
+                                                               mpart_leader);
+                }
+
                 /* Leader id */
-                rd_kafka_buf_write_i32(rkbuf, mpart->leader->id);
+                rd_kafka_buf_write_i32(rkbuf, leader_id);
                 /* Leader epoch */
-                rd_kafka_buf_write_i32(rkbuf, mpart->leader_epoch);
+                rd_kafka_buf_write_i32(rkbuf, leader_epoch);
                 /* Field tags */
                 rd_kafka_buf_write_tags_empty(rkbuf);
                 break;
+        }
         default:
                 break;
         }

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -1155,16 +1155,13 @@ void rd_kafka_offset_validate(rd_kafka_toppar_t *rktp, const char *fmt, ...) {
 
 
         if (rktp->rktp_leader_id == -1 || !rktp->rktp_leader ||
-            (rktp->rktp_leader->rkb_source == RD_KAFKA_INTERNAL &&
-             rktp->rktp_fetch_state !=
-                 RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT)) {
+            rktp->rktp_leader->rkb_source == RD_KAFKA_INTERNAL) {
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, FETCH, "VALIDATE",
                              "%.*s [%" PRId32
                              "]: unable to perform offset "
                              "validation: partition leader not available",
                              RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
                              rktp->rktp_partition);
-
                 rd_kafka_toppar_set_fetch_state(rktp,
                                                 RD_KAFKA_TOPPAR_FETCH_ACTIVE);
                 return;

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -1159,11 +1159,10 @@ void rd_kafka_offset_validate(rd_kafka_toppar_t *rktp, const char *fmt, ...) {
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, FETCH, "VALIDATE",
                              "%.*s [%" PRId32
                              "]: unable to perform offset "
-                             "validation: partition leader not available",
+                             "validation: partition leader not available. "
+                             "Retrying when available",
                              RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
                              rktp->rktp_partition);
-                rd_kafka_toppar_set_fetch_state(rktp,
-                                                RD_KAFKA_TOPPAR_FETCH_ACTIVE);
                 return;
         }
 

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -433,6 +433,8 @@ struct rd_kafka_toppar_s {                           /* rd_kafka_toppar_t */
 #define RD_KAFKA_TOPPAR_F_ASSIGNED                                             \
         0x2000 /**< Toppar is part of the consumer                             \
                 *   assignment. */
+#define RD_KAFKA_TOPPAR_F_VALIDATING                                           \
+        0x4000 /**< Toppar is currently requesting validation. */
 
         /*
          * Timers

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -682,6 +682,10 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
 
         rd_kafka_toppar_lock(rktp);
 
+        /* -1 (null) is excluded to allow to switch back to a
+         * leader not supporting KIP-320 still, for example
+         * during a cluster roll for upgrading brokers to
+         * a version supporting that KIP. */
         if (leader_epoch != -1 && leader_epoch < rktp->rktp_leader_epoch) {
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
                              "%s [%" PRId32

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -663,7 +663,8 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                                          int32_t leader_epoch) {
         rd_kafka_toppar_t *rktp;
         rd_bool_t need_epoch_validation = rd_false;
-        int r                           = 0;
+        rd_bool_t fetching_from_follower;
+        int r = 0;
 
         rktp = rd_kafka_toppar_get(rkt, partition, 0);
         if (unlikely(!rktp)) {
@@ -681,7 +682,7 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
 
         rd_kafka_toppar_lock(rktp);
 
-        if (leader_epoch < rktp->rktp_leader_epoch) {
+        if (leader_epoch != -1 && leader_epoch < rktp->rktp_leader_epoch) {
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
                              "%s [%" PRId32
                              "]: ignoring outdated metadata update with "
@@ -691,68 +692,61 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                              rktp->rktp_rkt->rkt_topic->str,
                              rktp->rktp_partition, leader_epoch,
                              rktp->rktp_leader_epoch);
-                if (rktp->rktp_fetch_state !=
-                    RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT) {
-                        rd_kafka_toppar_unlock(rktp);
-                        rd_kafka_toppar_destroy(rktp); /* from get() */
-                        return 0;
-                }
+                rd_kafka_toppar_unlock(rktp);
+                rd_kafka_toppar_destroy(rktp); /* from get() */
+                return 0;
         }
 
-        if (rktp->rktp_leader_epoch == -1 ||
-            leader_epoch > rktp->rktp_leader_epoch) {
-                rd_bool_t fetching_from_follower;
-                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
-                             "%s [%" PRId32 "]: leader %" PRId32
-                             " epoch %" PRId32 " -> leader %" PRId32
-                             " epoch %" PRId32,
-                             rktp->rktp_rkt->rkt_topic->str,
-                             rktp->rktp_partition, rktp->rktp_leader_id,
-                             rktp->rktp_leader_epoch, leader_id, leader_epoch);
-                if (leader_epoch > rktp->rktp_leader_epoch)
-                        rktp->rktp_leader_epoch = leader_epoch;
+        rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
+                     "%s [%" PRId32 "]: leader %" PRId32 " epoch %" PRId32
+                     " -> leader %" PRId32 " epoch %" PRId32,
+                     rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
+                     rktp->rktp_leader_id, rktp->rktp_leader_epoch, leader_id,
+                     leader_epoch);
+
+        if (leader_epoch > rktp->rktp_leader_epoch ||
+            rktp->rktp_fetch_state ==
+                RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT) {
+                /* Epoch increased and needs to be validated (leader_epoch > -1)
+                 * or we need to complete the validation. */
                 need_epoch_validation = rd_true;
+        }
 
+        rktp->rktp_leader_epoch = leader_epoch;
 
-                fetching_from_follower =
-                    leader != NULL && rktp->rktp_broker != NULL &&
-                    rktp->rktp_broker->rkb_source != RD_KAFKA_INTERNAL &&
-                    rktp->rktp_broker != leader;
+        fetching_from_follower =
+            leader != NULL && rktp->rktp_broker != NULL &&
+            rktp->rktp_broker->rkb_source != RD_KAFKA_INTERNAL &&
+            rktp->rktp_broker != leader;
 
-                if (fetching_from_follower &&
-                    rktp->rktp_leader_id == leader_id) {
-                        rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
-                                     "Topic %s [%" PRId32 "]: leader %" PRId32
-                                     " unchanged, "
-                                     "not migrating away from preferred "
-                                     "replica %" PRId32,
-                                     rktp->rktp_rkt->rkt_topic->str,
-                                     rktp->rktp_partition, leader_id,
-                                     rktp->rktp_broker_id);
-                        r = 0;
+        if (fetching_from_follower && rktp->rktp_leader_id == leader_id) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BROKER",
+                             "Topic %s [%" PRId32 "]: leader %" PRId32
+                             " unchanged, "
+                             "not migrating away from preferred "
+                             "replica %" PRId32,
+                             rktp->rktp_rkt->rkt_topic->str,
+                             rktp->rktp_partition, leader_id,
+                             rktp->rktp_broker_id);
+                r = 0;
 
-                } else {
+        } else {
 
-                        if (rktp->rktp_leader_id != leader_id ||
-                            rktp->rktp_leader != leader) {
-                                /* Update leader if it has changed */
-                                rktp->rktp_leader_id = leader_id;
-                                if (rktp->rktp_leader)
-                                        rd_kafka_broker_destroy(
-                                            rktp->rktp_leader);
-                                if (leader)
-                                        rd_kafka_broker_keep(leader);
-                                rktp->rktp_leader = leader;
-                        }
-
-                        /* Update handling broker */
-                        r = rd_kafka_toppar_broker_update(
-                            rktp, leader_id, leader, "leader updated");
+                if (rktp->rktp_leader_id != leader_id ||
+                    rktp->rktp_leader != leader) {
+                        /* Update leader if it has changed */
+                        rktp->rktp_leader_id = leader_id;
+                        if (rktp->rktp_leader)
+                                rd_kafka_broker_destroy(rktp->rktp_leader);
+                        if (leader)
+                                rd_kafka_broker_keep(leader);
+                        rktp->rktp_leader = leader;
                 }
 
-        } else if (rktp->rktp_fetch_state ==
-                   RD_KAFKA_TOPPAR_FETCH_VALIDATE_EPOCH_WAIT)
-                need_epoch_validation = rd_true;
+                /* Update handling broker */
+                r = rd_kafka_toppar_broker_update(rktp, leader_id, leader,
+                                                  "leader updated");
+        }
 
         if (need_epoch_validation) {
                 /* Set offset validation position,

--- a/tests/0139-offset_validation_mock.c
+++ b/tests/0139-offset_validation_mock.c
@@ -192,14 +192,14 @@ static void do_test_permanent_error_retried(rd_kafka_resp_err_t err) {
         rktpar         = rd_kafka_topic_partition_list_add(rktpars, topic, 0);
         rktpar->offset = 0;
 
-        /* Will validate the offset at start fetching again
+        /* Will validate the offset and start fetching again
          * from offset 0. */
         rd_kafka_topic_partition_set_leader_epoch(rktpar, 0);
         rd_kafka_seek_partitions(c1, rktpars, -1);
         rd_kafka_topic_partition_list_destroy(rktpars);
 
         /* Read all messages after seek to zero.
-         * In case of permanent error instead it reset to latest and
+         * In case of permanent error, instead, it resets to latest and
          * gets an EOF. */
         test_consumer_poll("MSG_ALL", c1, testid, 0, 0, 5, NULL);
 

--- a/tests/0139-offset_validation_mock.c
+++ b/tests/0139-offset_validation_mock.c
@@ -440,7 +440,7 @@ is_offset_for_leader_epoch_request(rd_kafka_mock_request_t *request,
 
 static rd_bool_t is_metadata_request(rd_kafka_mock_request_t *request,
                                      void *opaque) {
-        return rd_kafka_mock_request_api_key(request) == RD_KAFKAP_Fetch;
+        return rd_kafka_mock_request_api_key(request) == RD_KAFKAP_Metadata;
 }
 
 /**


### PR DESCRIPTION
* Closes: #4796.
  Fix to allow to migrate partitions to leaders with NULL leader epoch.
  NULL leader epoch can happen during a cluster roll with an upgrade to a
  version supporting KIP-320.
  Happening since v2.1.0
  
* Closes: #4804.
  Fix to allow to migrate partitions to leaders with same leader epoch.
  Same leader epoch can happen when partition is
  temporarily migrated to the internal broker (#4804), or if broker implementation
  never bumps it, as it's not needed to validate the offsets.
  Happening since v2.4.0 