### PR TITLE
[KIP-714] Fix to avoid sending a NULL metrics payload

### DIFF
--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -2657,6 +2657,7 @@ static int rd_kafka_mock_handle_PushTelemetry(rd_kafka_mock_connection_t *mconn,
 
         void *uncompressed_payload      = NULL;
         size_t uncompressed_payload_len = 0;
+        rd_assert(metrics.data != NULL);
 
         if (compression_type != RD_KAFKA_COMPRESSION_NONE) {
                 rd_rkb_log(rkb, LOG_DEBUG, "MOCKTELEMETRY",
@@ -2678,6 +2679,7 @@ static int rd_kafka_mock_handle_PushTelemetry(rd_kafka_mock_connection_t *mconn,
                 uncompressed_payload_len = metrics.len;
         }
 
+        rd_assert(uncompressed_payload != NULL);
         rd_kafka_mock_handle_PushTelemetry_payload(rkb, uncompressed_payload,
                                                    uncompressed_payload_len);
         if (compression_type != RD_KAFKA_COMPRESSION_NONE)

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6374,6 +6374,8 @@ rd_kafka_PushTelemetryRequest(rd_kafka_broker_t *rkb,
         rd_kafka_buf_write_bool(rkbuf, terminating);
         rd_kafka_buf_write_i8(rkbuf, compression_type);
 
+        rd_dassert(metrics != NULL);
+        rd_dassert(metrics_size >= 0);
         rd_kafkap_bytes_t *metric_bytes =
             rd_kafkap_bytes_new(metrics, metrics_size);
         rd_kafka_buf_write_kbytes(rkbuf, metric_bytes);

--- a/src/rdkafka_telemetry.c
+++ b/src/rdkafka_telemetry.c
@@ -266,6 +266,24 @@ rd_kafka_push_telemetry_payload_compress(rd_kafka_t *rk,
         rd_slice_t payload_slice;
         size_t i;
         rd_kafka_resp_err_t r = RD_KAFKA_RESP_ERR_NO_ERROR;
+
+        if (payload->rbuf_len == 0) {
+                /* We can only initialize the slice to compress
+                 * if not empty. */
+                rd_kafka_dbg(rk, TELEMETRY, "PUSH",
+                             "Empty payload. "
+                             "Sending uncompressed payload");
+
+                /* It's not important the payload isn't actually a segment
+                 * inside the buffer, as size is 0, we can send any allocated
+                 * memory here, but we chose the buffer because it's
+                 * freed like the other COMPRESSION_NONE case, without
+                 * memory leaks. */
+                *compressed_payload      = payload;
+                *compressed_payload_size = 0;
+                return RD_KAFKA_COMPRESSION_NONE;
+        }
+
         rd_slice_init_full(&payload_slice, payload);
         for (i = 0; i < rk->rk_telemetry.accepted_compression_types_cnt; i++) {
                 rd_kafka_compression_t compression_type =
@@ -359,20 +377,23 @@ static void rd_kafka_send_push_telemetry(rd_kafka_t *rk,
                                      compressed_metrics_payload_size,
                                      rk->rk_telemetry.telemetry_max_bytes);
                 }
-        } else {
-                rd_kafka_dbg(rk, TELEMETRY, "PUSH",
-                             "No metrics to push. Sending empty payload.");
-        }
 
-        rd_kafka_dbg(rk, TELEMETRY, "PUSH",
-                     "Sending PushTelemetryRequest with terminating = %s",
-                     RD_STR_ToF(terminating));
-        rd_kafka_PushTelemetryRequest(
-            rkb, &rk->rk_telemetry.client_instance_id,
-            rk->rk_telemetry.subscription_id, terminating, compression_used,
-            compressed_metrics_payload, compressed_metrics_payload_size, NULL,
-            0, RD_KAFKA_REPLYQ(rk->rk_ops, 0), rd_kafka_handle_PushTelemetry,
-            NULL);
+                rd_kafka_dbg(
+                    rk, TELEMETRY, "PUSH",
+                    "Sending PushTelemetryRequest with terminating = %s",
+                    RD_STR_ToF(terminating));
+                rd_kafka_PushTelemetryRequest(
+                    rkb, &rk->rk_telemetry.client_instance_id,
+                    rk->rk_telemetry.subscription_id, terminating,
+                    compression_used, compressed_metrics_payload,
+                    compressed_metrics_payload_size, NULL, 0,
+                    RD_KAFKA_REPLYQ(rk->rk_ops, 0),
+                    rd_kafka_handle_PushTelemetry, NULL);
+        } else {
+                rd_kafka_log(rk, LOG_WARNING, "PUSH",
+                             "Telemetry metrics encode error, not sending "
+                             "a NULL payload");
+        }
 
         if (metrics_payload)
                 rd_buf_destroy_free(metrics_payload);

--- a/src/rdkafka_telemetry_encode.c
+++ b/src/rdkafka_telemetry_encode.c
@@ -731,7 +731,7 @@ rd_buf_t *rd_kafka_telemetry_encode_metrics(rd_kafka_t *rk) {
         size_t i, metric_idx = 0;
 
         if (!metrics_to_encode_count)
-                return NULL;
+                return rd_buf_new(1, 1);
 
         opentelemetry_proto_metrics_v1_MetricsData metrics_data =
             opentelemetry_proto_metrics_v1_MetricsData_init_zero;


### PR DESCRIPTION
when no metrics are matching, client side, a NULL metrics payload must not be sent, because it's not accepted by the protocol and it causes a disconnection by the broker.
An empty payload must be sent instead.

There are some additional checks on the mock implementation to match the broker one, so the test 0150 
```C
                do_test_telemetry_empty_subscriptions_list(
                    type, "non-existent-metric");
```
is failing.
The fix returns NULL only in the serialization error case and it's not sending a Push in that case, while it returns an empty buffer when there are zero metrics to send.