### PR TITLE
Bumped minimum required CMake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 include("packaging/cmake/parseversion.cmake")
 parseversion("src/rdkafka.h")


### PR DESCRIPTION
This PR fixes builds on CMake 4.0.0.

As I understood from the output of my build CMake4.0.0 has dropped support of specifying `cmake_minimum_required` for versions less than 3.10.

```log
2025-03-30T16:11:58.4106970Z error: failed to run custom build command for `rdkafka-sys v4.8.0+2.3.0`
2025-03-30T16:11:58.4131670Z 
2025-03-30T16:11:58.4181430Z Caused by:
2025-03-30T16:11:58.4247160Z   process didn't exit successfully: `/Users/runner/work/rustus/rustus/target/release/build/rdkafka-sys-c56e0934f65b0daa/build-script-build` (exit status: 101)
2025-03-30T16:11:58.4353960Z   --- stdout
2025-03-30T16:11:58.4378690Z   Configuring and compiling librdkafka
2025-03-30T16:11:58.4391160Z   CMAKE_TOOLCHAIN_FILE_x86_64-apple-darwin = None
2025-03-30T16:11:58.4392380Z   CMAKE_TOOLCHAIN_FILE_x86_64_apple_darwin = None
2025-03-30T16:11:58.4393530Z   TARGET_CMAKE_TOOLCHAIN_FILE = None
2025-03-30T16:11:58.4394460Z   CMAKE_TOOLCHAIN_FILE = None
2025-03-30T16:11:58.4395290Z   CMAKE_GENERATOR_x86_64-apple-darwin = None
2025-03-30T16:11:58.4396320Z   CMAKE_GENERATOR_x86_64_apple_darwin = None
2025-03-30T16:11:58.4397150Z   TARGET_CMAKE_GENERATOR = None
2025-03-30T16:11:58.4397920Z   CMAKE_GENERATOR = None
2025-03-30T16:11:58.4398660Z   CMAKE_PREFIX_PATH_x86_64-apple-darwin = None
2025-03-30T16:11:58.4399530Z   CMAKE_PREFIX_PATH_x86_64_apple_darwin = None
2025-03-30T16:11:58.4400350Z   TARGET_CMAKE_PREFIX_PATH = None
2025-03-30T16:11:58.4419970Z   CMAKE_PREFIX_PATH = None
2025-03-30T16:11:58.4421040Z   CMAKE_x86_64-apple-darwin = None
2025-03-30T16:11:58.4421380Z   CMAKE_x86_64_apple_darwin = None
2025-03-30T16:11:58.4424090Z   TARGET_CMAKE = None
2025-03-30T16:11:58.4424700Z   CMAKE = None
2025-03-30T16:11:58.4432900Z   running: cd "/Users/runner/work/rustus/rustus/target/x86_64-apple-darwin/release/build/rdkafka-sys-7c3ab150a930bf0b/out/build" && CMAKE_PREFIX_PATH="/Users/runner/work/rustus/rustus/target/x86_64-apple-darwin/release/build/zstd-sys-94c6e3c915c22d1b/out:" LC_ALL="C" "cmake" "/Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rdkafka-sys-4.8.0+2.3.0/librdkafka" "-DCMAKE_OSX_ARCHITECTURES=x86_64" "-DRDKAFKA_BUILD_STATIC=1" "-DRDKAFKA_BUILD_TESTS=0" "-DRDKAFKA_BUILD_EXAMPLES=0" "-DCMAKE_INSTALL_LIBDIR=lib" "-DWITH_ZLIB=1" "-DWITH_CURL=0" "-DWITH_SSL=0" "-DWITH_SASL=0" "-DWITH_ZSTD=1" "-DENABLE_LZ4_EXT=0" "-DCMAKE_SYSTEM_NAME=Darwin" "-DCMAKE_SYSTEM_PROCESSOR=x86_64" "-DCMAKE_INSTALL_PREFIX=/Users/runner/work/rustus/rustus/target/x86_64-apple-darwin/release/build/rdkafka-sys-7c3ab150a930bf0b/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-apple-macosx -mmacosx-version-min=14.5" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-apple-macosx -mmacosx-version-min=14.5" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-apple-macosx -mmacosx-version-min=14.5" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Release"
2025-03-30T16:11:58.4437940Z   -- Configuring incomplete, errors occurred!
2025-03-30T16:11:58.4446080Z 
2025-03-30T16:11:58.4473780Z   --- stderr
2025-03-30T16:11:58.4475990Z   Building and linking librdkafka statically
2025-03-30T16:11:58.4477080Z   CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
2025-03-30T16:11:58.4492460Z     Compatibility with CMake < 3.5 has been removed from CMake.
2025-03-30T16:11:58.4495050Z 
2025-03-30T16:11:58.4495940Z     Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
2025-03-30T16:11:58.4499240Z     to tell CMake that the project requires at least <min> but has been updated
2025-03-30T16:11:58.4509760Z     to work with policies introduced by <max> or earlier.
2025-03-30T16:11:58.4515540Z 
2025-03-30T16:11:58.4520580Z     Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
2025-03-30T16:11:58.4524340Z 
2025-03-30T16:11:58.4533310Z 
2025-03-30T16:11:58.4536910Z 
2025-03-30T16:11:58.4540030Z   thread 'main' panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.52/src/lib.rs:1115:5:
2025-03-30T16:11:58.4550990Z 
2025-03-30T16:11:58.4556800Z   command did not execute successfully, got: exit status: 1
2025-03-30T16:11:58.4560220Z 
2025-03-30T16:11:58.4661130Z   build script failed, must exit now
2025-03-30T16:11:58.4696650Z   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

When I build it locally, I get this warning:

```bash
❯ cmake CMakeLists.txt
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Found Zstd: /usr/lib/libzstd.so
-- Found ZSTD: /usr/lib/libzstd.so
-- Configuring done (0.9s)
-- Generating done (0.1s)
-- Build files have been written to: /home/s3rius/projects/github/librdkafka

```