### PR TITLE
Fixing race in rd_kafka_fetch_pos2str

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -4631,7 +4631,7 @@ void rd_kafka_partition_leader_destroy_free(void *ptr) {
 
 const char *rd_kafka_fetch_pos2str(const rd_kafka_fetch_pos_t fetchpos) {
         static RD_TLS char ret[2][64];
-        static int idx;
+        static RD_TLS int idx;
 
         idx = (idx + 1) % 2;
 


### PR DESCRIPTION
Example report from the build with thread sanitizer:

https://s3.amazonaws.com/clickhouse-test-reports/PRs/76621/9f945d18dc233e523ce746f73c856409e1ed8670//integration_tests_tsan_3_6/integration_run_test_storage_kafka_test_batch_fast_py_0.log