### PR TITLE
Fix SSL verification fail bug when Kafka endpoint is a FQDN with a do…

### DIFF
--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -581,6 +581,11 @@ void rd_kafka_transport_post_connect_setup(rd_kafka_transport_t *rktrans) {
  * Locality: broker thread
  */
 static void rd_kafka_transport_connected(rd_kafka_transport_t *rktrans) {
+        // If the domain name is an FQDN, remove the trailing dot
+        char* dot = strrchr(rktrans->rktrans_rkb->rkb_nodename, '.');
+        if (dot != NULL && dot[1] == ':')
+                memmove(dot, &dot[1], strlen(&dot[1]) + 1);
+
         rd_kafka_broker_t *rkb = rktrans->rktrans_rkb;
 
         rd_rkb_dbg(


### PR DESCRIPTION
I'm not able to connect to Kafka server when the BOOTSTRAP_BROKER is a FQDN with a dot at the end.
Different Kafka implementation provide endpoints with a dot at the end so you can use a BOOTSTRAP_BROKER without dot at the end but you ad not able to connect to the topic anyway.