### PR TITLE
Fix checking SASLHandshake from APIVersions

### DIFF
--- a/src/rdkafka_feature.c
+++ b/src/rdkafka_feature.c
@@ -156,7 +156,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_SASL_HANDSHAKE,
         .depends =
             {
-                {RD_KAFKAP_SaslHandshake, 0, 0},
+                {RD_KAFKAP_SaslHandshake, 0, 1},
                 {-1},
             },
     },


### PR DESCRIPTION
`librdkafka`'s current (SASL) authentication behavior:

1. It sends an `APIVersions` request and sets `RD_KAFKA_FEATURE_SASL_HANDSHAKE` if the supported versions of [`SASLHandshake` from server overlap with `[0, 0]`](https://github.com/confluentinc/librdkafka/blob/93877617709eb071a0f4ec7038c54e2764abefc9/src/rdkafka_feature.c#L159).

2. If not set, it [errors](https://github.com/confluentinc/librdkafka/blob/93877617709eb071a0f4ec7038c54e2764abefc9/src/rdkafka_sasl.c#L254) with _SASL Handshake not supported by broker_.
3. If set, it sends a `SASLHandshake` request at the [supported highest version in `[0, 1]`](https://github.com/confluentinc/librdkafka/blob/93877617709eb071a0f4ec7038c54e2764abefc9/src/rdkafka_request.c#L3245).

In short, if the server doesn't support version 0, `librdkafka` errors. If the server supports version 0 and 1, `librdkafka` sends a request at version 1.

This PR fixes step 1 to make it allow versions `[0, 1]`, consistent with step 3.