### PR TITLE
Fix to avoid issuing a warning in case server requests a certificate and client is using SASL authentication only

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -1076,6 +1076,15 @@ static int rd_kafka_ssl_cert_callback(SSL *ssl, void *arg) {
         X509 *cert;
         int i;
 
+        /* Get client cert from SSL connection */
+        cert = SSL_get_certificate(ssl);
+        if (cert == NULL) {
+                /* If there's no client certificate,
+                 * skip certificate issuer verification and
+                 * avoid logging a warning. */
+                return 1;
+        }
+
         /* Get the accepted client CA list from the SSL connection, this
          * comes from the `certificate_authorities` field. */
         ca_list = SSL_get_client_CA_list(ssl);
@@ -1087,9 +1096,6 @@ static int rd_kafka_ssl_cert_callback(SSL *ssl, void *arg) {
                  * and let the server validate it. */
                 return 1;
         }
-
-        /* Get client cert from SSL connection */
-        cert = SSL_get_certificate(ssl);
 
         if (cert != NULL && rd_kafka_ssl_cert_issuer_match(ca_list, cert)) {
                 /* A match is found, use the certificate. */

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -1097,7 +1097,7 @@ static int rd_kafka_ssl_cert_callback(SSL *ssl, void *arg) {
                 return 1;
         }
 
-        if (cert != NULL && rd_kafka_ssl_cert_issuer_match(ca_list, cert)) {
+        if (rd_kafka_ssl_cert_issuer_match(ca_list, cert)) {
                 /* A match is found, use the certificate. */
                 return 1;
         }


### PR DESCRIPTION
without any client certificate set.