### PR TITLE
[KIP-848] Removed partition.assignment.strategy configuration for the new consumer protocol

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2488,9 +2488,6 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                 goto fail;
         }
 
-        if (rk->rk_conf.group_protocol == RD_KAFKA_GROUP_PROTOCOL_CONSUMER)
-                rk->rk_conf.partition_assignors_cooperative = rd_true;
-
         /* Create Mock cluster */
         rd_atomic32_init(&rk->rk_mock.cluster_cnt, 0);
         if (rk->rk_conf.mock.broker_cnt > 0) {

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2286,7 +2286,6 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
         rd_kafka_resp_err_t ret_err = RD_KAFKA_RESP_ERR_NO_ERROR;
         int ret_errno               = 0;
         const char *conf_err;
-        char *group_remote_assignor_override = NULL;
 #ifndef _WIN32
         sigset_t newset, oldset;
 #endif
@@ -2489,63 +2488,8 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                 goto fail;
         }
 
-        if (!rk->rk_conf.group_remote_assignor) {
-                rd_kafka_assignor_t *cooperative_assignor;
-
-                /* Detect if chosen assignor is cooperative
-                 * FIXME: remove this compatibility altogether
-                 * and apply the breaking changes that will be required
-                 * in next major version. */
-
-                cooperative_assignor =
-                    rd_kafka_assignor_find(rk, "cooperative-sticky");
-                rk->rk_conf.partition_assignors_cooperative =
-                    !rk->rk_conf.partition_assignors.rl_cnt ||
-                    (cooperative_assignor &&
-                     cooperative_assignor->rkas_enabled);
-
-                if (rk->rk_conf.group_protocol ==
-                    RD_KAFKA_GROUP_PROTOCOL_CONSUMER) {
-                        /* Default remote assignor to the chosen local one. */
-                        if (rk->rk_conf.partition_assignors_cooperative) {
-                                group_remote_assignor_override =
-                                    rd_strdup("uniform");
-                                rk->rk_conf.group_remote_assignor =
-                                    group_remote_assignor_override;
-                        } else {
-                                rd_kafka_assignor_t *range_assignor =
-                                    rd_kafka_assignor_find(rk, "range");
-                                if (range_assignor &&
-                                    range_assignor->rkas_enabled) {
-                                        rd_kafka_log(
-                                            rk, LOG_WARNING, "ASSIGNOR",
-                                            "\"range\" assignor is sticky "
-                                            "with group protocol CONSUMER");
-                                        group_remote_assignor_override =
-                                            rd_strdup("range");
-                                        rk->rk_conf.group_remote_assignor =
-                                            group_remote_assignor_override;
-                                } else {
-                                        rd_kafka_log(
-                                            rk, LOG_WARNING, "ASSIGNOR",
-                                            "roundrobin assignor isn't "
-                                            "available "
-                                            "with group protocol CONSUMER, "
-                                            "using the \"uniform\" one. "
-                                            "It's similar, "
-                                            "but it's also sticky");
-                                        group_remote_assignor_override =
-                                            rd_strdup("uniform");
-                                        rk->rk_conf.group_remote_assignor =
-                                            group_remote_assignor_override;
-                                }
-                        }
-                }
-        } else {
-                /* When users starts setting properties of the new protocol,
-                 * they can only use incremental_assign/unassign. */
+        if (rk->rk_conf.group_protocol == RD_KAFKA_GROUP_PROTOCOL_CONSUMER)
                 rk->rk_conf.partition_assignors_cooperative = rd_true;
-        }
 
         /* Create Mock cluster */
         rd_atomic32_init(&rk->rk_mock.cluster_cnt, 0);
@@ -2839,8 +2783,6 @@ fail:
          * that belong to rk_conf and thus needs to be cleaned up.
          * Legacy APIs, sigh.. */
         if (app_conf) {
-                if (group_remote_assignor_override)
-                        rd_free(group_remote_assignor_override);
                 rd_kafka_assignors_term(rk);
                 rd_kafka_interceptors_destroy(&rk->rk_conf);
                 memset(&rk->rk_conf, 0, sizeof(rk->rk_conf));

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -177,9 +177,7 @@ rd_kafka_cgrp_rebalance_protocol(rd_kafka_cgrp_t *rkcg) {
                       RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE))
                         return RD_KAFKA_REBALANCE_PROTOCOL_NONE;
 
-                return rkcg->rkcg_rk->rk_conf.partition_assignors_cooperative
-                           ? RD_KAFKA_REBALANCE_PROTOCOL_COOPERATIVE
-                           : RD_KAFKA_REBALANCE_PROTOCOL_EAGER;
+                return RD_KAFKA_REBALANCE_PROTOCOL_COOPERATIVE;
         }
 
         if (!rkcg->rkcg_assignor)
@@ -458,9 +456,8 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_group_instance_id =
             rd_kafkap_str_new(rk->rk_conf.group_instance_id, -1);
 
-        if (rkcg->rkcg_group_remote_assignor)
-                rkcg->rkcg_group_remote_assignor =
-                    rd_kafkap_str_new(rk->rk_conf.group_remote_assignor, -1);
+        rkcg->rkcg_group_remote_assignor =
+            rd_kafkap_str_new(rk->rk_conf.group_remote_assignor, -1);
 
         if (!RD_KAFKAP_STR_LEN(rkcg->rkcg_rk->rk_conf.client_rack))
                 rkcg->rkcg_client_rack = rd_kafkap_str_new(NULL, -1);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -457,8 +457,11 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_q                        = rd_kafka_consume_q_new(rk);
         rkcg->rkcg_group_instance_id =
             rd_kafkap_str_new(rk->rk_conf.group_instance_id, -1);
-        rkcg->rkcg_group_remote_assignor =
-            rd_kafkap_str_new(rk->rk_conf.group_remote_assignor, -1);
+
+        if (rkcg->rkcg_group_remote_assignor)
+                rkcg->rkcg_group_remote_assignor =
+                    rd_kafkap_str_new(rk->rk_conf.group_remote_assignor, -1);
+
         if (!RD_KAFKAP_STR_LEN(rkcg->rkcg_rk->rk_conf.client_rack))
                 rkcg->rkcg_client_rack = rd_kafkap_str_new(NULL, -1);
         else
@@ -6046,6 +6049,9 @@ rd_kafka_cgrp_consumer_subscribe(rd_kafka_cgrp_t *rkcg,
  *        to the next state.
  */
 static void rd_kafka_cgrp_consumer_incr_unassign_done(rd_kafka_cgrp_t *rkcg) {
+
+        /* Leave group, if desired. */
+        rd_kafka_cgrp_leave_maybe(rkcg);
 
         /* If this action was underway when a terminate was initiated, it will
          * be left to complete. Now that's done, unassign all partitions */

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -455,7 +455,6 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_q                        = rd_kafka_consume_q_new(rk);
         rkcg->rkcg_group_instance_id =
             rd_kafkap_str_new(rk->rk_conf.group_instance_id, -1);
-
         rkcg->rkcg_group_remote_assignor =
             rd_kafkap_str_new(rk->rk_conf.group_remote_assignor, -1);
 
@@ -6047,9 +6046,6 @@ rd_kafka_cgrp_consumer_subscribe(rd_kafka_cgrp_t *rkcg,
  */
 static void rd_kafka_cgrp_consumer_incr_unassign_done(rd_kafka_cgrp_t *rkcg) {
 
-        /* Leave group, if desired. */
-        rd_kafka_cgrp_leave_maybe(rkcg);
-
         /* If this action was underway when a terminate was initiated, it will
          * be left to complete. Now that's done, unassign all partitions */
         if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
@@ -6058,6 +6054,9 @@ static void rd_kafka_cgrp_consumer_incr_unassign_done(rd_kafka_cgrp_t *rkcg) {
                              "unassign",
                              rkcg->rkcg_group_id->str);
                 rd_kafka_cgrp_unassign(rkcg);
+
+                /* Leave group, if desired. */
+                rd_kafka_cgrp_leave_maybe(rkcg);
                 return;
         }
 

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -394,7 +394,6 @@ struct rd_kafka_conf_s {
         rd_kafkap_str_t *group_protocol_type;
         char *partition_assignment_strategy;
         rd_list_t partition_assignors;
-        rd_bool_t partition_assignors_cooperative;
         int enabled_assignor_cnt;
 
         void (*rebalance_cb)(rd_kafka_t *rk,

--- a/tests/0018-cgrp_term.c
+++ b/tests/0018-cgrp_term.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0018-cgrp_term.c
+++ b/tests/0018-cgrp_term.c
@@ -63,14 +63,16 @@ static void rebalance_cb(rd_kafka_t *rk,
         switch (err) {
         case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
                 assign_cnt++;
-                rd_kafka_assign(rk, partitions);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           partitions);
                 break;
 
         case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
                 if (assign_cnt == 0)
                         TEST_FAIL("asymetric rebalance_cb\n");
                 assign_cnt--;
-                rd_kafka_assign(rk, NULL);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             partitions);
                 break;
 
         default:

--- a/tests/0026-consume_pause.c
+++ b/tests/0026-consume_pause.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0026-consume_pause.c
+++ b/tests/0026-consume_pause.c
@@ -377,7 +377,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                  * while auto.offset.reset is default at `latest`. */
 
                 parts->elems[0].offset = RD_KAFKA_OFFSET_BEGINNING;
-                test_consumer_assign("rebalance", rk, parts);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
                 TEST_SAY("Pausing partitions\n");
                 if ((err2 = rd_kafka_pause_partitions(rk, parts)))
                         TEST_FAIL("Failed to pause: %s",
@@ -388,7 +389,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                                   rd_kafka_err2str(err2));
                 break;
         default:
-                test_consumer_unassign("rebalance", rk);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
                 break;
         }
 }

--- a/tests/0029-assign_offset.c
+++ b/tests/0029-assign_offset.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0029-assign_offset.c
+++ b/tests/0029-assign_offset.c
@@ -89,11 +89,19 @@ static void rebalance_cb(rd_kafka_t *rk,
                 }
                 TEST_SAY("Use these offsets:\n");
                 test_print_partition_list(parts);
-                test_consumer_assign("HL.REBALANCE", rk, parts);
+                if (test_consumer_group_protocol_classic())
+                        test_consumer_assign("HL.REBALANCE", rk, parts);
+                else
+                        test_consumer_incremental_assign("HL.REBALANCE", rk,
+                                                         parts);
                 break;
 
         case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-                test_consumer_unassign("HL.REBALANCE", rk);
+                if (test_consumer_group_protocol_classic())
+                        test_consumer_unassign("HL.REBALANCE", rk);
+                else
+                        test_consumer_incremental_unassign("HL.REBALANCE", rk,
+                                                           parts);
                 break;
 
         default:

--- a/tests/0029-assign_offset.c
+++ b/tests/0029-assign_offset.c
@@ -89,19 +89,13 @@ static void rebalance_cb(rd_kafka_t *rk,
                 }
                 TEST_SAY("Use these offsets:\n");
                 test_print_partition_list(parts);
-                if (test_consumer_group_protocol_classic())
-                        test_consumer_assign("HL.REBALANCE", rk, parts);
-                else
-                        test_consumer_incremental_assign("HL.REBALANCE", rk,
-                                                         parts);
+                test_consumer_assign_by_rebalance_protocol("HL.REBALANCE", rk,
+                                                           parts);
                 break;
 
         case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-                if (test_consumer_group_protocol_classic())
-                        test_consumer_unassign("HL.REBALANCE", rk);
-                else
-                        test_consumer_incremental_unassign("HL.REBALANCE", rk,
-                                                           parts);
+                test_consumer_unassign_by_rebalance_protocol("HL.REBALANCE", rk,
+                                                             parts);
                 break;
 
         default:

--- a/tests/0033-regex_subscribe.c
+++ b/tests/0033-regex_subscribe.c
@@ -135,7 +135,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                             exp->name, exp->result);
                 }
                 expect_match(exp, parts);
-                test_consumer_assign("rebalance", rk, parts);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
                 exp->result = _EXP_ASSIGNED;
                 break;
 
@@ -147,7 +148,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                             exp->name, exp->result);
                 }
 
-                test_consumer_unassign("rebalance", rk);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
                 exp->result = _EXP_REVOKED;
                 break;
 

--- a/tests/0040-io_event.c
+++ b/tests/0040-io_event.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0040-io_event.c
+++ b/tests/0040-io_event.c
@@ -170,13 +170,13 @@ int main_0040_io_event(int argc, char **argv) {
                                         if (rd_kafka_event_error(rkev) ==
                                             RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
                                                 test_consumer_assign_by_rebalance_protocol(
-                                                    "rebalance", rk_c,
+                                                    "rebalance event", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                                 expecting_io = _NOPE;
                                         } else {
                                                 test_consumer_unassign_by_rebalance_protocol(
-                                                    "rebalance", rk_c,
+                                                    "rebalance event", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                         }

--- a/tests/0040-io_event.c
+++ b/tests/0040-io_event.c
@@ -169,13 +169,17 @@ int main_0040_io_event(int argc, char **argv) {
                                                     "expecting message\n");
                                         if (rd_kafka_event_error(rkev) ==
                                             RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-                                                rd_kafka_assign(
-                                                    rk_c,
+                                                test_consumer_assign_by_rebalance_protocol(
+                                                    "rebalance", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                                 expecting_io = _NOPE;
-                                        } else
-                                                rd_kafka_assign(rk_c, NULL);
+                                        } else {
+                                                test_consumer_unassign_by_rebalance_protocol(
+                                                    "rebalance", rk_c,
+                                                    rd_kafka_event_topic_partition_list(
+                                                        rkev));
+                                        }
                                         break;
 
                                 case RD_KAFKA_EVENT_FETCH:

--- a/tests/0056-balanced_group_mt.c
+++ b/tests/0056-balanced_group_mt.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0056-balanced_group_mt.c
+++ b/tests/0056-balanced_group_mt.c
@@ -152,7 +152,8 @@ static void rebalance_cb(rd_kafka_t *rk,
         case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
                 assign_cnt++;
 
-                rd_kafka_assign(rk, partitions);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           partitions);
                 mtx_lock(&lock);
                 consumers_running = 1;
                 mtx_unlock(&lock);
@@ -177,7 +178,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                 if (assign_cnt == 0)
                         TEST_FAIL("asymetric rebalance_cb");
                 assign_cnt--;
-                rd_kafka_assign(rk, NULL);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             partitions);
                 mtx_lock(&lock);
                 consumers_running = 0;
                 mtx_unlock(&lock);

--- a/tests/0069-consumer_add_parts.c
+++ b/tests/0069-consumer_add_parts.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0069-consumer_add_parts.c
+++ b/tests/0069-consumer_add_parts.c
@@ -58,12 +58,7 @@ static void rebalance_cb(rd_kafka_t *rk,
                  rd_kafka_err2str(err));
         test_print_partition_list(parts);
 
-        if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
-                                                           parts);
-        else
-                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
-                                                             parts);
+        test_rebalance_cb(rk, err, parts, opaque);
 
         *statep = err;
 }

--- a/tests/0069-consumer_add_parts.c
+++ b/tests/0069-consumer_add_parts.c
@@ -59,9 +59,11 @@ static void rebalance_cb(rd_kafka_t *rk,
         test_print_partition_list(parts);
 
         if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                rd_kafka_assign(rk, parts);
-        else if (err == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS)
-                rd_kafka_assign(rk, NULL);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
+        else
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
 
         *statep = err;
 }

--- a/tests/0083-cb_event.c
+++ b/tests/0083-cb_event.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2018-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0083-cb_event.c
+++ b/tests/0083-cb_event.c
@@ -154,13 +154,13 @@ int main_0083_cb_event(int argc, char **argv) {
                                         if (rd_kafka_event_error(rkev) ==
                                             RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
                                                 test_consumer_assign_by_rebalance_protocol(
-                                                    "rebalance", rk_c,
+                                                    "rebalance event", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                                 expecting_io = _NOPE;
                                         } else
                                                 test_consumer_unassign_by_rebalance_protocol(
-                                                    "rebalance", rk_c,
+                                                    "rebalance event", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                         break;

--- a/tests/0083-cb_event.c
+++ b/tests/0083-cb_event.c
@@ -153,13 +153,16 @@ int main_0083_cb_event(int argc, char **argv) {
                                                     "expecting message\n");
                                         if (rd_kafka_event_error(rkev) ==
                                             RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-                                                rd_kafka_assign(
-                                                    rk_c,
+                                                test_consumer_assign_by_rebalance_protocol(
+                                                    "rebalance", rk_c,
                                                     rd_kafka_event_topic_partition_list(
                                                         rkev));
                                                 expecting_io = _NOPE;
                                         } else
-                                                rd_kafka_assign(rk_c, NULL);
+                                                test_consumer_unassign_by_rebalance_protocol(
+                                                    "rebalance", rk_c,
+                                                    rd_kafka_event_topic_partition_list(
+                                                        rkev));
                                         break;
 
                                 case RD_KAFKA_EVENT_FETCH:

--- a/tests/0084-destroy_flags.c
+++ b/tests/0084-destroy_flags.c
@@ -42,10 +42,6 @@ static void destroy_flags_rebalance_cb(rd_kafka_t *rk,
                                        rd_kafka_topic_partition_list_t *parts,
                                        void *opaque) {
         rebalance_cnt++;
-
-        TEST_SAY("rebalance_cb: %s with %d partition(s)\n",
-                 rd_kafka_err2str(err), parts->cnt);
-
         test_rebalance_cb(rk, err, parts, opaque);
 }
 

--- a/tests/0084-destroy_flags.c
+++ b/tests/0084-destroy_flags.c
@@ -46,18 +46,7 @@ static void destroy_flags_rebalance_cb(rd_kafka_t *rk,
         TEST_SAY("rebalance_cb: %s with %d partition(s)\n",
                  rd_kafka_err2str(err), parts->cnt);
 
-        switch (err) {
-        case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
-                test_consumer_assign("rebalance", rk, parts);
-                break;
-
-        case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-                test_consumer_unassign("rebalance", rk);
-                break;
-
-        default:
-                TEST_FAIL("rebalance_cb: error: %s", rd_kafka_err2str(err));
-        }
+        test_rebalance_cb(rk, err, parts, opaque);
 }
 
 struct df_args {

--- a/tests/0084-destroy_flags.c
+++ b/tests/0084-destroy_flags.c
@@ -203,11 +203,21 @@ static void destroy_flags(int local_mode) {
 
 
 int main_0084_destroy_flags_local(int argc, char **argv) {
+        /* FIXME: fix the test with subscribe/unsubscribe PR. */
+        if (test_consumer_group_protocol_consumer()) {
+                TEST_SKIP("FIXME: fix the test with subscribe/unsubscribe PR");
+                return 0;
+        }
         destroy_flags(1 /*no brokers*/);
         return 0;
 }
 
 int main_0084_destroy_flags(int argc, char **argv) {
+        /* FIXME: fix the test with subscribe/unsubscribe PR. */
+        if (test_consumer_group_protocol_consumer()) {
+                TEST_SKIP("FIXME: fix the test with subscribe/unsubscribe PR");
+                return 0;
+        }
         destroy_flags(0 /*with brokers*/);
         return 0;
 }

--- a/tests/0084-destroy_flags.c
+++ b/tests/0084-destroy_flags.c
@@ -204,7 +204,7 @@ static void destroy_flags(int local_mode) {
 
 int main_0084_destroy_flags_local(int argc, char **argv) {
         /* FIXME: fix the test with subscribe/unsubscribe PR. */
-        if (test_consumer_group_protocol_consumer()) {
+        if (!test_consumer_group_protocol_classic()) {
                 TEST_SKIP("FIXME: fix the test with subscribe/unsubscribe PR");
                 return 0;
         }
@@ -214,7 +214,7 @@ int main_0084_destroy_flags_local(int argc, char **argv) {
 
 int main_0084_destroy_flags(int argc, char **argv) {
         /* FIXME: fix the test with subscribe/unsubscribe PR. */
-        if (test_consumer_group_protocol_consumer()) {
+        if (!test_consumer_group_protocol_classic()) {
                 TEST_SKIP("FIXME: fix the test with subscribe/unsubscribe PR");
                 return 0;
         }

--- a/tests/0089-max_poll_interval.c
+++ b/tests/0089-max_poll_interval.c
@@ -413,7 +413,9 @@ do_test_rejoin_after_interval_expire(rd_bool_t forward_to_another_q,
         TEST_ASSERT(rd_kafka_event_error(event) ==
                         RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS,
                     "Group join should assign partitions");
-        rd_kafka_assign(rk, rd_kafka_event_topic_partition_list(event));
+        test_consumer_assign_by_rebalance_protocol(
+            "initial group join", rk,
+            rd_kafka_event_topic_partition_list(event));
         rd_kafka_event_destroy(event);
 
         rd_sleep(10 + 1); /* Exceed max.poll.interval.ms. */
@@ -426,7 +428,8 @@ do_test_rejoin_after_interval_expire(rd_bool_t forward_to_another_q,
         TEST_ASSERT(rd_kafka_event_error(event) ==
                         RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS,
                     "Group leave should revoke partitions");
-        rd_kafka_assign(rk, NULL);
+        test_consumer_unassign_by_rebalance_protocol(
+            "group leave", rk, rd_kafka_event_topic_partition_list(event));
         rd_kafka_event_destroy(event);
 
         event = test_wait_event(polling_queue, RD_KAFKA_EVENT_REBALANCE,
@@ -435,7 +438,9 @@ do_test_rejoin_after_interval_expire(rd_bool_t forward_to_another_q,
         TEST_ASSERT(rd_kafka_event_error(event) ==
                         RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS,
                     "Group rejoin should assign partitions");
-        rd_kafka_assign(rk, rd_kafka_event_topic_partition_list(event));
+
+        test_consumer_assign_by_rebalance_protocol(
+            "group rejoin", rk, rd_kafka_event_topic_partition_list(event));
         rd_kafka_event_destroy(event);
 
         if (forward_to_another_q)

--- a/tests/0091-max_poll_interval_timeout.c
+++ b/tests/0091-max_poll_interval_timeout.c
@@ -102,9 +102,11 @@ static void rebalance_cb(rd_kafka_t *rk,
                     cons->max_rebalance_cnt);
 
         if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                rd_kafka_assign(rk, parts);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
         else
-                rd_kafka_assign(rk, NULL);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
 }
 
 

--- a/tests/0091-max_poll_interval_timeout.c
+++ b/tests/0091-max_poll_interval_timeout.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0091-max_poll_interval_timeout.c
+++ b/tests/0091-max_poll_interval_timeout.c
@@ -101,12 +101,7 @@ static void rebalance_cb(rd_kafka_t *rk,
                     rd_kafka_name(cons->rk), cons->rebalance_cnt,
                     cons->max_rebalance_cnt);
 
-        if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
-                                                           parts);
-        else
-                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
-                                                             parts);
+        test_rebalance_cb(rk, err, parts, opaque);
 }
 
 

--- a/tests/0093-holb.c
+++ b/tests/0093-holb.c
@@ -93,9 +93,11 @@ static void rebalance_cb(rd_kafka_t *rk,
                     cons->max_rebalance_cnt);
 
         if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                rd_kafka_assign(rk, parts);
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
         else
-                rd_kafka_assign(rk, NULL);
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
 }
 
 

--- a/tests/0093-holb.c
+++ b/tests/0093-holb.c
@@ -92,12 +92,7 @@ static void rebalance_cb(rd_kafka_t *rk,
                     rd_kafka_name(cons->rk), cons->rebalance_cnt,
                     cons->max_rebalance_cnt);
 
-        if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS)
-                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
-                                                           parts);
-        else
-                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
-                                                             parts);
+        test_rebalance_cb(rk, err, parts, opaque);
 }
 
 

--- a/tests/0106-cgrp_sess_timeout.c
+++ b/tests/0106-cgrp_sess_timeout.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2020-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0106-cgrp_sess_timeout.c
+++ b/tests/0106-cgrp_sess_timeout.c
@@ -55,7 +55,7 @@ static void rebalance_cb(rd_kafka_t *rk,
             rd_kafka_err2name(rebalance_exp_event), rd_kafka_err2name(err));
 
         if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-                test_consumer_assign("assign", rk, parts);
+                test_consumer_assign_by_rebalance_protocol("assign", rk, parts);
         } else {
                 rd_kafka_resp_err_t commit_err;
 
@@ -92,8 +92,8 @@ static void rebalance_cb(rd_kafka_t *rk,
                                     rd_kafka_err2name(commit_exp_err),
                                     rd_kafka_err2name(commit_err));
                 }
-
-                test_consumer_unassign("unassign", rk);
+                test_consumer_unassign_by_rebalance_protocol("unassign", rk,
+                                                             parts);
         }
 
         /* Make sure only one rebalance callback is served per poll()

--- a/tests/0113-cooperative_rebalance.cpp
+++ b/tests/0113-cooperative_rebalance.cpp
@@ -3443,7 +3443,10 @@ int main_0113_cooperative_rebalance(int argc, char **argv) {
   e_change_subscription_remove_topic(true /*close consumer*/);
   e_change_subscription_remove_topic(false /*don't close consumer*/);
   f_assign_call_cooperative();
-  g_incremental_assign_call_eager();
+  /* KIP-848 doesn't support EAGER protocol*/
+  if (test_consumer_group_protocol_classic()) {
+    g_incremental_assign_call_eager();
+  }
   h_delete_topic();
   i_delete_topic_2();
   j_delete_topic_no_rb_callback();

--- a/tests/0113-cooperative_rebalance.cpp
+++ b/tests/0113-cooperative_rebalance.cpp
@@ -1411,6 +1411,13 @@ class GTestRebalanceCb : public RdKafka::RebalanceCb {
 static void g_incremental_assign_call_eager() {
   SUB_TEST();
 
+  /* Only classic consumer group protocol supports EAGER protocol*/
+  if (!test_consumer_group_protocol_classic()) {
+    SUB_TEST_SKIP(
+        "Skipping incremental assign call eager test as EAGER protocol is only "
+        "supported in `classic` consumer group protocol");
+  }
+
   std::string topic_name = Test::mk_topic_name("0113-cooperative_rebalance", 1);
   test_create_topic(NULL, topic_name.c_str(), 1, 1);
 
@@ -3443,10 +3450,7 @@ int main_0113_cooperative_rebalance(int argc, char **argv) {
   e_change_subscription_remove_topic(true /*close consumer*/);
   e_change_subscription_remove_topic(false /*don't close consumer*/);
   f_assign_call_cooperative();
-  /* KIP-848 doesn't support EAGER protocol*/
-  if (test_consumer_group_protocol_classic()) {
-    g_incremental_assign_call_eager();
-  }
+  g_incremental_assign_call_eager();
   h_delete_topic();
   i_delete_topic_2();
   j_delete_topic_no_rb_callback();

--- a/tests/0117-mock_errors.c
+++ b/tests/0117-mock_errors.c
@@ -167,11 +167,11 @@ static void do_test_offset_commit_error_during_rebalance(void) {
          * only the new partitions are assigned to the consumer. All the
          * previously assigned partitions will start consuming from the last
          * offset. */
-        if (test_consumer_group_protocol_consumer())
+        if (!test_consumer_group_protocol_classic())
                 exp_msg_cnt_final = msgcnt - exp_msg_cnt_intial;
 
         /* Wait for new assignment and able to read all messages */
-        test_consumer_poll("C1.PRE", c1, 0, -1, -1, exp_msg_cnt_final, NULL);
+        test_consumer_poll("C1.POST", c1, 0, -1, -1, exp_msg_cnt_final, NULL);
 
         rd_kafka_destroy(c1);
 

--- a/tests/0117-mock_errors.c
+++ b/tests/0117-mock_errors.c
@@ -102,8 +102,10 @@ static void do_test_offset_commit_error_during_rebalance(void) {
         rd_kafka_t *c1, *c2;
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
-        const char *topic = "test";
-        const int msgcnt  = 100;
+        const char *topic            = "test";
+        const int msgcnt             = 100;
+        const int exp_msg_cnt_intial = 1;
+        int exp_msg_cnt_final        = msgcnt;
         rd_kafka_resp_err_t err;
 
         SUB_TEST();
@@ -136,8 +138,8 @@ static void do_test_offset_commit_error_during_rebalance(void) {
 
 
         /* Wait for assignment and one message */
-        test_consumer_poll("C1.PRE", c1, 0, -1, -1, 1, NULL);
-        test_consumer_poll("C2.PRE", c2, 0, -1, -1, 1, NULL);
+        test_consumer_poll("C1.PRE", c1, 0, -1, -1, exp_msg_cnt_intial, NULL);
+        test_consumer_poll("C2.PRE", c2, 0, -1, -1, exp_msg_cnt_intial, NULL);
 
         /* Trigger rebalance */
         test_consumer_close(c2);
@@ -161,8 +163,15 @@ static void do_test_offset_commit_error_during_rebalance(void) {
                     "not %s",
                     rd_kafka_err2name(err));
 
+        /* Since all the assignors in the `consumer` protocol are COOPERATIVE
+         * only the new partitions are assigned to the consumer. All the
+         * previously assigned partitions will start consuming from the last
+         * offset. */
+        if (test_consumer_group_protocol_consumer())
+                exp_msg_cnt_final = msgcnt - exp_msg_cnt_intial;
+
         /* Wait for new assignment and able to read all messages */
-        test_consumer_poll("C1.PRE", c1, 0, -1, -1, msgcnt, NULL);
+        test_consumer_poll("C1.PRE", c1, 0, -1, -1, exp_msg_cnt_final, NULL);
 
         rd_kafka_destroy(c1);
 

--- a/tests/0117-mock_errors.c
+++ b/tests/0117-mock_errors.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2020-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0118-commit_rebalance.c
+++ b/tests/0118-commit_rebalance.c
@@ -2,6 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2020-2022, Magnus Edenhill
+ *               2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/0118-commit_rebalance.c
+++ b/tests/0118-commit_rebalance.c
@@ -45,22 +45,16 @@ static void rebalance_cb(rd_kafka_t *rk,
                  rd_kafka_err2name(err), parts->cnt);
         rebalances++;
         if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-                if (test_consumer_group_protocol_classic())
-                        TEST_CALL_ERR__(rd_kafka_assign(rk, parts));
-                else
-                        TEST_CALL_ERROR__(
-                            rd_kafka_incremental_assign(rk, parts));
+                test_consumer_assign_by_rebalance_protocol("rebalance", rk,
+                                                           parts);
 
         } else if (err == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
                 rd_kafka_resp_err_t commit_err;
 
                 TEST_CALL_ERR__(rd_kafka_position(rk, parts));
 
-                if (test_consumer_group_protocol_classic())
-                        TEST_CALL_ERR__(rd_kafka_assign(rk, NULL));
-                else
-                        TEST_CALL_ERROR__(
-                            rd_kafka_incremental_unassign(rk, parts));
+                test_consumer_unassign_by_rebalance_protocol("rebalance", rk,
+                                                             parts);
 
                 if (rk == c1)
                         return;
@@ -129,7 +123,7 @@ int main_0118_commit_rebalance(int argc, char **argv) {
          * only the new partitions are assigned to the consumer. All the
          * previously assigned partitions will start consuming from the last
          * offset. */
-        if (test_consumer_group_protocol_consumer())
+        if (!test_consumer_group_protocol_classic())
                 exp_msg_cnt_post = msgcnt - exp_msg_cnt_pre;
 
         /* Since no offsets were successfully committed the remaining consumer

--- a/tests/test.c
+++ b/tests/test.c
@@ -2674,11 +2674,18 @@ void test_consumer_assign_by_rebalance_protocol(
     const char *what,
     rd_kafka_t *rk,
     rd_kafka_topic_partition_list_t *parts) {
-        TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
-        if (!strcmp(rd_kafka_rebalance_protocol(rk), "EAGER"))
+        const char *protocol = rd_kafka_rebalance_protocol(rk);
+        if (!strcmp(protocol, "NONE")) {
+                TEST_FAIL(
+                    "Assign not supported with "
+                    "rebalance protocol NONE\n");
+        } else if (!strcmp(protocol, "EAGER")) {
+                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
                 test_consumer_assign(what, rk, parts);
-        else
+        } else {
+                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
                 test_consumer_incremental_assign(what, rk, parts);
+        }
 }
 
 
@@ -2686,7 +2693,12 @@ void test_consumer_unassign_by_rebalance_protocol(
     const char *what,
     rd_kafka_t *rk,
     rd_kafka_topic_partition_list_t *parts) {
-        if (!strcmp(rd_kafka_rebalance_protocol(rk), "EAGER")) {
+        const char *protocol = rd_kafka_rebalance_protocol(rk);
+        if (!strcmp(protocol, "NONE")) {
+                TEST_FAIL(
+                    "Unassign not supported with "
+                    "rebalance protocol NONE\n");
+        } else if (!strcmp(protocol, "EAGER")) {
                 TEST_SAY("Unassign all partition(s)\n");
                 test_consumer_unassign(what, rk);
         } else {

--- a/tests/test.c
+++ b/tests/test.c
@@ -2670,6 +2670,31 @@ void test_rebalance_cb(rd_kafka_t *rk,
 }
 
 
+void test_consumer_assign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts) {
+        TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
+        if (!strcmp(rd_kafka_rebalance_protocol(rk), "EAGER"))
+                test_consumer_assign(what, rk, parts);
+        else
+                test_consumer_incremental_assign(what, rk, parts);
+}
+
+
+void test_consumer_unassign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts) {
+        if (!strcmp(rd_kafka_rebalance_protocol(rk), "EAGER")) {
+                TEST_SAY("Unassign all partition(s)\n");
+                test_consumer_unassign(what, rk);
+        } else {
+                TEST_SAY("Unassign: %d partition(s)\n", parts->cnt);
+                test_consumer_incremental_unassign(what, rk, parts);
+        }
+}
+
 
 rd_kafka_t *test_create_consumer(
     const char *group_id,

--- a/tests/test.c
+++ b/tests/test.c
@@ -2670,44 +2670,6 @@ void test_rebalance_cb(rd_kafka_t *rk,
 }
 
 
-void test_consumer_assign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts) {
-        const char *protocol = rd_kafka_rebalance_protocol(rk);
-        if (!strcmp(protocol, "NONE")) {
-                TEST_FAIL(
-                    "Assign not supported with "
-                    "rebalance protocol NONE\n");
-        } else if (!strcmp(protocol, "EAGER")) {
-                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
-                test_consumer_assign(what, rk, parts);
-        } else {
-                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
-                test_consumer_incremental_assign(what, rk, parts);
-        }
-}
-
-
-void test_consumer_unassign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts) {
-        const char *protocol = rd_kafka_rebalance_protocol(rk);
-        if (!strcmp(protocol, "NONE")) {
-                TEST_FAIL(
-                    "Unassign not supported with "
-                    "rebalance protocol NONE\n");
-        } else if (!strcmp(protocol, "EAGER")) {
-                TEST_SAY("Unassign all partition(s)\n");
-                test_consumer_unassign(what, rk);
-        } else {
-                TEST_SAY("Unassign: %d partition(s)\n", parts->cnt);
-                test_consumer_incremental_unassign(what, rk, parts);
-        }
-}
-
-
 rd_kafka_t *test_create_consumer(
     const char *group_id,
     void (*rebalance_cb)(rd_kafka_t *rk,
@@ -3224,6 +3186,44 @@ void test_consumer_incremental_unassign(
         } else
                 TEST_SAY("%s: incremental unassign of %d partition(s) done\n",
                          what, partitions->cnt);
+}
+
+
+void test_consumer_assign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts) {
+        const char *protocol = rd_kafka_rebalance_protocol(rk);
+        if (!strcmp(protocol, "NONE")) {
+                TEST_FAIL(
+                    "Assign not supported with "
+                    "rebalance protocol NONE\n");
+        } else if (!strcmp(protocol, "EAGER")) {
+                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
+                test_consumer_assign(what, rk, parts);
+        } else {
+                TEST_SAY("Assign: %d partition(s)\n", parts->cnt);
+                test_consumer_incremental_assign(what, rk, parts);
+        }
+}
+
+
+void test_consumer_unassign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts) {
+        const char *protocol = rd_kafka_rebalance_protocol(rk);
+        if (!strcmp(protocol, "NONE")) {
+                TEST_FAIL(
+                    "Unassign not supported with "
+                    "rebalance protocol NONE\n");
+        } else if (!strcmp(protocol, "EAGER")) {
+                TEST_SAY("Unassign all partition(s)\n");
+                test_consumer_unassign(what, rk);
+        } else {
+                TEST_SAY("Unassign: %d partition(s)\n", parts->cnt);
+                test_consumer_incremental_unassign(what, rk, parts);
+        }
 }
 
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -675,14 +675,6 @@ void test_consumer_verify_assignment0(const char *func,
                                          fail_immediately, __VA_ARGS__)
 
 
-void test_consumer_assign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts);
-void test_consumer_unassign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts);
 void test_consumer_assign(const char *what,
                           rd_kafka_t *rk,
                           rd_kafka_topic_partition_list_t *parts);
@@ -693,6 +685,14 @@ void test_consumer_unassign(const char *what, rd_kafka_t *rk);
 void test_consumer_incremental_unassign(const char *what,
                                         rd_kafka_t *rk,
                                         rd_kafka_topic_partition_list_t *parts);
+void test_consumer_assign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
+void test_consumer_unassign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
 void test_consumer_assign_partition(const char *what,
                                     rd_kafka_t *rk,
                                     const char *topic,

--- a/tests/test.h
+++ b/tests/test.h
@@ -887,6 +887,16 @@ int test_consumer_group_protocol_classic();
 
 int test_consumer_group_protocol_consumer();
 
+void test_consumer_assign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
+
+void test_consumer_unassign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
+
 /**
  * @brief Calls rdkafka function (with arguments)
  *        and checks its return value (must be rd_kafka_resp_err_t) for

--- a/tests/test.h
+++ b/tests/test.h
@@ -674,6 +674,15 @@ void test_consumer_verify_assignment0(const char *func,
         test_consumer_verify_assignment0(__FUNCTION__, __LINE__, rk,           \
                                          fail_immediately, __VA_ARGS__)
 
+
+void test_consumer_assign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
+void test_consumer_unassign_by_rebalance_protocol(
+    const char *what,
+    rd_kafka_t *rk,
+    rd_kafka_topic_partition_list_t *parts);
 void test_consumer_assign(const char *what,
                           rd_kafka_t *rk,
                           rd_kafka_topic_partition_list_t *parts);
@@ -886,16 +895,6 @@ const char *test_consumer_group_protocol();
 int test_consumer_group_protocol_classic();
 
 int test_consumer_group_protocol_consumer();
-
-void test_consumer_assign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts);
-
-void test_consumer_unassign_by_rebalance_protocol(
-    const char *what,
-    rd_kafka_t *rk,
-    rd_kafka_topic_partition_list_t *parts);
 
 /**
  * @brief Calls rdkafka function (with arguments)


### PR DESCRIPTION
Closing https://github.com/confluentinc/librdkafka/pull/4749 in favour of this PR.