### PR TITLE
Fix: Avoid unnecessary producer epoch bumps

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3871,7 +3871,7 @@ rd_kafka_handle_idempotent_Produce_error(rd_kafka_broker_t *rkb,
                          * reason about the state of messages and thus
                          * not guarantee ordering or once-ness for R1,
                          * nor give the user a chance to opt out of sending
-                         * R2 to R4 which would be retried automatically. */
+                         * R2 to R5 which would be retried automatically. */
 
                         rd_kafka_idemp_set_fatal_error(
                             rk, perr->err,


### PR DESCRIPTION
 Fixes: #4953
 
 When the producer is idempotent and `max.in.flight.requests.per.connection` is set to a value between 2 and 5, it's normal to receive `OUT_OF_ORDER_SEQUENCE_NUMBER` produce responses for requests R2 through R5 when the R1 failed for any other reason.
 
Bumping the producer epoch in this scenario violates the "exactly-once" guarantees. Therefore, we believe that it's unnecessary to bump the producer's epoch; re-enqueuing the messages is sufficient.
 
The same "retry, but don't bump producer epoch" behavior is implemented in the Java client: https://github.com/apache/kafka/blob/a6a588fbed9982598377060c63f94ee6184b4295/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1015-L1016