### PR TITLE
* fix build Visual C++

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -39,6 +39,7 @@
 
 #ifdef _WIN32
 #include <wincrypt.h>
+#undef X509_NAME
 #pragma comment(lib, "crypt32.lib")
 #pragma comment(lib, "libcrypto.lib")
 #pragma comment(lib, "libssl.lib")


### PR DESCRIPTION
wincrypt.h

#define X509_NAME                           ((LPCSTR) 7)

Error:

librdkafka\src\rdkafka_ssl.c(1044,30): error C2065: 'issuer_dn': undeclared identifier
librdkafka\src\rdkafka_ssl.c(1044,30): error C2296: '*': illegal, left operand has type 'LPCSTR'
librdkafka\src\rdkafka_ssl.c(1045,22): error C2065: 'dn': undeclared identifier
librdkafka\src\rdkafka_ssl.c(1045,22): error C2296: '*': illegal, left operand has type 'LPCSTR'
librdkafka\src\rdkafka_ssl.c(1049,20): error C2065: 'dn': undeclared identifier
librdkafka\src\rdkafka_ssl.c(1049,51): warning C4047: '=': 'int' differs in levels of indirection from 'X509_NAME *'
librdkafka\src\rdkafka_ssl.c(1050,42): error C2065: 'dn': undeclared identifier
librdkafka\src\rdkafka_ssl.c(1050,42): warning C4047: 'function': 'const X509_NAME *' differs in levels of indirection from 'int'
librdkafka\src\rdkafka_ssl.c(1050,40): warning C4024: 'X509_NAME_cmp': different types for formal and actual parameter 1
librdkafka\src\rdkafka_ssl.c(1050,53): error C2065: 'issuer_dn': undeclared identifier
librdkafka\src\rdkafka_ssl.c(1050,53): warning C4047: 'function': 'const X509_NAME *' differs in levels of indirection from 'int'
librdkafka\src\rdkafka_ssl.c(1050,44): warning C4024: 'X509_NAME_cmp': different types for formal and actual parameter 2