### PR TITLE
KIP 848:Extend DescribeConfigs and IncrementalAlterConfigs to support GROUP Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ librdkafka v2.10.0 is a feature release:
 
 librdkafka v2.8.0 is a maintenance release:
 
+* Extend Config Apis to support group config (#4939).
 * Socket options are now all set before connection (#4893).
 * Client certificate chain is now sent when using `ssl.certificate.pem`
   or `ssl_certificate` or `ssl.keystore.location` (#4894).

--- a/examples/incremental_alter_configs.c
+++ b/examples/incremental_alter_configs.c
@@ -181,13 +181,13 @@ cmd_incremental_alter_configs(rd_kafka_conf_t *conf, int argc, char **argv) {
                 char *config_name     = argv[i * 5 + 3];
                 char *config_value    = argv[i * 5 + 4];
                 rd_kafka_ConfigResource_t *config;
-                rd_kafka_AlterConfigOpType_t op_type = -1;
+                rd_kafka_AlterConfigOpType_t op_type;
                 rd_kafka_ResourceType_t restype =
                     !strcmp(restype_s, "TOPIC")
                         ? RD_KAFKA_RESOURCE_TOPIC
                         : !strcmp(restype_s, "BROKER")
                               ? RD_KAFKA_RESOURCE_BROKER
-                              : !strcmp(restype_s, "GROUP")  // Add this case
+                              : !strcmp(restype_s, "GROUP")
                                     ? RD_KAFKA_RESOURCE_GROUP
                                     : RD_KAFKA_RESOURCE_UNKNOWN;
 

--- a/examples/incremental_alter_configs.c
+++ b/examples/incremental_alter_configs.c
@@ -181,7 +181,7 @@ cmd_incremental_alter_configs(rd_kafka_conf_t *conf, int argc, char **argv) {
                 char *config_name     = argv[i * 5 + 3];
                 char *config_value    = argv[i * 5 + 4];
                 rd_kafka_ConfigResource_t *config;
-                rd_kafka_AlterConfigOpType_t op_type;
+                rd_kafka_AlterConfigOpType_t op_type = -1;
                 rd_kafka_ResourceType_t restype =
                     !strcmp(restype_s, "TOPIC")
                         ? RD_KAFKA_RESOURCE_TOPIC

--- a/examples/incremental_alter_configs.c
+++ b/examples/incremental_alter_configs.c
@@ -187,7 +187,9 @@ cmd_incremental_alter_configs(rd_kafka_conf_t *conf, int argc, char **argv) {
                         ? RD_KAFKA_RESOURCE_TOPIC
                         : !strcmp(restype_s, "BROKER")
                               ? RD_KAFKA_RESOURCE_BROKER
-                              : RD_KAFKA_RESOURCE_UNKNOWN;
+                              : !strcmp(restype_s, "GROUP")  // Add this case
+                                    ? RD_KAFKA_RESOURCE_GROUP
+                                    : RD_KAFKA_RESOURCE_UNKNOWN;
 
                 if (restype == RD_KAFKA_RESOURCE_UNKNOWN) {
                         usage("Invalid resource type: %s", restype_s);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7855,25 +7855,6 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 
 
 /**
- * @enum rd_kafka_ConfigType_t
- * @brief Apache Kafka config types.
- */
-typedef enum rd_kafka_ConfigType_t {
-        RD_KAFKA_CONFIG_UNKNOWN  = 0,
-        RD_KAFKA_CONFIG_BOOLEAN  = 1,
-        RD_KAFKA_CONFIG_STRING   = 2,
-        RD_KAFKA_CONFIG_INT      = 3,
-        RD_KAFKA_CONFIG_SHORT    = 4,
-        RD_KAFKA_CONFIG_LONG     = 5,
-        RD_KAFKA_CONFIG_DOUBLE   = 6,
-        RD_KAFKA_CONFIG_LIST     = 7,
-        RD_KAFKA_CONFIG_CLASS    = 8,
-        RD_KAFKA_CONFIG_PASSWORD = 9,
-        RD_KAFKA_CONFIG__CNT,
-} rd_kafka_ConfigType_t;
-
-
-/**
  * @returns the synonym config entry array.
  *
  * @param entry Entry to get synonyms for.
@@ -7886,30 +7867,6 @@ typedef enum rd_kafka_ConfigType_t {
 RD_EXPORT const rd_kafka_ConfigEntry_t **
 rd_kafka_ConfigEntry_synonyms(const rd_kafka_ConfigEntry_t *entry,
                               size_t *cntp);
-
-/**
- * @returns the config type.
- *
- * @param entry Entry to get type for.
- *
- * @remark The lifetime of the returned entry is the same as \p conf .
- * @remark Shall only be used on a DescribeConfigs result,
- *         otherwise returns RD_KAFKA_CONFIG_UNKNOWN.
- */
-RD_EXPORT const rd_kafka_ConfigType_t
-rd_kafka_ConfigEntry_type(const rd_kafka_ConfigEntry_t *entry);
-
-/**
- * @returns the config documentation.
- *
- * @param entry Entry to get documentation for.
- *
- * @remark The lifetime of the returned entry is the same as \p conf .
- * @remark Shall only be used on a DescribeConfigs result,
- *         otherwise returns NULL.
- */
-RD_EXPORT const char *
-rd_kafka_ConfigEntry_documentation(const rd_kafka_ConfigEntry_t *entry);
 
 
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7855,7 +7855,7 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 
 
 /**
- * @enum rd_kafka_ConfigType_t.
+ * @enum rd_kafka_ConfigType_t
  * @brief Apache Kafka config types.
  */
 typedef enum rd_kafka_ConfigType_t {

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7787,6 +7787,8 @@ typedef enum rd_kafka_ConfigSource_t {
         /** Built-in default configuration for configs that have a
          *  default value */
         RD_KAFKA_CONFIG_SOURCE_DEFAULT_CONFIG = 5,
+        /** Group config that is configured for a specific group */
+        RD_KAFKA_CONFIG_SOURCE_GROUP_CONFIG = 8,
 
         /** Number of source types defined */
         RD_KAFKA_CONFIG_SOURCE__CNT,

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7855,6 +7855,26 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 
 
 /**
+ * @enum rd_kafka_ConfigType_t.
+ *
+ * @brief Apache Kafka config types.
+ */
+typedef enum rd_kafka_ConfigType_t {
+        RD_KAFKA_CONFIG_UNKNOWN  = 0,
+        RD_KAFKA_CONFIG_BOOLEAN  = 1,
+        RD_KAFKA_CONFIG_STRING   = 2,
+        RD_KAFKA_CONFIG_INT      = 3,
+        RD_KAFKA_CONFIG_SHORT    = 4,
+        RD_KAFKA_CONFIG_LONG     = 5,
+        RD_KAFKA_CONFIG_DOUBLE   = 6,
+        RD_KAFKA_CONFIG_LIST     = 7,
+        RD_KAFKA_CONFIG_CLASS    = 8,
+        RD_KAFKA_CONFIG_PASSWORD = 9,
+        RD_KAFKA_CONFIG__CNT,
+} rd_kafka_ConfigType_t;
+
+
+/**
  * @returns the synonym config entry array.
  *
  * @param entry Entry to get synonyms for.
@@ -7867,6 +7887,30 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 RD_EXPORT const rd_kafka_ConfigEntry_t **
 rd_kafka_ConfigEntry_synonyms(const rd_kafka_ConfigEntry_t *entry,
                               size_t *cntp);
+
+/**
+ * @returns the config type.
+ *
+ * @param entry Entry to get type for.
+ *
+ * @remark The lifetime of the returned entry is the same as \p conf .
+ * @remark Shall only be used on a DescribeConfigs result,
+ *         otherwise returns RD_KAFKA_CONFIG_UNKNOWN.
+ */
+RD_EXPORT const rd_kafka_ConfigType_t
+rd_kafka_ConfigEntry_type(const rd_kafka_ConfigEntry_t *entry);
+
+/**
+ * @returns the config documentation.
+ *
+ * @param entry Entry to get documentation for.
+ *
+ * @remark The lifetime of the returned entry is the same as \p conf .
+ * @remark Shall only be used on a DescribeConfigs result,
+ *         otherwise returns NULL.
+ */
+RD_EXPORT const char *
+rd_kafka_ConfigEntry_documentation(const rd_kafka_ConfigEntry_t *entry);
 
 
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7856,7 +7856,6 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 
 /**
  * @enum rd_kafka_ConfigType_t.
- *
  * @brief Apache Kafka config types.
  */
 typedef enum rd_kafka_ConfigType_t {

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2912,22 +2912,20 @@ const char *rd_kafka_ResourceType_name(rd_kafka_ResourceType_t restype) {
 }
 
 
-rd_kafka_ConfigResourceType_t map_from_resource_type_to_config_resource_type(
-    rd_kafka_ResourceType_t resourcetype) {
-        if (resourcetype == RD_KAFKA_RESOURCE_GROUP) {
+int8_t map_from_resource_type_to_config_resource_type(
+    rd_kafka_ResourceType_t restype) {
+        if (restype == RD_KAFKA_RESOURCE_GROUP)
                 return RD_KAFKA_CONFIG_RESOURCE_GROUP;
-        }
 
-        return resourcetype;
+        return restype;
 }
 
-rd_kafka_ResourceType_t map_from_config_resource_type_to_resource_type(
-    rd_kafka_ConfigResourceType_t internal_resourcetype) {
-        if (internal_resourcetype == RD_KAFKA_CONFIG_RESOURCE_GROUP) {
+rd_kafka_ResourceType_t
+map_from_config_resource_type_to_resource_type(int8_t config_resource_type) {
+        if (config_resource_type == RD_KAFKA_CONFIG_RESOURCE_GROUP)
                 return RD_KAFKA_RESOURCE_GROUP;
-        }
 
-        return internal_resourcetype;
+        return config_resource_type;
 }
 
 
@@ -3388,7 +3386,7 @@ rd_kafka_IncrementalAlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 int16_t error_code;
                 rd_kafkap_str_t error_msg;
                 int8_t res_type;
-                int8_t internal_res_type;
+                int8_t config_resource_type;
                 rd_kafkap_str_t kres_name;
                 char *res_name;
                 char *this_errstr = NULL;
@@ -3398,13 +3396,13 @@ rd_kafka_IncrementalAlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
 
                 rd_kafka_buf_read_i16(reply, &error_code);
                 rd_kafka_buf_read_str(reply, &error_msg);
-                rd_kafka_buf_read_i8(reply, &internal_res_type);
+                rd_kafka_buf_read_i8(reply, &config_resource_type);
                 rd_kafka_buf_read_str(reply, &kres_name);
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                 rd_kafka_buf_skip_tags(reply);
 
                 res_type = map_from_config_resource_type_to_resource_type(
-                    internal_res_type);
+                    config_resource_type);
 
                 if (error_code) {
                         if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||
@@ -3662,7 +3660,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
         for (i = 0; i < (int)res_cnt; i++) {
                 int16_t error_code;
                 rd_kafkap_str_t error_msg;
-                int8_t internal_res_type;
+                int8_t config_resource_type;
                 int8_t res_type;
                 rd_kafkap_str_t kres_name;
                 char *res_name;
@@ -3674,12 +3672,12 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
 
                 rd_kafka_buf_read_i16(reply, &error_code);
                 rd_kafka_buf_read_str(reply, &error_msg);
-                rd_kafka_buf_read_i8(reply, &internal_res_type);
+                rd_kafka_buf_read_i8(reply, &config_resource_type);
                 rd_kafka_buf_read_str(reply, &kres_name);
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
 
                 res_type = map_from_config_resource_type_to_resource_type(
-                    internal_res_type);
+                    config_resource_type);
 
                 if (error_code) {
                         if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2865,10 +2865,14 @@ rd_kafka_ConfigEntry_synonyms(const rd_kafka_ConfigEntry_t *entry,
 
 const char *rd_kafka_ConfigSource_name(rd_kafka_ConfigSource_t confsource) {
         static const char *names[] = {
-            "UNKNOWN_CONFIG",        "DYNAMIC_TOPIC_CONFIG",
-            "DYNAMIC_BROKER_CONFIG", "DYNAMIC_DEFAULT_BROKER_CONFIG",
-            "STATIC_BROKER_CONFIG",  "DEFAULT_CONFIG",
-            "UNSUPPORTED",           "UNSUPPORTED",
+            "UNKNOWN_CONFIG",
+            "DYNAMIC_TOPIC_CONFIG",
+            "DYNAMIC_BROKER_CONFIG",
+            "DYNAMIC_DEFAULT_BROKER_CONFIG",
+            "STATIC_BROKER_CONFIG",
+            "DEFAULT_CONFIG",
+            "DYNAMIC_BROKER_LOGGER_CONFIG",
+            "CLIENT_METRICS_CONFIG",
             "GROUP_CONFIG",
         };
 
@@ -3195,6 +3199,7 @@ rd_kafka_AlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 int16_t error_code;
                 rd_kafkap_str_t error_msg;
                 int8_t res_type;
+                int8_t config_resource_type;
                 rd_kafkap_str_t kres_name;
                 char *res_name;
                 char *this_errstr = NULL;
@@ -3204,10 +3209,13 @@ rd_kafka_AlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
 
                 rd_kafka_buf_read_i16(reply, &error_code);
                 rd_kafka_buf_read_str(reply, &error_msg);
-                rd_kafka_buf_read_i8(reply, &res_type);
+                rd_kafka_buf_read_i8(reply, &config_resource_type);
                 rd_kafka_buf_read_str(reply, &kres_name);
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                 rd_kafka_buf_skip_tags(reply);
+
+                res_type = map_from_config_resource_type_to_resource_type(
+                    config_resource_type);
 
                 if (error_code) {
                         if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2932,8 +2932,8 @@ rd_kafka_ResourceType_to_ConfigResourceType(rd_kafka_ResourceType_t restype) {
         }
 }
 
-rd_kafka_ResourceType_t
-rd_kafka_ConfigResourceType_to_ResourceType(int8_t config_resource_type) {
+rd_kafka_ResourceType_t rd_kafka_ConfigResourceType_to_ResourceType(
+    rd_kafka_ConfigResourceType_t config_resource_type) {
         switch (config_resource_type) {
         case RD_KAFKA_CONFIG_RESOURCE_TOPIC:
                 return RD_KAFKA_RESOURCE_TOPIC;

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2912,52 +2912,23 @@ const char *rd_kafka_ResourceType_name(rd_kafka_ResourceType_t restype) {
 }
 
 
-rd_kafka_InternalConfigResourceType_t
+rd_kafka_ConfigResourceType_t
 map_from_resource_type_to_internal_config_resource_type(
     rd_kafka_ResourceType_t resourcetype) {
-
-        if (resourcetype > RD_KAFKA_RESOURCE__CNT) {
-                rd_assert("Invalid resource type");
+        if (resourcetype == RD_KAFKA_RESOURCE_GROUP) {
+                return RD_KAFKA_CONFIG_RESOURCE_GROUP;
         }
 
-        switch (resourcetype) {
-        case RD_KAFKA_RESOURCE_UNKNOWN:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN;
-        case RD_KAFKA_RESOURCE_ANY:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_ANY;
-        case RD_KAFKA_RESOURCE_TOPIC:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_TOPIC;
-        case RD_KAFKA_RESOURCE_GROUP:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP;
-        case RD_KAFKA_RESOURCE_BROKER:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_BROKER;
-        case RD_KAFKA_RESOURCE__CNT:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT;
-        }
+        return resourcetype;
 }
 
 rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
-    rd_kafka_InternalConfigResourceType_t internal_resourcetype) {
-
-        if (internal_resourcetype != RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP &&
-            internal_resourcetype > RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT) {
-                rd_assert("Recieved invalid resource type");
-        }
-
-        switch (internal_resourcetype) {
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN:
-                return RD_KAFKA_RESOURCE_UNKNOWN;
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_ANY:
-                return RD_KAFKA_RESOURCE_ANY;
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_TOPIC:
-                return RD_KAFKA_RESOURCE_TOPIC;
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP:
+    rd_kafka_ConfigResourceType_t internal_resourcetype) {
+        if (internal_resourcetype == RD_KAFKA_CONFIG_RESOURCE_GROUP) {
                 return RD_KAFKA_RESOURCE_GROUP;
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_BROKER:
-                return RD_KAFKA_RESOURCE_BROKER;
-        case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT:
-                return RD_KAFKA_RESOURCE__CNT;
         }
+
+        return internal_resourcetype;
 }
 
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2912,8 +2912,7 @@ const char *rd_kafka_ResourceType_name(rd_kafka_ResourceType_t restype) {
 }
 
 
-rd_kafka_ConfigResourceType_t
-map_from_resource_type_to_internal_config_resource_type(
+rd_kafka_ConfigResourceType_t map_from_resource_type_to_config_resource_type(
     rd_kafka_ResourceType_t resourcetype) {
         if (resourcetype == RD_KAFKA_RESOURCE_GROUP) {
                 return RD_KAFKA_CONFIG_RESOURCE_GROUP;
@@ -2922,7 +2921,7 @@ map_from_resource_type_to_internal_config_resource_type(
         return resourcetype;
 }
 
-rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
+rd_kafka_ResourceType_t map_from_config_resource_type_to_resource_type(
     rd_kafka_ConfigResourceType_t internal_resourcetype) {
         if (internal_resourcetype == RD_KAFKA_CONFIG_RESOURCE_GROUP) {
                 return RD_KAFKA_RESOURCE_GROUP;
@@ -3404,9 +3403,8 @@ rd_kafka_IncrementalAlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                 rd_kafka_buf_skip_tags(reply);
 
-                res_type =
-                    map_from_internal_config_resource_type_to_resource_type(
-                        internal_res_type);
+                res_type = map_from_config_resource_type_to_resource_type(
+                    internal_res_type);
 
                 if (error_code) {
                         if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||
@@ -3680,9 +3678,8 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 rd_kafka_buf_read_str(reply, &kres_name);
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
 
-                res_type =
-                    map_from_internal_config_resource_type_to_resource_type(
-                        internal_res_type);
+                res_type = map_from_config_resource_type_to_resource_type(
+                    internal_res_type);
 
                 if (error_code) {
                         if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2868,6 +2868,8 @@ const char *rd_kafka_ConfigSource_name(rd_kafka_ConfigSource_t confsource) {
             "UNKNOWN_CONFIG",        "DYNAMIC_TOPIC_CONFIG",
             "DYNAMIC_BROKER_CONFIG", "DYNAMIC_DEFAULT_BROKER_CONFIG",
             "STATIC_BROKER_CONFIG",  "DEFAULT_CONFIG",
+            "UNSUPPORTED",           "UNSUPPORTED",
+            "GROUP_CONFIG",
         };
 
         if ((unsigned int)confsource >=

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2915,6 +2915,11 @@ const char *rd_kafka_ResourceType_name(rd_kafka_ResourceType_t restype) {
 rd_kafka_InternalConfigResourceType_t
 map_from_resource_type_to_internal_config_resource_type(
     rd_kafka_ResourceType_t resourcetype) {
+
+        if (resourcetype > RD_KAFKA_RESOURCE__CNT) {
+                rd_assert("Invalid resource type");
+        }
+
         switch (resourcetype) {
         case RD_KAFKA_RESOURCE_UNKNOWN:
                 return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN;
@@ -2928,13 +2933,17 @@ map_from_resource_type_to_internal_config_resource_type(
                 return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_BROKER;
         case RD_KAFKA_RESOURCE__CNT:
                 return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT;
-        default:
-                return RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN;
         }
 }
 
 rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
     rd_kafka_InternalConfigResourceType_t internal_resourcetype) {
+
+        if (internal_resourcetype != RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP &&
+            internal_resourcetype > RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT) {
+                rd_assert("Recieved invalid resource type");
+        }
+
         switch (internal_resourcetype) {
         case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN:
                 return RD_KAFKA_RESOURCE_UNKNOWN;
@@ -2948,8 +2957,6 @@ rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
                 return RD_KAFKA_RESOURCE_BROKER;
         case RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT:
                 return RD_KAFKA_RESOURCE__CNT;
-        default:
-                return RD_KAFKA_RESOURCE_UNKNOWN;
         }
 }
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2918,20 +2918,32 @@ const char *rd_kafka_ResourceType_name(rd_kafka_ResourceType_t restype) {
 }
 
 
-int8_t map_from_resource_type_to_config_resource_type(
-    rd_kafka_ResourceType_t restype) {
-        if (restype == RD_KAFKA_RESOURCE_GROUP)
+rd_kafka_ConfigResourceType_t
+rd_kafka_ResourceType_to_ConfigResourceType(rd_kafka_ResourceType_t restype) {
+        switch (restype) {
+        case RD_KAFKA_RESOURCE_TOPIC:
+                return RD_KAFKA_CONFIG_RESOURCE_TOPIC;
+        case RD_KAFKA_RESOURCE_BROKER:
+                return RD_KAFKA_CONFIG_RESOURCE_BROKER;
+        case RD_KAFKA_RESOURCE_GROUP:
                 return RD_KAFKA_CONFIG_RESOURCE_GROUP;
-
-        return restype;
+        default:
+                return RD_KAFKA_CONFIG_RESOURCE_UNKNOWN;
+        }
 }
 
 rd_kafka_ResourceType_t
-map_from_config_resource_type_to_resource_type(int8_t config_resource_type) {
-        if (config_resource_type == RD_KAFKA_CONFIG_RESOURCE_GROUP)
+rd_kafka_ConfigResourceType_to_ResourceType(int8_t config_resource_type) {
+        switch (config_resource_type) {
+        case RD_KAFKA_CONFIG_RESOURCE_TOPIC:
+                return RD_KAFKA_RESOURCE_TOPIC;
+        case RD_KAFKA_CONFIG_RESOURCE_BROKER:
+                return RD_KAFKA_RESOURCE_BROKER;
+        case RD_KAFKA_CONFIG_RESOURCE_GROUP:
                 return RD_KAFKA_RESOURCE_GROUP;
-
-        return config_resource_type;
+        default:
+                return RD_KAFKA_RESOURCE_UNKNOWN;
+        }
 }
 
 
@@ -3214,7 +3226,7 @@ rd_kafka_AlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                 rd_kafka_buf_skip_tags(reply);
 
-                res_type = map_from_config_resource_type_to_resource_type(
+                res_type = rd_kafka_ConfigResourceType_to_ResourceType(
                     config_resource_type);
 
                 if (error_code) {
@@ -3411,7 +3423,7 @@ rd_kafka_IncrementalAlterConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                 rd_kafka_buf_skip_tags(reply);
 
-                res_type = map_from_config_resource_type_to_resource_type(
+                res_type = rd_kafka_ConfigResourceType_to_ResourceType(
                     config_resource_type);
 
                 if (error_code) {
@@ -3686,7 +3698,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                 rd_kafka_buf_read_str(reply, &kres_name);
                 RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
 
-                res_type = map_from_config_resource_type_to_resource_type(
+                res_type = rd_kafka_ConfigResourceType_to_ResourceType(
                     config_resource_type);
 
                 if (error_code) {

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -233,7 +233,7 @@ struct rd_kafka_ConfigEntry_s {
                 rd_bool_t is_synonym;   /**< Value is synonym */
         } a;
 
-        rd_list_t synonyms; /**< Type (rd_kafka_configEntry *) */
+        rd_list_t synonyms;         /**< Type (rd_kafka_configEntry *) */
         rd_kafka_ConfigType_t type; /**< Config type */
         char *documentation;        /**< Config documentation */
 };

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -234,6 +234,8 @@ struct rd_kafka_ConfigEntry_s {
         } a;
 
         rd_list_t synonyms; /**< Type (rd_kafka_configEntry *) */
+        rd_kafka_ConfigType_t type; /**< Config type */
+        char *documentation;        /**< Config documentation */
 };
 
 /**
@@ -282,6 +284,32 @@ struct rd_kafka_ConfigResource_result_s {
                               *   List of config resources, sans config
                               *   but with response error values. */
 };
+
+typedef enum rd_kafka_InternalConfigResourceType_t {
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN = 0,
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_ANY     = 1,
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_TOPIC   = 2,
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP =
+            32,  // Changed value for config APIs
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_BROKER = 4,
+        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT,
+} rd_kafka_InternalConfigResourceType_t;
+
+/**
+ * @brief Map from rd_kafka_ResourceType_t to
+ * rd_kafka_InternalConfigResourceType_t
+ */
+rd_kafka_InternalConfigResourceType_t
+map_to_internal_config_resourcetype(rd_kafka_ResourceType_t resourcetype);
+
+/**
+ * @brief Map from rd_kafka_InternalConfigResourceType_t to
+ * rd_kafka_ResourceType_t
+ */
+
+rd_kafka_ResourceType_t map_from_internal_config_resourcetype(
+    rd_kafka_InternalConfigResourceType_t internal_resourcetype);
+
 
 /**@}*/
 

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -291,8 +291,7 @@ typedef enum rd_kafka_ConfigResourceType_t {
  * @brief Map from rd_kafka_ResourceType_t to
  * rd_kafka_ConfigResourceType_t
  */
-rd_kafka_ConfigResourceType_t
-map_from_resource_type_to_internal_config_resource_type(
+rd_kafka_ConfigResourceType_t map_from_resource_type_to_config_resource_type(
     rd_kafka_ResourceType_t resourcetype);
 
 /**
@@ -300,7 +299,7 @@ map_from_resource_type_to_internal_config_resource_type(
  * rd_kafka_ResourceType_t
  */
 
-rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
+rd_kafka_ResourceType_t map_from_config_resource_type_to_resource_type(
     rd_kafka_ConfigResourceType_t internal_resourcetype);
 
 

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -291,19 +291,22 @@ typedef enum rd_kafka_ConfigResourceType_t {
 } rd_kafka_ConfigResourceType_t;
 
 /**
- * @brief Maps rd_kafka_ResourceType_t to int8_t for IncrementalAlterConfigs
- *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
- *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other
- *        apis.
+ * @brief Maps rd_kafka_ResourceType_t to int8_t(rd_kafka_ConfigResourceType_t)
+ *        for Config Apis. We are incorrectly using rd_kafka_ResourceType_t in
+ *        both Config Apis and ACL Apis. So, we need this function to map the
+ *        resource type internally to rd_kafka_ConfigResourceType_t. Like the
+ *        enum value for GROUP is 32 in Config Apis, but it is 3 for ACL Apis.
  */
 int8_t
 map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
 
 /**
- * @brief Maps int8_t to rd_kafka_ResourceType_t for IncrementalAlterConfigs
- *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
- *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other
- *        apis.
+ * @brief Maps int8_t(rd_kafka_ConfigResourceType_t) to rd_kafka_ResourceType_t
+ *        for Config Apis. We are incorrectly using rd_kafka_ResourceType_t in
+ *        both Config Apis and ACL Apis. So, we need this function to map the
+ *        int8_t(rd_kafka_ConfigResourceType_t) internally to
+ *        rd_kafka_ResourceType_t. Like the enum value for GROUP is 32 in Config
+ *        Apis, but it is 3 for ACL Apis.
  */
 rd_kafka_ResourceType_t
 map_from_config_resource_type_to_resource_type(int8_t config_resource_type);

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -284,23 +284,21 @@ struct rd_kafka_ConfigResource_result_s {
 };
 
 typedef enum rd_kafka_ConfigResourceType_t {
-        RD_KAFKA_CONFIG_RESOURCE_GROUP = 32,  // Changed value for config APIs
+        RD_KAFKA_CONFIG_RESOURCE_GROUP = 32,
 } rd_kafka_ConfigResourceType_t;
 
 /**
- * @brief Map from rd_kafka_ResourceType_t to
- * rd_kafka_ConfigResourceType_t
+ * @brief Map from rd_kafka_ResourceType_t to int8_t
  */
-rd_kafka_ConfigResourceType_t map_from_resource_type_to_config_resource_type(
-    rd_kafka_ResourceType_t resourcetype);
+int8_t
+map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
 
 /**
- * @brief Map from rd_kafka_ConfigResourceType_t to
- * rd_kafka_ResourceType_t
+ * @brief Map from int8_t to rd_kafka_ResourceType_t
  */
 
-rd_kafka_ResourceType_t map_from_config_resource_type_to_resource_type(
-    rd_kafka_ConfigResourceType_t internal_resourcetype);
+rd_kafka_ResourceType_t
+map_from_config_resource_type_to_resource_type(int8_t config_resource_type);
 
 
 /**@}*/

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -233,9 +233,7 @@ struct rd_kafka_ConfigEntry_s {
                 rd_bool_t is_synonym;   /**< Value is synonym */
         } a;
 
-        rd_list_t synonyms;         /**< Type (rd_kafka_configEntry *) */
-        rd_kafka_ConfigType_t type; /**< Config type */
-        char *documentation;        /**< Config documentation */
+        rd_list_t synonyms; /**< Type (rd_kafka_configEntry *) */
 };
 
 /**
@@ -300,14 +298,15 @@ typedef enum rd_kafka_InternalConfigResourceType_t {
  * rd_kafka_InternalConfigResourceType_t
  */
 rd_kafka_InternalConfigResourceType_t
-map_to_internal_config_resourcetype(rd_kafka_ResourceType_t resourcetype);
+map_from_resource_type_to_internal_config_resource_type(
+    rd_kafka_ResourceType_t resourcetype);
 
 /**
  * @brief Map from rd_kafka_InternalConfigResourceType_t to
  * rd_kafka_ResourceType_t
  */
 
-rd_kafka_ResourceType_t map_from_internal_config_resourcetype(
+rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
     rd_kafka_InternalConfigResourceType_t internal_resourcetype);
 
 

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -291,13 +291,17 @@ typedef enum rd_kafka_ConfigResourceType_t {
 } rd_kafka_ConfigResourceType_t;
 
 /**
- * @brief Map from rd_kafka_ResourceType_t to int8_t
+ * @brief Maps rd_kafka_ResourceType_t to int8_t for IncrementalAlterConfigs
+ *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
+ *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other apis.
  */
 int8_t
 map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
 
 /**
- * @brief Map from int8_t to rd_kafka_ResourceType_t
+ * @brief Maps int8_t to rd_kafka_ResourceType_t for IncrementalAlterConfigs
+ *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
+ *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other apis.
  */
 rd_kafka_ResourceType_t
 map_from_config_resource_type_to_resource_type(int8_t config_resource_type);

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -283,6 +283,9 @@ struct rd_kafka_ConfigResource_result_s {
                               *   but with response error values. */
 };
 
+/**
+ * @brief Resource type specific to config apis.
+ */
 typedef enum rd_kafka_ConfigResourceType_t {
         RD_KAFKA_CONFIG_RESOURCE_GROUP = 32,
 } rd_kafka_ConfigResourceType_t;
@@ -296,7 +299,6 @@ map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
 /**
  * @brief Map from int8_t to rd_kafka_ResourceType_t
  */
-
 rd_kafka_ResourceType_t
 map_from_config_resource_type_to_resource_type(int8_t config_resource_type);
 

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -287,7 +287,10 @@ struct rd_kafka_ConfigResource_result_s {
  * @brief Resource type specific to config apis.
  */
 typedef enum rd_kafka_ConfigResourceType_t {
-        RD_KAFKA_CONFIG_RESOURCE_GROUP = 32,
+        RD_KAFKA_CONFIG_RESOURCE_UNKNOWN = 0,
+        RD_KAFKA_CONFIG_RESOURCE_TOPIC   = 2,
+        RD_KAFKA_CONFIG_RESOURCE_BROKER  = 4,
+        RD_KAFKA_CONFIG_RESOURCE_GROUP   = 32,
 } rd_kafka_ConfigResourceType_t;
 
 /**
@@ -297,8 +300,8 @@ typedef enum rd_kafka_ConfigResourceType_t {
  *        resource type internally to rd_kafka_ConfigResourceType_t. Like the
  *        enum value for GROUP is 32 in Config Apis, but it is 3 for ACL Apis.
  */
-int8_t
-map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
+rd_kafka_ConfigResourceType_t
+rd_kafka_ResourceType_to_ConfigResourceType(rd_kafka_ResourceType_t restype);
 
 /**
  * @brief Maps int8_t(rd_kafka_ConfigResourceType_t) to rd_kafka_ResourceType_t
@@ -309,7 +312,7 @@ map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
  *        Apis, but it is 3 for ACL Apis.
  */
 rd_kafka_ResourceType_t
-map_from_config_resource_type_to_resource_type(int8_t config_resource_type);
+rd_kafka_ConfigResourceType_to_ResourceType(int8_t config_resource_type);
 
 
 /**@}*/

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -295,21 +295,21 @@ typedef enum rd_kafka_ConfigResourceType_t {
 
 /**
  * @brief Maps `rd_kafka_ResourceType_t` to `rd_kafka_ConfigResourceType_t`
- *        for Config Apis. We are incorrectly using rd_kafka_ResourceType_t in
+ *        for Config Apis. We are incorrectly using `rd_kafka_ResourceType_t` in
  *        both Config Apis and ACL Apis. So, we need this function to map the
- *        resource type internally to rd_kafka_ConfigResourceType_t. Like the
- *        enum value for GROUP is 32 in Config Apis, but it is 3 for ACL Apis.
+ *        resource type internally to `rd_kafka_ConfigResourceType_t`. Like the
+ *        enum value for `GROUP` is 32 in Config Apis, but it is 3 for ACL Apis.
  */
 rd_kafka_ConfigResourceType_t
 rd_kafka_ResourceType_to_ConfigResourceType(rd_kafka_ResourceType_t restype);
 
 /**
- * @brief Maps int8_t(rd_kafka_ConfigResourceType_t) to rd_kafka_ResourceType_t
- *        for Config Apis. We are incorrectly using rd_kafka_ResourceType_t in
+ * @brief Maps `rd_kafka_ConfigResourceType_t` to `rd_kafka_ResourceType_t`
+ *        for Config Apis. We are incorrectly using `rd_kafka_ResourceType_t` in
  *        both Config Apis and ACL Apis. So, we need this function to map the
- *        int8_t(rd_kafka_ConfigResourceType_t) internally to
- *        rd_kafka_ResourceType_t. Like the enum value for GROUP is 32 in Config
- *        Apis, but it is 3 for ACL Apis.
+ *        `rd_kafka_ConfigResourceType_t` internally to
+ *        `rd_kafka_ResourceType_t`. Like the enum value for `GROUP` is 32 in
+ *        Config Apis, but it is 3 for ACL Apis.
  */
 rd_kafka_ResourceType_t rd_kafka_ConfigResourceType_to_ResourceType(
     rd_kafka_ConfigResourceType_t config_resource_type);

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -294,7 +294,7 @@ typedef enum rd_kafka_ConfigResourceType_t {
 } rd_kafka_ConfigResourceType_t;
 
 /**
- * @brief Maps rd_kafka_ResourceType_t to int8_t(rd_kafka_ConfigResourceType_t)
+ * @brief Maps `rd_kafka_ResourceType_t` to `rd_kafka_ConfigResourceType_t`
  *        for Config Apis. We are incorrectly using rd_kafka_ResourceType_t in
  *        both Config Apis and ACL Apis. So, we need this function to map the
  *        resource type internally to rd_kafka_ConfigResourceType_t. Like the
@@ -311,8 +311,8 @@ rd_kafka_ResourceType_to_ConfigResourceType(rd_kafka_ResourceType_t restype);
  *        rd_kafka_ResourceType_t. Like the enum value for GROUP is 32 in Config
  *        Apis, but it is 3 for ACL Apis.
  */
-rd_kafka_ResourceType_t
-rd_kafka_ConfigResourceType_to_ResourceType(int8_t config_resource_type);
+rd_kafka_ResourceType_t rd_kafka_ConfigResourceType_to_ResourceType(
+    rd_kafka_ConfigResourceType_t config_resource_type);
 
 
 /**@}*/

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -293,7 +293,8 @@ typedef enum rd_kafka_ConfigResourceType_t {
 /**
  * @brief Maps rd_kafka_ResourceType_t to int8_t for IncrementalAlterConfigs
  *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
- *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other apis.
+ *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other
+ *        apis.
  */
 int8_t
 map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
@@ -301,7 +302,8 @@ map_from_resource_type_to_config_resource_type(rd_kafka_ResourceType_t restype);
 /**
  * @brief Maps int8_t to rd_kafka_ResourceType_t for IncrementalAlterConfigs
  *        and DescribeConfigs. Note that the enum value for GROUP is 32 in
- *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other apis.
+ *        IncrementalAlterConfigs and DescribeConfigs, but it is 3 for other
+ *        apis.
  */
 rd_kafka_ResourceType_t
 map_from_config_resource_type_to_resource_type(int8_t config_resource_type);

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -283,31 +283,25 @@ struct rd_kafka_ConfigResource_result_s {
                               *   but with response error values. */
 };
 
-typedef enum rd_kafka_InternalConfigResourceType_t {
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_UNKNOWN = 0,
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_ANY     = 1,
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_TOPIC   = 2,
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_GROUP =
-            32,  // Changed value for config APIs
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_BROKER = 4,
-        RD_KAFKA_INTERNAL_RESOURCE_CONFIG_CNT,
-} rd_kafka_InternalConfigResourceType_t;
+typedef enum rd_kafka_ConfigResourceType_t {
+        RD_KAFKA_CONFIG_RESOURCE_GROUP = 32,  // Changed value for config APIs
+} rd_kafka_ConfigResourceType_t;
 
 /**
  * @brief Map from rd_kafka_ResourceType_t to
- * rd_kafka_InternalConfigResourceType_t
+ * rd_kafka_ConfigResourceType_t
  */
-rd_kafka_InternalConfigResourceType_t
+rd_kafka_ConfigResourceType_t
 map_from_resource_type_to_internal_config_resource_type(
     rd_kafka_ResourceType_t resourcetype);
 
 /**
- * @brief Map from rd_kafka_InternalConfigResourceType_t to
+ * @brief Map from rd_kafka_ConfigResourceType_t to
  * rd_kafka_ResourceType_t
  */
 
 rd_kafka_ResourceType_t map_from_internal_config_resource_type_to_resource_type(
-    rd_kafka_InternalConfigResourceType_t internal_resourcetype);
+    rd_kafka_ConfigResourceType_t internal_resourcetype);
 
 
 /**@}*/

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5426,7 +5426,8 @@ rd_kafka_resp_err_t rd_kafka_IncrementalAlterConfigsRequest(
                 /* ResourceType */
                 rd_kafka_buf_write_i8(
                     rkbuf,
-                    map_to_internal_config_resourcetype(config->restype));
+                    map_from_resource_type_to_internal_config_resource_type(
+                        config->restype));
 
                 /* ResourceName */
                 rd_kafka_buf_write_str(rkbuf, config->name, -1);
@@ -5500,7 +5501,7 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DescribeConfigs, 0, 3, NULL);
+            rkb, RD_KAFKAP_DescribeConfigs, 0, 1, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "DescribeConfigs (KIP-133) not supported "
@@ -5509,9 +5510,8 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DescribeConfigs,
-                                                 1, rd_list_cnt(configs) * 200,
-                                                 ApiVersion >= 4);
+        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_DescribeConfigs, 1,
+                                         rd_list_cnt(configs) * 200);
 
         /* #resources */
         rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(configs));
@@ -5523,7 +5523,8 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
                 /* resource_type */
                 rd_kafka_buf_write_i8(
                     rkbuf,
-                    map_to_internal_config_resourcetype(config->restype));
+                    map_from_resource_type_to_internal_config_resource_type(
+                        config->restype));
 
                 /* resource_name */
                 rd_kafka_buf_write_str(rkbuf, config->name, -1);
@@ -5542,20 +5543,13 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
                         /* config_name */
                         rd_kafka_buf_write_str(rkbuf, entry->kv->name, -1);
                 }
-                rd_kafka_buf_write_tags_empty(rkbuf);
         }
 
 
-        if (ApiVersion >= 1) {
+        if (ApiVersion == 1) {
                 /* include_synonyms */
                 rd_kafka_buf_write_i8(rkbuf, 1);
         }
-
-        if (ApiVersion >= 3) {
-                /* include_documentation */
-                rd_kafka_buf_write_i8(rkbuf, 1);
-        }
-        rd_kafka_buf_write_tags_empty(rkbuf);
 
         /* timeout */
         op_timeout = rd_kafka_confval_get_int(&options->operation_timeout);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5425,9 +5425,8 @@ rd_kafka_resp_err_t rd_kafka_IncrementalAlterConfigsRequest(
 
                 /* ResourceType */
                 rd_kafka_buf_write_i8(
-                    rkbuf,
-                    map_from_resource_type_to_internal_config_resource_type(
-                        config->restype));
+                    rkbuf, map_from_resource_type_to_config_resource_type(
+                               config->restype));
 
                 /* ResourceName */
                 rd_kafka_buf_write_str(rkbuf, config->name, -1);
@@ -5522,9 +5521,8 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
 
                 /* resource_type */
                 rd_kafka_buf_write_i8(
-                    rkbuf,
-                    map_from_resource_type_to_internal_config_resource_type(
-                        config->restype));
+                    rkbuf, map_from_resource_type_to_config_resource_type(
+                               config->restype));
 
                 /* resource_name */
                 rd_kafka_buf_write_str(rkbuf, config->name, -1);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5343,7 +5343,7 @@ rd_kafka_AlterConfigsRequest(rd_kafka_broker_t *rkb,
 
                 /* ResourceType */
                 rd_kafka_buf_write_i8(
-                    rkbuf, map_from_resource_type_to_config_resource_type(
+                    rkbuf, rd_kafka_ResourceType_to_ConfigResourceType(
                                config->restype));
 
                 /* ResourceName */
@@ -5427,7 +5427,7 @@ rd_kafka_resp_err_t rd_kafka_IncrementalAlterConfigsRequest(
 
                 /* ResourceType */
                 rd_kafka_buf_write_i8(
-                    rkbuf, map_from_resource_type_to_config_resource_type(
+                    rkbuf, rd_kafka_ResourceType_to_ConfigResourceType(
                                config->restype));
 
                 /* ResourceName */
@@ -5523,7 +5523,7 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
 
                 /* resource_type */
                 rd_kafka_buf_write_i8(
-                    rkbuf, map_from_resource_type_to_config_resource_type(
+                    rkbuf, rd_kafka_ResourceType_to_ConfigResourceType(
                                config->restype));
 
                 /* resource_name */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5342,7 +5342,9 @@ rd_kafka_AlterConfigsRequest(rd_kafka_broker_t *rkb,
                 int ei;
 
                 /* ResourceType */
-                rd_kafka_buf_write_i8(rkbuf, config->restype);
+                rd_kafka_buf_write_i8(
+                    rkbuf, map_from_resource_type_to_config_resource_type(
+                               config->restype));
 
                 /* ResourceName */
                 rd_kafka_buf_write_str(rkbuf, config->name, -1);

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1063,7 +1063,12 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
             configs[ci], "consumer.session.timeout.ms",
             RD_KAFKA_ALTER_CONFIG_OP_TYPE_SET, "50000");
         TEST_ASSERT(!error, "%s", rd_kafka_error_string(error));
-        exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
+        if (group_configs_supported() &&
+            !test_consumer_group_protocol_classic) {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
+        } else {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+        }
         ci++;
 
         /*

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1481,12 +1481,12 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                 }
 
                 if (err != exp_err) {
-                    TEST_FAIL_LATER(
-                        "ConfigResource #%d: "
-                        "expected %s (%d), got %s (%s)",
-                        i, rd_kafka_err2name(exp_err), exp_err,
-                        rd_kafka_err2name(err), errstr2 ? errstr2 : "");
-                    fails++;
+                        TEST_FAIL_LATER(
+                            "ConfigResource #%d: "
+                            "expected %s (%d), got %s (%s)",
+                            i, rd_kafka_err2name(exp_err), exp_err,
+                            rd_kafka_err2name(err), errstr2 ? errstr2 : "");
+                        fails++;
                 }
         }
 

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -948,7 +948,7 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                 const char *confs_delete_subtract_broker[] = {
                     "background.threads", "DELETE",   "",
                     "log.cleanup.policy", "SUBTRACT", "compact"};
-                const char *confs_set_append_group[] = {
+                const char *confs_set_group[] = {
                     "consumer.session.timeout.ms", "SET", "50000"};
                 const char *confs_delete_group[] = {
                     "consumer.session.timeout.ms", "DELETE", ""};
@@ -978,7 +978,7 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                     "Testing test helper with SET with GROUP resource type\n");
                 test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP,
                                                     group_id,
-                                                    confs_set_append_group, 1);
+                                                    confs_set_group, 1);
                 TEST_SAY(
                     "Testing test helper with DELETE with GROUP resource "
                     "type\n");
@@ -1484,7 +1484,6 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                                 rd_kafka_ConfigResource_type(rconfigs[i])),
                             rd_kafka_ConfigResource_name(rconfigs[i]));
                         fails++;
-                        continue;
                 }
         }
 

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1372,9 +1372,10 @@ retry_describe:
  */
 static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                                            rd_kafka_queue_t *rkqu) {
-        rd_kafka_ConfigResource_t *configs[1];
+#define MY_CONFRES_CNT 1
+        rd_kafka_ConfigResource_t *configs[MY_CONFRES_CNT];
         rd_kafka_AdminOptions_t *options;
-        rd_kafka_resp_err_t exp_err;
+        rd_kafka_resp_err_t exp_err[MY_CONFRES_CNT];
         rd_kafka_event_t *rkev;
         rd_kafka_resp_err_t err;
         const rd_kafka_DescribeConfigs_result_t *res;
@@ -1392,14 +1393,15 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
         /*
          * ConfigResource #0: group config, for a non-existent group.
          */
-        configs[0] =
+        configs[ci] =
             rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
         if (test_broker_version >= TEST_BRKVER(3, 8, 0, 0) &&
             !test_consumer_group_protocol_classic()) {
-                exp_err = RD_KAFKA_RESP_ERR_NO_ERROR;
+                exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
-                exp_err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+                exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
         }
+        ci++;
 
         /*
          * Timeout options
@@ -1480,11 +1482,11 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                         fails++;
                 }
 
-                if (err != exp_err) {
+                if (err != exp_err[i]) {
                         TEST_FAIL_LATER(
                             "ConfigResource #%d: "
                             "expected %s (%d), got %s (%s)",
-                            i, rd_kafka_err2name(exp_err), exp_err,
+                            i, rd_kafka_err2name(exp_err[i]), exp_err[i],
                             rd_kafka_err2name(err), errstr2 ? errstr2 : "");
                         fails++;
                 }

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -902,7 +902,7 @@ static void do_test_AlterConfigs(rd_kafka_t *rk, rd_kafka_queue_t *rkqu) {
  */
 static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                                             rd_kafka_queue_t *rkqu) {
-#define MY_CONFRES_CNT 3
+#define MY_CONFRES_CNT 4
         char *topics[MY_CONFRES_CNT];
         rd_kafka_ConfigResource_t *configs[MY_CONFRES_CNT];
         rd_kafka_AdminOptions_t *options;
@@ -935,6 +935,7 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
         /** Test the test helper, for use in other tests. */
         do {
                 const char *broker_id = tsprintf("%d", avail_brokers[0]);
+                const char *group_id  = "my-group";
                 const char *confs_set_append[] = {
                     "compression.type", "SET",    "lz4",
                     "cleanup.policy",   "APPEND", "compact"};
@@ -947,6 +948,10 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                 const char *confs_delete_subtract_broker[] = {
                     "background.threads", "DELETE",   "",
                     "log.cleanup.policy", "SUBTRACT", "compact"};
+                const char *confs_set_append_group[] = {
+                    "consumer.session.timeout.ms", "SET", "50000"};
+                const char *confs_delete_group[] = {
+                    "consumer.session.timeout.ms", "DELETE", ""};
 
                 TEST_SAY("Testing test helper with SET and APPEND\n");
                 test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_TOPIC,
@@ -969,6 +974,17 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                 test_IncrementalAlterConfigs_simple(
                     rk, RD_KAFKA_RESOURCE_BROKER, broker_id,
                     confs_delete_subtract_broker, 2);
+                TEST_SAY(
+                    "Testing test helper with SET with GROUP resource type\n");
+                test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP,
+                                                    group_id,
+                                                    confs_set_append_group, 1);
+                TEST_SAY(
+                    "Testing test helper with DELETE with GROUP resource "
+                    "type\n");
+                test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP,
+                                                    group_id,
+                                                    confs_delete_group, 1);
                 TEST_SAY("End testing test helper\n");
         } while (0);
 
@@ -1033,6 +1049,23 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                 exp_err[ci] = RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
         else
                 exp_err[ci] = RD_KAFKA_RESP_ERR_UNKNOWN;
+        ci++;
+
+        /**
+         * ConfigResource #3: valid group config
+         */
+        configs[ci] =
+            rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, "my-group");
+
+        error = rd_kafka_ConfigResource_add_incremental_config(
+            configs[ci], "consumer.session.timeout.ms",
+            RD_KAFKA_ALTER_CONFIG_OP_TYPE_SET, "50000");
+        TEST_ASSERT(!error, "%s", rd_kafka_error_string(error));
+        if (!test_consumer_group_protocol_classic()) {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
+        } else {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+        }
         ci++;
 
         /*
@@ -1319,6 +1352,137 @@ retry_describe:
                             i, rd_kafka_err2name(exp_err[i]), exp_err[i],
                             rd_kafka_err2name(err), errstr2 ? errstr2 : "");
                         fails++;
+                }
+        }
+
+        TEST_ASSERT(!fails, "See %d previous failure(s)", fails);
+
+        rd_kafka_event_destroy(rkev);
+
+        rd_kafka_ConfigResource_destroy_array(configs, ci);
+
+        TEST_LATER_CHECK();
+#undef MY_CONFRES_CNT
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test DescribeConfigs for groups
+ */
+static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
+                                           rd_kafka_queue_t *rkqu) {
+#define MY_CONFRES_CNT 1
+        rd_kafka_ConfigResource_t *configs[MY_CONFRES_CNT];
+        rd_kafka_AdminOptions_t *options;
+        rd_kafka_resp_err_t exp_err[MY_CONFRES_CNT];
+        rd_kafka_event_t *rkev;
+        rd_kafka_resp_err_t err;
+        const rd_kafka_DescribeConfigs_result_t *res;
+        const rd_kafka_ConfigResource_t **rconfigs;
+        char *group = rd_strdup(test_mk_topic_name(__FUNCTION__, 1));
+        size_t rconfig_cnt;
+        char errstr[128];
+        const char *errstr2;
+        int ci = 0;
+        int i;
+        int fails = 0;
+
+        SUB_TEST_QUICK();
+
+        /*
+         * ConfigResource #0: group config, for a non-existent group.
+         */
+        /*
+         * ConfigResource #3: group config, for a non-existent group.
+         */
+        configs[ci] =
+            rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
+        if (!test_consumer_group_protocol_classic()) {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
+        } else {
+                exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+        }
+        ci++;
+
+        /*
+         * Timeout options
+         */
+        options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ANY);
+        err = rd_kafka_AdminOptions_set_request_timeout(options, 10000, errstr,
+                                                        sizeof(errstr));
+        TEST_ASSERT(!err, "%s", errstr);
+
+        /*
+         * Fire off request
+         */
+        rd_kafka_DescribeConfigs(rk, configs, ci, options, rkqu);
+
+        /*
+         * Wait for result
+         */
+        rkev = test_wait_admin_result(
+            rkqu, RD_KAFKA_EVENT_DESCRIBECONFIGS_RESULT, 10000 + 1000);
+
+        /*
+         * Extract result
+         */
+        res = rd_kafka_event_DescribeConfigs_result(rkev);
+        TEST_ASSERT(res, "Expected DescribeConfigs result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(!err, "Expected success, not %s: %s",
+                    rd_kafka_err2name(err), errstr2);
+
+        rconfigs = rd_kafka_DescribeConfigs_result_resources(res, &rconfig_cnt);
+        TEST_ASSERT((int)rconfig_cnt == ci,
+                    "Expected %d result resources, got %" PRIusz "\n", ci,
+                    rconfig_cnt);
+
+        /*
+         * Verify status per resource
+         */
+        for (i = 0; i < (int)rconfig_cnt; i++) {
+                const rd_kafka_ConfigEntry_t **entries;
+                size_t entry_cnt;
+
+                err     = rd_kafka_ConfigResource_error(rconfigs[i]);
+                errstr2 = rd_kafka_ConfigResource_error_string(rconfigs[i]);
+
+                entries =
+                    rd_kafka_ConfigResource_configs(rconfigs[i], &entry_cnt);
+
+                TEST_SAY(
+                    "ConfigResource #%d: type %s (%d), \"%s\": "
+                    "%" PRIusz " ConfigEntries, error %s (%s)\n",
+                    i,
+                    rd_kafka_ResourceType_name(
+                        rd_kafka_ConfigResource_type(rconfigs[i])),
+                    rd_kafka_ConfigResource_type(rconfigs[i]),
+                    rd_kafka_ConfigResource_name(rconfigs[i]), entry_cnt,
+                    rd_kafka_err2name(err), errstr2 ? errstr2 : "");
+
+                test_print_ConfigEntry_array(entries, entry_cnt, 1);
+
+                if (rd_kafka_ConfigResource_type(rconfigs[i]) !=
+                        rd_kafka_ConfigResource_type(configs[i]) ||
+                    strcmp(rd_kafka_ConfigResource_name(rconfigs[i]),
+                           rd_kafka_ConfigResource_name(configs[i]))) {
+                        TEST_FAIL_LATER(
+                            "ConfigResource #%d: "
+                            "expected type %s name %s, "
+                            "got type %s name %s",
+                            i,
+                            rd_kafka_ResourceType_name(
+                                rd_kafka_ConfigResource_type(configs[i])),
+                            rd_kafka_ConfigResource_name(configs[i]),
+                            rd_kafka_ResourceType_name(
+                                rd_kafka_ConfigResource_type(rconfigs[i])),
+                            rd_kafka_ConfigResource_name(rconfigs[i]));
+                        fails++;
+                        continue;
                 }
         }
 
@@ -5267,6 +5431,7 @@ static void do_test_apis(rd_kafka_type_t cltype) {
 
         /* DescribeConfigs */
         do_test_DescribeConfigs(rk, mainq);
+        do_test_DescribeConfigs_groups(rk, mainq);
 
         /* Delete records */
         do_test_DeleteRecords("temp queue, op timeout 0", rk, NULL, 0);

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1064,7 +1064,7 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
             RD_KAFKA_ALTER_CONFIG_OP_TYPE_SET, "50000");
         TEST_ASSERT(!error, "%s", rd_kafka_error_string(error));
         if (group_configs_supported() &&
-            !test_consumer_group_protocol_classic) {
+            !test_consumer_group_protocol_classic()) {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -40,7 +40,7 @@ static int32_t *avail_brokers;
 static size_t avail_broker_cnt;
 
 #define group_configs_supported()                                              \
-        (test_broker_version >= TEST_BRKVER(3, 8, 0, 0))
+        (test_broker_version >= TEST_BRKVER(4, 0, 0, 0))
 
 
 
@@ -1063,8 +1063,7 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
             configs[ci], "consumer.session.timeout.ms",
             RD_KAFKA_ALTER_CONFIG_OP_TYPE_SET, "50000");
         TEST_ASSERT(!error, "%s", rd_kafka_error_string(error));
-        if (group_configs_supported() &&
-            !test_consumer_group_protocol_classic()) {
+        if (group_configs_supported()) {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
@@ -1400,8 +1399,7 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
          */
         configs[ci] =
             rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
-        if (group_configs_supported() &&
-            !test_consumer_group_protocol_classic()) {
+        if (group_configs_supported()) {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
@@ -1470,17 +1468,17 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                 test_print_ConfigEntry_array(entries, entry_cnt, 1);
 
                 if (rd_kafka_ConfigResource_type(rconfigs[i]) !=
-                        rd_kafka_ConfigResource_type(configs[0]) ||
+                        rd_kafka_ConfigResource_type(configs[i]) ||
                     strcmp(rd_kafka_ConfigResource_name(rconfigs[i]),
-                           rd_kafka_ConfigResource_name(configs[0]))) {
+                           rd_kafka_ConfigResource_name(configs[i]))) {
                         TEST_FAIL_LATER(
                             "ConfigResource #%d: "
                             "expected type %s name %s, "
                             "got type %s name %s",
                             i,
                             rd_kafka_ResourceType_name(
-                                rd_kafka_ConfigResource_type(configs[0])),
-                            rd_kafka_ConfigResource_name(configs[0]),
+                                rd_kafka_ConfigResource_type(configs[i])),
+                            rd_kafka_ConfigResource_name(configs[i]),
                             rd_kafka_ResourceType_name(
                                 rd_kafka_ConfigResource_type(rconfigs[i])),
                             rd_kafka_ConfigResource_name(rconfigs[i]));

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1061,7 +1061,8 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
             configs[ci], "consumer.session.timeout.ms",
             RD_KAFKA_ALTER_CONFIG_OP_TYPE_SET, "50000");
         TEST_ASSERT(!error, "%s", rd_kafka_error_string(error));
-        if (!test_consumer_group_protocol_classic()) {
+        if (test_broker_version >= TEST_BRKVER(3, 8, 0, 0) &&
+            !test_consumer_group_protocol_classic()) {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
@@ -1398,7 +1399,8 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
          */
         configs[ci] =
             rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
-        if (!test_consumer_group_protocol_classic()) {
+        if (test_broker_version >= TEST_BRKVER(3, 8, 0, 0) &&
+            !test_consumer_group_protocol_classic()) {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
                 exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1372,10 +1372,9 @@ retry_describe:
  */
 static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                                            rd_kafka_queue_t *rkqu) {
-#define MY_CONFRES_CNT 1
-        rd_kafka_ConfigResource_t *configs[MY_CONFRES_CNT];
+        rd_kafka_ConfigResource_t *configs;
         rd_kafka_AdminOptions_t *options;
-        rd_kafka_resp_err_t exp_err[MY_CONFRES_CNT];
+        rd_kafka_resp_err_t exp_err;
         rd_kafka_event_t *rkev;
         rd_kafka_resp_err_t err;
         const rd_kafka_DescribeConfigs_result_t *res;
@@ -1393,18 +1392,14 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
         /*
          * ConfigResource #0: group config, for a non-existent group.
          */
-        /*
-         * ConfigResource #3: group config, for a non-existent group.
-         */
-        configs[ci] =
+        configs =
             rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
         if (test_broker_version >= TEST_BRKVER(3, 8, 0, 0) &&
             !test_consumer_group_protocol_classic()) {
-                exp_err[ci] = RD_KAFKA_RESP_ERR_NO_ERROR;
+                exp_err = RD_KAFKA_RESP_ERR_NO_ERROR;
         } else {
-                exp_err[ci] = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+                exp_err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
         }
-        ci++;
 
         /*
          * Timeout options
@@ -1468,17 +1463,17 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                 test_print_ConfigEntry_array(entries, entry_cnt, 1);
 
                 if (rd_kafka_ConfigResource_type(rconfigs[i]) !=
-                        rd_kafka_ConfigResource_type(configs[i]) ||
-                    strcmp(rd_kafka_ConfigResource_name(rconfigs[i]),
-                           rd_kafka_ConfigResource_name(configs[i]))) {
+                        rd_kafka_ConfigResource_type(configs) ||
+                    strcmp(rd_kafka_ConfigResource_name(rconfigs),
+                           rd_kafka_ConfigResource_name(configs))) {
                         TEST_FAIL_LATER(
                             "ConfigResource #%d: "
                             "expected type %s name %s, "
                             "got type %s name %s",
                             i,
                             rd_kafka_ResourceType_name(
-                                rd_kafka_ConfigResource_type(configs[i])),
-                            rd_kafka_ConfigResource_name(configs[i]),
+                                rd_kafka_ConfigResource_type(configs)),
+                            rd_kafka_ConfigResource_name(configs),
                             rd_kafka_ResourceType_name(
                                 rd_kafka_ConfigResource_type(rconfigs[i])),
                             rd_kafka_ConfigResource_name(rconfigs[i]));
@@ -1493,7 +1488,6 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
         rd_kafka_ConfigResource_destroy_array(configs, ci);
 
         TEST_LATER_CHECK();
-#undef MY_CONFRES_CNT
 
         SUB_TEST_PASS();
 }

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -948,8 +948,8 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                 const char *confs_delete_subtract_broker[] = {
                     "background.threads", "DELETE",   "",
                     "log.cleanup.policy", "SUBTRACT", "compact"};
-                const char *confs_set_group[] = {
-                    "consumer.session.timeout.ms", "SET", "50000"};
+                const char *confs_set_group[] = {"consumer.session.timeout.ms",
+                                                 "SET", "50000"};
                 const char *confs_delete_group[] = {
                     "consumer.session.timeout.ms", "DELETE", ""};
 
@@ -976,9 +976,8 @@ static void do_test_IncrementalAlterConfigs(rd_kafka_t *rk,
                     confs_delete_subtract_broker, 2);
                 TEST_SAY(
                     "Testing test helper with SET with GROUP resource type\n");
-                test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP,
-                                                    group_id,
-                                                    confs_set_group, 1);
+                test_IncrementalAlterConfigs_simple(
+                    rk, RD_KAFKA_RESOURCE_GROUP, group_id, confs_set_group, 1);
                 TEST_SAY(
                     "Testing test helper with DELETE with GROUP resource "
                     "type\n");

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1372,7 +1372,7 @@ retry_describe:
  */
 static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                                            rd_kafka_queue_t *rkqu) {
-        rd_kafka_ConfigResource_t *configs;
+        rd_kafka_ConfigResource_t *configs[1];
         rd_kafka_AdminOptions_t *options;
         rd_kafka_resp_err_t exp_err;
         rd_kafka_event_t *rkev;
@@ -1392,7 +1392,7 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
         /*
          * ConfigResource #0: group config, for a non-existent group.
          */
-        configs =
+        configs[0] =
             rd_kafka_ConfigResource_new(RD_KAFKA_RESOURCE_GROUP, group);
         if (test_broker_version >= TEST_BRKVER(3, 8, 0, 0) &&
             !test_consumer_group_protocol_classic()) {
@@ -1463,21 +1463,30 @@ static void do_test_DescribeConfigs_groups(rd_kafka_t *rk,
                 test_print_ConfigEntry_array(entries, entry_cnt, 1);
 
                 if (rd_kafka_ConfigResource_type(rconfigs[i]) !=
-                        rd_kafka_ConfigResource_type(configs) ||
-                    strcmp(rd_kafka_ConfigResource_name(rconfigs),
-                           rd_kafka_ConfigResource_name(configs))) {
+                        rd_kafka_ConfigResource_type(configs[0]) ||
+                    strcmp(rd_kafka_ConfigResource_name(rconfigs[i]),
+                           rd_kafka_ConfigResource_name(configs[0]))) {
                         TEST_FAIL_LATER(
                             "ConfigResource #%d: "
                             "expected type %s name %s, "
                             "got type %s name %s",
                             i,
                             rd_kafka_ResourceType_name(
-                                rd_kafka_ConfigResource_type(configs)),
-                            rd_kafka_ConfigResource_name(configs),
+                                rd_kafka_ConfigResource_type(configs[0])),
+                            rd_kafka_ConfigResource_name(configs[0]),
                             rd_kafka_ResourceType_name(
                                 rd_kafka_ConfigResource_type(rconfigs[i])),
                             rd_kafka_ConfigResource_name(rconfigs[i]));
                         fails++;
+                }
+
+                if (err != exp_err) {
+                    TEST_FAIL_LATER(
+                        "ConfigResource #%d: "
+                        "expected %s (%d), got %s (%s)",
+                        i, rd_kafka_err2name(exp_err), exp_err,
+                        rd_kafka_err2name(err), errstr2 ? errstr2 : "");
+                    fails++;
                 }
         }
 


### PR DESCRIPTION
This PR intends to add support for Group Resource type for IncrementalALterConfigs API as specified in KIP 848 and extended the DescribeConfigs support till API version 3.
Additional changed the integration test to check for Group Resource Type.