### PR TITLE
Exclude trivup tgz in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ cov-int
 gdbrun*.gdb
 TAGS
 vcpkg_installed
+!/tests/trivup/trivup-*.tar.gz


### PR DESCRIPTION
Some copy tools use `.gitignore` to determine which files to copy. The file `/tests/trivup/trivup-*.tar.gz` is tracked by version control but is ignored due to the `*.gz` rule in `.gitignore`. This PR exclude it from being ignored.