### PR TITLE
[KIP-848] Handle topic authorization failure on consumer group heartbeat

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3321,8 +3321,7 @@ err:
                     rkcg, "coordinator query");
         }
 
-        if (actions & RD_KAFKA_ERR_ACTION_SPECIAL &&
-            rkcg->rkcg_flags & RD_KAFKA_CGRP_F_SUBSCRIPTION) {
+        if (actions & RD_KAFKA_ERR_ACTION_SPECIAL) {
                 rd_ts_t min_error_interval =
                     RD_MAX(rkcg->rkcg_heartbeat_intvl_ms * 1000,
                            /* default group.consumer.heartbeat.interval.ms */

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -370,6 +370,36 @@ static int rd_kafka_cgrp_set_state(rd_kafka_cgrp_t *rkcg, int state) {
         return 1;
 }
 
+/**
+ * @brief Set the cgrp last error and current timestamp
+ *        as last error timestamp.
+ */
+static void rd_kafka_cgrp_set_last_err(rd_kafka_cgrp_t *rkcg,
+                                       rd_kafka_resp_err_t rkcg_last_err) {
+        rkcg->rkcg_last_err    = rkcg_last_err;
+        rkcg->rkcg_ts_last_err = rd_clock();
+}
+
+/**
+ * @brief Clears cgrp last error and its timestamp.
+ */
+static void rd_kafka_cgrp_clear_last_err(rd_kafka_cgrp_t *rkcg) {
+        rkcg->rkcg_last_err    = RD_KAFKA_RESP_ERR_NO_ERROR;
+        rkcg->rkcg_ts_last_err = 0;
+}
+
+/**
+ * @brief Clears cgrp last error if it's an heartbeat related error like
+ *        a topic authorization failed one.
+ */
+static void
+rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rd_kafka_cgrp_t *rkcg) {
+        if (rkcg->rkcg_last_err ==
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
+                rd_kafka_cgrp_clear_last_err(rkcg);
+        }
+}
+
 
 void rd_kafka_cgrp_set_join_state(rd_kafka_cgrp_t *rkcg, int join_state) {
         if ((int)rkcg->rkcg_join_state == join_state)
@@ -775,7 +805,7 @@ err:
                             "FindCoordinator response error: %s", errstr);
 
                         /* Suppress repeated errors */
-                        rkcg->rkcg_last_err = ErrorCode;
+                        rd_kafka_cgrp_set_last_err(rkcg, ErrorCode);
                 }
 
                 /* Retries are performed by the timer-intervalled
@@ -3185,6 +3215,7 @@ void rd_kafka_cgrp_handle_ConsumerGroupHeartbeat(rd_kafka_t *rk,
             ~RD_KAFKA_CGRP_CONSUMER_F_SENDING_NEW_SUBSCRIPTION &
             ~RD_KAFKA_CGRP_CONSUMER_F_SEND_FULL_REQUEST &
             ~RD_KAFKA_CGRP_CONSUMER_F_SENDING_ACK;
+        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
         rkcg->rkcg_last_heartbeat_err         = RD_KAFKA_RESP_ERR_NO_ERROR;
         rkcg->rkcg_expedite_heartbeat_retries = 0;
 
@@ -3252,8 +3283,13 @@ err:
                 actions = RD_KAFKA_ERR_ACTION_FATAL;
                 break;
         default:
-                actions = rd_kafka_err_action(rkb, err, request,
-                                              RD_KAFKA_ERR_ACTION_END);
+                actions = rd_kafka_err_action(
+                    rkb, err, request,
+
+                    RD_KAFKA_ERR_ACTION_SPECIAL,
+                    RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED,
+
+                    RD_KAFKA_ERR_ACTION_END);
                 break;
         }
 
@@ -3283,6 +3319,21 @@ err:
                 rd_kafka_cgrp_coord_query(rkcg, rd_kafka_err2str(err));
                 rd_kafka_cgrp_consumer_expedite_next_heartbeat(
                     rkcg, "coordinator query");
+        }
+
+        if (actions & RD_KAFKA_ERR_ACTION_SPECIAL &&
+            rkcg->rkcg_flags & RD_KAFKA_CGRP_F_SUBSCRIPTION) {
+                rd_ts_t min_error_interval =
+                    RD_MAX(rkcg->rkcg_heartbeat_intvl_ms * 1000, 3000000);
+                if (rkcg->rkcg_last_err != err ||
+                    (rd_clock() >
+                     rkcg->rkcg_ts_last_err + min_error_interval)) {
+                        rd_kafka_cgrp_set_last_err(rkcg, err);
+                        rd_kafka_consumer_err(
+                            rkcg->rkcg_q, rd_kafka_broker_id(rkb), err, 0, NULL,
+                            NULL, err, "ConsumerGroupHeartbeat failed: %s",
+                            rd_kafka_err2str(err));
+                }
         }
 
         if (actions & RD_KAFKA_ERR_ACTION_RETRY &&
@@ -5321,6 +5372,7 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
                         rkcg->rkcg_consumer_flags |=
                             RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
                             RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
+                        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
                 }
         } else {
                 rkcg->rkcg_subscription_regex  = NULL;

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -336,6 +336,8 @@ typedef struct rd_kafka_cgrp_s {
          *  incremental unassign. */
         rd_bool_t rkcg_rebalance_rejoin;
 
+        rd_ts_t rkcg_ts_last_err;          /* Timestamp of last error
+                                            * propagated to application */
         rd_kafka_resp_err_t rkcg_last_err; /* Last error propagated to
                                             * application.
                                             * This is for silencing

--- a/tests/0109-auto_create_topics.cpp
+++ b/tests/0109-auto_create_topics.cpp
@@ -192,7 +192,7 @@ static void do_test_consumer(bool allow_auto_create_topics,
 
     case RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED:
       if (test_consumer_group_protocol_classic()) {
-        run = rd_true;
+        run = true;
       } else {
         /* `consumer` rebalance protocol:
          * wait for `unauthorized_error_cnt` consecutive errors. */

--- a/tests/0109-auto_create_topics.cpp
+++ b/tests/0109-auto_create_topics.cpp
@@ -39,19 +39,30 @@
  * The same test is run with and without allow.auto.create.topics
  * and with and without wildcard subscribes.
  *
+ * With the KIP 848 consumer group protocol, topics aren't automatically
+ * created when subscribing and the topic authorization error
+ * applies to the whole subscription, not just the unauthorized topics.
  */
 
 
 static void do_test_consumer(bool allow_auto_create_topics,
-                             bool with_wildcards) {
+                             bool with_wildcards,
+                             bool test_unauthorized_topic) {
   Test::Say(tostr() << _C_MAG << "[ Test allow.auto.create.topics="
                     << (allow_auto_create_topics ? "true" : "false")
                     << " with_wildcards=" << (with_wildcards ? "true" : "false")
-                    << " ]\n");
+                    << " test_unauthorized_topic="
+                    << (test_unauthorized_topic ? "true" : "false") << " ]\n");
 
   bool has_acl_cli = test_broker_version >= TEST_BRKVER(2, 1, 0, 0) &&
                      !test_needs_auth(); /* We can't bother passing Java
                                           * security config to kafka-acls.sh */
+  if (test_unauthorized_topic && !has_acl_cli) {
+    Test::Say(
+        "Skipping unauthorized topic test since kafka-acls.sh is not "
+        "available\n");
+    return;
+  }
 
   bool supports_allow = test_broker_version >= TEST_BRKVER(0, 11, 0, 0);
 
@@ -83,7 +94,7 @@ static void do_test_consumer(bool allow_auto_create_topics,
   /* Create topics */
   Test::create_topic(c, topic_exists.c_str(), 1, 1);
 
-  if (has_acl_cli) {
+  if (test_unauthorized_topic) {
     Test::create_topic(c, topic_unauth.c_str(), 1, 1);
 
     /* Add denying ACL for unauth topic */
@@ -107,34 +118,40 @@ static void do_test_consumer(bool allow_auto_create_topics,
   std::map<std::string, RdKafka::ErrorCode> exp_errors;
 
   topics.push_back(topic_notexists);
-  if (has_acl_cli)
+
+  if (test_unauthorized_topic)
     topics.push_back(topic_unauth);
 
   if (with_wildcards) {
     topics.push_back("^" + topic_exists);
     topics.push_back("^" + topic_notexists);
+  } else {
+    topics.push_back(topic_exists);
+  }
+
+  if (test_consumer_group_protocol_classic()) {
     /* If the subscription contains at least one wildcard/regex
      * then no auto topic creation will take place (since the consumer
      * requests all topics in metadata, and not specific ones, thus
      * not triggering topic auto creation).
      * We need to handle the expected error cases accordingly. */
-    exp_errors["^" + topic_notexists] = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
-    exp_errors[topic_notexists]       = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
-
-    if (has_acl_cli) {
-      /* Unauthorized topics are not included in list-all-topics Metadata,
-       * which we use for wildcards, so in this case the error code for
-       * unauthorixed topics show up as unknown topic. */
-      exp_errors[topic_unauth] = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
-    }
-  } else {
-    topics.push_back(topic_exists);
-
-    /* Consumer doesn't do a preliminary Metadata call that
-     * returns a TOPIC_AUTHORIZATION_FAILED error with the consumer
-     * protocol. */
-    if (has_acl_cli && test_consumer_group_protocol_classic())
+    if (with_wildcards) {
+      exp_errors["^" + topic_notexists] = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
+      exp_errors[topic_notexists]       = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
+      if (test_unauthorized_topic) {
+        /* Unauthorized topics are not included in list-all-topics Metadata,
+         * which we use for wildcards, so in this case the error code for
+         * unauthorixed topics show up as unknown topic. */
+        exp_errors[topic_unauth] = RdKafka::ERR_UNKNOWN_TOPIC_OR_PART;
+      }
+    } else if (test_unauthorized_topic) {
       exp_errors[topic_unauth] = RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED;
+    }
+  } else if (test_unauthorized_topic) {
+    /* Authorization errors happen if even a single topic
+     * is unauthorized and an error is returned for the whole subscription
+     * without reference to the topic. */
+    exp_errors[""] = RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED;
   }
 
   /* Consumer doesn't do a preliminary Metadata call that returns
@@ -160,6 +177,10 @@ static void do_test_consumer(bool allow_auto_create_topics,
     case RdKafka::ERR__PARTITION_EOF:
       run = false;
       break;
+
+    case RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED:
+      run = test_consumer_group_protocol_classic();
+      /* FALLTHRU */
 
     default:
       Test::Say("Consume error on " + msg->topic_name() + ": " + msg->errstr() +
@@ -212,22 +233,19 @@ static void do_test_consumer(bool allow_auto_create_topics,
 
 extern "C" {
 int main_0109_auto_create_topics(int argc, char **argv) {
-  if (!test_consumer_group_protocol_classic()) {
-    Test::Skip(
-        "Test disabled, to be enabled again when TOPIC_AUTHORIZATION_FAILED "
-        "error is handled by KIP-848 implementation.\n");
-    return 0;
-  }
   /* Parameters:
-   *  allow auto create, with wildcards */
-  do_test_consumer(true, false);
-  do_test_consumer(false, false);
+   *  allow auto create, with wildcards, test unauthorized topic */
+  do_test_consumer(true, false, false);
+  do_test_consumer(false, false, false);
 
-  /* TODO: check again when regexes will be supported by KIP-848 */
-  if (test_consumer_group_protocol_classic()) {
-    do_test_consumer(true, true);
-    do_test_consumer(false, true);
-  }
+  do_test_consumer(true, true, false);
+  do_test_consumer(false, true, false);
+
+  do_test_consumer(true, false, true);
+  do_test_consumer(false, false, true);
+
+  do_test_consumer(true, true, true);
+  do_test_consumer(false, true, true);
 
   return 0;
 }


### PR DESCRIPTION
in this case the heartbeat is retried with given interval or with exponential backoff if it's the first heartbeat. An error is returned
to the user in this case and isn't sent again for the given heartbeat interval or at least 3 seconds.