### PR TITLE
Avoid "ignored-qualifiers" warning in rdkafka.h.

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -8401,7 +8401,7 @@ const rd_kafka_TopicPartitionInfo_t **rd_kafka_TopicDescription_partitions(
  * @return The partition id.
  */
 RD_EXPORT
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition);
 
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -8638,7 +8638,7 @@ static void rd_kafka_TopicDescription_free(void *ptr) {
         rd_kafka_TopicDescription_destroy(ptr);
 }
 
-const int rd_kafka_TopicPartitionInfo_partition(
+int rd_kafka_TopicPartitionInfo_partition(
     const rd_kafka_TopicPartitionInfo_t *partition) {
         return partition->partition;
 }


### PR DESCRIPTION
This avoid this simple warning:

```
/remote/tmp/rnd-css/bms_workflow_replica/osp/Librdkafka/23-0-0-4/include/librdkafka/rdkafka.h:8258:1: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
 8258 | const int rd_kafka_TopicPartitionInfo_partition(
      | ^~~~~
```

indeed returning a `const int` makes no sense, it's just `int`.