### PR TITLE
Upgrade semaphore agent to Ubuntu 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,7 +87,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-amd64-2
+          type: s1-prod-ubuntu22-04-amd64-2
       jobs:
         - name: 'Generate documentation'
           commands:
@@ -106,7 +106,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-amd64-2
+          type: s1-prod-ubuntu22-04-amd64-2
       env_vars:
         - name: CFLAGS
           value: -std=gnu90 # Test minimum C standard, default in CentOS 7
@@ -150,7 +150,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-amd64-2
+          type: s1-prod-ubuntu22-04-amd64-2
       prologue:
         commands:
           - '[[ -z $DOCKERHUB_APIKEY ]] || docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY'
@@ -192,7 +192,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu22-04-arm64-2
       prologue:
         commands:
           - '[[ -z $DOCKERHUB_APIKEY ]] || docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY'
@@ -321,7 +321,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-amd64-2
+          type: s1-prod-ubuntu22-04-amd64-2
       jobs:
         - name: 'Build NuGet and static packages'
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -141,7 +141,7 @@ blocks:
             - make -j -C tests build
             - make -C tests run_local_quick
             - DESTDIR="$PWD/dest" make install
-            - (cd tests && python3 -m trivup.clusters.KafkaCluster --version 3.4.0 --cmd 'make quick')
+            - (cd tests && python3 -m trivup.clusters.KafkaCluster --version 3.4.0 --cmd "PATH=\"$PATH\" make quick")
 
 
   - name: 'Linux x64: release artifact docker builds'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,6 +77,7 @@ blocks:
       jobs:
         - name: 'Style check'
           commands:
+            - sudo apt update
             - sudo apt install -y clang-format-10 python3 python3-pip python3-setuptools
             - python3 -m pip install -r packaging/tools/requirements.txt
             - CLANG_FORMAT=clang-format-10 make style-check


### PR DESCRIPTION
except for the Style check job because it needs clang format 10