### PR TITLE
use OPENSSL_NO_ENGINE from OpenSSL config

### DIFF
--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -35,9 +35,13 @@
 
 #if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10100000 &&                        \
     !defined(OPENSSL_IS_BORINGSSL)
+#ifdef OPENSSL_NO_ENGINE
+#include <openssl/rand.h>
+#else
 #define WITH_SSL_ENGINE 1
 /* Deprecated in OpenSSL 3 */
 #include <openssl/engine.h>
+#endif
 #endif /* WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10100000 */
 
 /**


### PR DESCRIPTION
This fixes build on distribution where deprecated ENGINE are removed (e.g. RHEL-10)

`rand.h` is needed for `RAND_priv_bytes` (was previously included from `engine.h`)

`engine.h` may be missing (ex: RHEL-10-beta), or empty (CentOS Stream 10, so RHEL-10.0)

Tested on
- RHEL-8.10, OpenSSL 1.1.1k
- RHEL-9.5, openSSL 3.2.2
- RHEL-1.0-beta, openSSL 3.2.2 (no engine)