### PR TITLE
Count 'Too Many Requests' as a retriable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ librdkafka v2.6.1 is a maintenance release:
   zstd 1.5.6, zlib 1.3.1, OpenSSL 3.3.2, CURL 8.10.1 (#4872).
 * SASL/SCRAM authentication fix: avoid concatenating
   client side nonce once more, as it's already prepended in server sent nonce (#4895).
+* Allow retrying for status code 429 ('Too Many Requests') in HTTP requests for
+  OAUTHBEARER OIDC (#4902).
 
 
 ## Fixes

--- a/src/rdhttp.c
+++ b/src/rdhttp.c
@@ -269,6 +269,7 @@ static rd_bool_t rd_http_is_failure_temporary(int error_code) {
         switch (error_code) {
         case 408: /**< Request timeout */
         case 425: /**< Too early */
+        case 429: /**< Too many requests */
         case 500: /**< Internal server error */
         case 502: /**< Bad gateway */
         case 503: /**< Service unavailable */


### PR DESCRIPTION
(for OIDC)