### PR TITLE
Deal with topic recreation for produce (using metadata)

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -675,14 +675,32 @@ rd_kafka_mock_topic_new(rd_kafka_mock_cluster_t *mcluster,
         TAILQ_INSERT_TAIL(&mcluster->topics, mtopic, link);
         mcluster->topic_cnt++;
 
-        rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
-                     "Created topic \"%s\" with %d partition(s) and "
-                     "replication-factor %d",
-                     mtopic->name, mtopic->partition_cnt, replication_factor);
+        rd_kafka_dbg(
+            mcluster->rk, MOCK, "MOCK",
+            "Created topic \"%s\" with topic id \"%s\", %d partition(s) "
+            "and replication-factor %d",
+            mtopic->name, rd_kafka_Uuid_base64str(&mtopic->id),
+            mtopic->partition_cnt, replication_factor);
 
         return mtopic;
 }
 
+static void rd_kafka_mock_topic_remove(rd_kafka_mock_cluster_t *mcluster,
+                                       const char *topic) {
+        rd_kafka_mock_topic_t *mtopic;
+
+        mtopic = rd_kafka_mock_topic_find(mcluster, topic);
+        if (!mtopic)
+                return;
+
+        TAILQ_REMOVE(&mcluster->topics, mtopic, link);
+
+        rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
+                     "Deleted topic \"%s\" with topic id \"%s\"", mtopic->name,
+                     rd_kafka_Uuid_base64str(&mtopic->id));
+
+        rd_kafka_mock_topic_destroy(mtopic);
+}
 
 rd_kafka_mock_topic_t *
 rd_kafka_mock_topic_find(const rd_kafka_mock_cluster_t *mcluster,
@@ -2087,6 +2105,18 @@ rd_kafka_mock_topic_create(rd_kafka_mock_cluster_t *mcluster,
 }
 
 rd_kafka_resp_err_t
+rd_kafka_mock_topic_delete(rd_kafka_mock_cluster_t *mcluster,
+                           const char *topic) {
+        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_MOCK);
+
+        rko->rko_u.mock.name = rd_strdup(topic);
+        rko->rko_u.mock.cmd  = RD_KAFKA_MOCK_CMD_TOPIC_DELETE;
+
+        return rd_kafka_op_err_destroy(
+            rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
+}
+
+rd_kafka_resp_err_t
 rd_kafka_mock_partition_set_leader(rd_kafka_mock_cluster_t *mcluster,
                                    const char *topic,
                                    int32_t partition,
@@ -2394,6 +2424,10 @@ rd_kafka_mock_cluster_cmd(rd_kafka_mock_cluster_t *mcluster,
                                              /* replication_factor */
                                              (int)rko->rko_u.mock.hi))
                         return RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION;
+                break;
+
+        case RD_KAFKA_MOCK_CMD_TOPIC_DELETE:
+                rd_kafka_mock_topic_remove(mcluster, rko->rko_u.mock.name);
                 break;
 
         case RD_KAFKA_MOCK_CMD_TOPIC_SET_ERROR:

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -248,6 +248,18 @@ rd_kafka_mock_topic_create(rd_kafka_mock_cluster_t *mcluster,
                            int partition_cnt,
                            int replication_factor);
 
+/**
+ * @brief Delete a topic.
+ *
+ * This is an alternative to automatic topic deletion as performed by
+ * the client itself.
+ *
+ * @remark The Topic Admin API (DeleteTopics) is not supported by the
+ *         mock broker.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_mock_topic_delete(rd_kafka_mock_cluster_t *mcluster,
+                           const char *topic);
 
 /**
  * @brief Sets the partition leader.

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -585,6 +585,7 @@ struct rd_kafka_op_s {
                                RD_KAFKA_MOCK_CMD_APIVERSION_SET,
                                RD_KAFKA_MOCK_CMD_REQUESTED_METRICS_SET,
                                RD_KAFKA_MOCK_CMD_TELEMETRY_PUSH_INTERVAL_SET,
+                               RD_KAFKA_MOCK_CMD_TOPIC_DELETE,
                         } cmd;
 
                         rd_kafka_resp_err_t err; /**< Error for:

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -2,7 +2,7 @@
  * librdkafka - Apache Kafka C library
  *
  * Copyright (c) 2012-2022, Magnus Edenhill
- *               2023, Confluent Inc.
+ *               2023-2025, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@
 #include "rdkafka_partition.h"
 #include "rdkafka_broker.h"
 #include "rdkafka_cgrp.h"
+#include "rdkafka_idempotence.h"
 #include "rdkafka_metadata.h"
 #include "rdkafka_offset.h"
 #include "rdlog.h"
@@ -55,7 +56,8 @@ static int
 rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
                                const struct rd_kafka_metadata_topic *mdt,
                                const rd_kafka_metadata_topic_internal_t *mdit,
-                               rd_ts_t ts_age);
+                               rd_ts_t ts_age,
+                               rd_bool_t *update_epoch_bump);
 
 
 /**
@@ -494,13 +496,15 @@ rd_kafka_topic_t *rd_kafka_topic_new0(rd_kafka_t *rk,
         /* Populate from metadata cache. */
         if ((rkmce = rd_kafka_metadata_cache_find(rk, topic, 1 /*valid*/)) &&
             !rkmce->rkmce_mtopic.err) {
+                rd_bool_t update_epoch_bump =
+                    rd_false; /* ignored for new topic anyway. */
                 if (existing)
                         *existing = 1;
 
                 rd_kafka_topic_metadata_update(
                     rkt, &rkmce->rkmce_mtopic,
                     &rkmce->rkmce_metadata_internal_topic,
-                    rkmce->rkmce_ts_insert);
+                    rkmce->rkmce_ts_insert, &update_epoch_bump);
         }
 
         if (do_lock)
@@ -887,7 +891,8 @@ static void rd_kafka_toppar_idemp_msgid_restore(rd_kafka_topic_t *rkt,
  * @locks rd_kafka_topic_wrlock(rkt) MUST be held.
  */
 static int rd_kafka_topic_partition_cnt_update(rd_kafka_topic_t *rkt,
-                                               int32_t partition_cnt) {
+                                               int32_t partition_cnt,
+                                               rd_bool_t topic_id_change) {
         rd_kafka_t *rk = rkt->rkt_rk;
         rd_kafka_toppar_t **rktps;
         rd_kafka_toppar_t *rktp;
@@ -996,8 +1001,14 @@ static int rd_kafka_topic_partition_cnt_update(rd_kafka_topic_t *rkt,
                  * topic as non-existent, triggering the removal of partitions
                  * on the producer client. When metadata is eventually correct
                  * again and the topic is "re-created" on the producer, it
-                 * must continue with the next msgid/baseseq. */
-                if (is_idempodent && rd_kafka_pid_valid(rktp->rktp_eos.pid))
+                 * must continue with the next msgid/baseseq.
+                 *
+                 * This isn't applicable if the topic id changes (because it's
+                 * a new topic entirely). This is just to avoid saving, we will
+                 * still need to call rd_kafka_topic_recreated_partition_reset
+                 * on this topic. */
+                if (is_idempodent && rd_kafka_pid_valid(rktp->rktp_eos.pid) &&
+                    !topic_id_change)
                         rd_kafka_toppar_idemp_msgid_save(rkt, rktp);
 
                 rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_UNKNOWN;
@@ -1045,7 +1056,44 @@ static int rd_kafka_topic_partition_cnt_update(rd_kafka_topic_t *rkt,
         return 1;
 }
 
+/**
+ * @brief Update partitions of a topic after it has been recreated.
+ *
+ * @param rkt The topic to update.
+ * @param mdt The metadata of the topic.
+ * @param mdit The internal metadata of the topic.
+ */
+static void rd_kafka_topic_recreated_partition_reset(
+    rd_kafka_topic_t *rkt,
+    const struct rd_kafka_metadata_topic *mdt,
+    const rd_kafka_metadata_topic_internal_t *mdit) {
+        rd_kafka_t *rk = rkt->rkt_rk;
+        rd_kafka_toppar_t *rktp;
+        int32_t i;
 
+        /* Common */
+        for (i = 0; i < rkt->rkt_partition_cnt; i++) {
+                rktp = rkt->rkt_p[i];
+                rd_kafka_toppar_lock(rktp);
+                /* By setting partition's leader epoch to -1, we make sure to
+                 * always pick up whatever is in the metadata. Even if the
+                 * metadata is stale, it's better than what we have because the
+                 * topic has been recreated. We don't need to set any other
+                 * field, because (suppose) the leader is the same, then we can
+                 * just continue, and if we're fetching from a follower, we'll
+                 * just get a not follower error if applicable. */
+                rktp->rktp_leader_epoch = -1;
+                rd_kafka_toppar_unlock(rktp);
+        }
+        if (rk->rk_type == RD_KAFKA_PRODUCER) {
+                /* No op - we bump epoch and drain on rk-level for an idempotent
+                 * producer. */
+        } else if (rk->rk_type == RD_KAFKA_CONSUMER) {
+                /* Consumer */
+                /* We need to reset offsets to be invalid. */
+                /* TODO. */
+        }
+}
 
 /**
  * Topic 'rkt' does not exist: propagate to interested parties.
@@ -1215,7 +1263,8 @@ rd_bool_t rd_kafka_topic_set_notexists(rd_kafka_topic_t *rkt,
         rkt->rkt_flags &= ~RD_KAFKA_TOPIC_F_LEADER_UNAVAIL;
 
         /* Update number of partitions */
-        rd_kafka_topic_partition_cnt_update(rkt, 0);
+        rd_kafka_topic_partition_cnt_update(rkt, 0,
+                                            rd_false /* topic_id_change */);
 
         /* Purge messages with forced partition */
         rd_kafka_topic_assign_uas(rkt, err);
@@ -1300,7 +1349,8 @@ rd_bool_t rd_kafka_topic_set_error(rd_kafka_topic_t *rkt,
         rkt->rkt_err = err;
 
         /* Update number of partitions */
-        rd_kafka_topic_partition_cnt_update(rkt, 0);
+        rd_kafka_topic_partition_cnt_update(rkt, 0,
+                                            rd_false /* topic_id_change */);
 
         /* Purge messages with forced partition */
         rd_kafka_topic_assign_uas(rkt, err);
@@ -1316,6 +1366,9 @@ rd_bool_t rd_kafka_topic_set_error(rd_kafka_topic_t *rkt,
  * @param mdt Topic metadata.
  * @param mdit Topic internal metadata.
  * @param ts_age absolute age (timestamp) of metadata.
+ * @param update_epoch_bump this is set as an out parameter. If set to true,
+ * caller should run rd_kafka_idemp_drain_epoch_bump().
+ *
  * @returns 1 if the number of partitions changed, 0 if not, and -1 if the
  *          topic is unknown.
 
@@ -1326,7 +1379,8 @@ static int
 rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
                                const struct rd_kafka_metadata_topic *mdt,
                                const rd_kafka_metadata_topic_internal_t *mdit,
-                               rd_ts_t ts_age) {
+                               rd_ts_t ts_age,
+                               rd_bool_t *update_epoch_bump) {
         rd_kafka_t *rk = rkt->rkt_rk;
         int upd        = 0;
         int j;
@@ -1335,6 +1389,7 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         int old_state;
         rd_bool_t partition_exists_with_no_leader_epoch    = rd_false;
         rd_bool_t partition_exists_with_stale_leader_epoch = rd_false;
+        rd_bool_t different_topic_id                       = rd_false;
 
         if (mdt->err != RD_KAFKA_RESP_ERR_NO_ERROR)
                 rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_METADATA, "METADATA",
@@ -1385,12 +1440,17 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         /* Update number of partitions, but not if there are
          * (possibly intermittent) errors (e.g., "Leader not available"). */
         if (mdt->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
-                rd_bool_t different_topic_id =
+                /* Avoids those id changes where we're creating the topic or
+                 * deleting it during termination. */
+                rd_bool_t both_topic_ids_non_zero =
+                    !RD_KAFKA_UUID_IS_ZERO(mdit->topic_id) &&
+                    !RD_KAFKA_UUID_IS_ZERO(rkt->rkt_topic_id);
+                different_topic_id =
                     rd_kafka_Uuid_cmp(mdit->topic_id, rkt->rkt_topic_id) != 0;
                 if (different_topic_id ||
                     mdt->partition_cnt > rkt->rkt_partition_cnt)
                         upd += rd_kafka_topic_partition_cnt_update(
-                            rkt, mdt->partition_cnt);
+                            rkt, mdt->partition_cnt, different_topic_id);
                 if (different_topic_id) {
                         /* FIXME: an offset reset must be triggered.
                          * when rkt_topic_id wasn't zero.
@@ -1406,7 +1466,16 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
                             rkt->rkt_topic->str,
                             rd_kafka_Uuid_base64str(&rkt->rkt_topic_id),
                             rd_kafka_Uuid_base64str(&mdit->topic_id));
+
                         rkt->rkt_topic_id = mdit->topic_id;
+
+                        rd_kafka_topic_recreated_partition_reset(rkt, mdt,
+                                                                 mdit);
+
+                        if (rd_kafka_is_idempotent(rk) &&
+                            both_topic_ids_non_zero) {
+                                *update_epoch_bump = rd_true;
+                        }
                 }
                 /* If the metadata times out for a topic (because all brokers
                  * are down) the state will transition to S_UNKNOWN.
@@ -1505,6 +1574,7 @@ int rd_kafka_topic_metadata_update2(
     const rd_kafka_metadata_topic_internal_t *mdit) {
         rd_kafka_topic_t *rkt;
         int r;
+        rd_bool_t update_epoch_bump = rd_false;
 
         rd_kafka_wrlock(rkb->rkb_rk);
 
@@ -1520,9 +1590,27 @@ int rd_kafka_topic_metadata_update2(
                 return -1; /* Ignore topics that we dont have locally. */
         }
 
-        r = rd_kafka_topic_metadata_update(rkt, mdt, mdit, rd_clock());
+        r = rd_kafka_topic_metadata_update(rkt, mdt, mdit, rd_clock(),
+                                           &update_epoch_bump);
 
         rd_kafka_wrunlock(rkb->rkb_rk);
+
+        /* This is true in case of topic recreation and when we're using an
+         * idempotent/transactional producer. */
+        if (update_epoch_bump) {
+                /* Why do we bump epoch here rather than, say, at an rk-level
+                 * after checking this for all topics?
+                 * 1. We need to make sure leader changes (and the subsequent
+                 * broker delegation change) does not run before this, as
+                 * the producer might start sending to the new broker, which
+                 * would give us out of sequence errors.
+                 * 2. The rd_kafka_idemp_drain_epoch_bump() sets state in an
+                 * idempotent way, though the function isn't entirely
+                 * idempotent, so it's okay to do this repeatedly.
+                 */
+                rd_kafka_idemp_drain_epoch_bump(
+                    rkb->rkb_rk, RD_KAFKA_RESP_ERR_NO_ERROR, "topic recreated");
+        }
 
         rd_kafka_topic_destroy0(rkt); /* from find() */
 
@@ -1591,7 +1679,8 @@ void rd_kafka_topic_partitions_remove(rd_kafka_topic_t *rkt) {
 
         /* Setting the partition count to 0 moves all partitions to
          * the desired list (rktp_desp). */
-        rd_kafka_topic_partition_cnt_update(rkt, 0);
+        rd_kafka_topic_partition_cnt_update(rkt, 0,
+                                            rd_false /* topic_id_change */);
 
         /* Now clean out the desired partitions list.
          * Use reverse traversal to avoid excessive memory shuffling
@@ -2106,6 +2195,7 @@ void rd_ut_kafka_topic_set_topic_exists(rd_kafka_topic_t *rkt,
                                               .partition_cnt = partition_cnt};
         rd_kafka_metadata_topic_internal_t mdit = {.partitions = partitions};
         int i;
+        rd_bool_t update_epoch_bump;
 
         mdt.partitions = rd_alloca(sizeof(*mdt.partitions) * partition_cnt);
 
@@ -2118,7 +2208,9 @@ void rd_ut_kafka_topic_set_topic_exists(rd_kafka_topic_t *rkt,
         rd_kafka_wrlock(rkt->rkt_rk);
         rd_kafka_metadata_cache_topic_update(rkt->rkt_rk, &mdt, &mdit, rd_true,
                                              rd_false, rd_true);
-        rd_kafka_topic_metadata_update(rkt, &mdt, &mdit, rd_clock());
+        update_epoch_bump = rd_false;
+        rd_kafka_topic_metadata_update(rkt, &mdt, &mdit, rd_clock(),
+                                       &update_epoch_bump);
         rd_kafka_wrunlock(rkt->rkt_rk);
         rd_free(partitions);
 }

--- a/tests/0151-topic_recreate_mock.c
+++ b/tests/0151-topic_recreate_mock.c
@@ -1,0 +1,251 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2025, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+#include "../src/rdkafka_proto.h"
+
+/**
+ *  @name Verify that producer and consumer resumes operation after
+ *       a topic has been deleted and recreated (with topic id change) using
+ *       the mock broker.
+ *
+ * @note These tests should be revised after the implementation of KIP-516 is
+ * added to the actual broker for Produce.
+ */
+
+/**
+ * Test topic recreation for producer. There are two configurable flags:
+ * 1. is_idempotent: decides whether producer is idempotent or not.
+ * 2. leader_change: if set to true, changes leader of the initial topic to push
+ *    the leader epoch beyond that of the recreated topic.
+ */
+static void do_test_topic_recreated_producer(rd_bool_t is_idempotent,
+                                             rd_bool_t leader_change) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstrap_servers;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+
+        SUB_TEST("Testing topic recreation with %s producer",
+                 is_idempotent ? "idempotent" : "normal");
+
+        /* Create mock cluster */
+        mcluster = test_mock_cluster_new(3, &bootstrap_servers);
+
+        /* Create topic and change leader to bump leader epoch */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+        if (leader_change)
+                rd_kafka_mock_partition_set_leader(mcluster, "test_topic", 0,
+                                                   2);
+
+        /* Create and init a producer */
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstrap_servers);
+        test_conf_set(conf, "enable.idempotence",
+                      is_idempotent ? "true" : "false");
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+
+        /* Produce 10 messages */
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+
+        /* Delete topic */
+        rd_kafka_mock_topic_delete(mcluster, "test_topic");
+
+        /* Re-create topic */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+
+        /* Propagate topic change in metadata. */
+        rd_sleep(2);
+
+        /* Produce messages to rereated topic - it should be seamless. */
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * Test two topics' recreation (at the same time) with normal and idempotent
+ * producer.
+ */
+static void do_test_two_topics_recreated_producer(rd_bool_t is_idempotent) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstrap_servers;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+
+        SUB_TEST("Testing two topics' recreation with %s producer",
+                 is_idempotent ? "idempotent" : "normal");
+
+        /* Create mock cluster */
+        mcluster = test_mock_cluster_new(3, &bootstrap_servers);
+
+        /* Create topic and change leader to bump leader epoch */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+        rd_kafka_mock_topic_create(mcluster, "test_topic2", 3, 1);
+        rd_kafka_mock_partition_set_leader(mcluster, "test_topic", 0, 2);
+        rd_kafka_mock_partition_set_leader(mcluster, "test_topic2", 0, 2);
+
+        /* Create and init a producer */
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstrap_servers);
+        test_conf_set(conf, "enable.idempotence",
+                      is_idempotent ? "true" : "false");
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+
+        /* Produce 10 messages */
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+        test_produce_msgs2(rk, "test_topic2", 0, 0, 0, 10, "test", 10);
+
+        /* Delete topic */
+        rd_kafka_mock_topic_delete(mcluster, "test_topic");
+        rd_kafka_mock_topic_delete(mcluster, "test_topic2");
+        /* Re-create topic */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+        rd_kafka_mock_topic_create(mcluster, "test_topic2", 3, 1);
+
+        /* Propagate topic change in metadata. */
+        rd_sleep(2);
+
+        /* Produce messages to rereated topic - it should be seamless. */
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+        test_produce_msgs2(rk, "test_topic2", 0, 0, 0, 10, "test", 10);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/* Test topic recreation with transactional producer */
+static void do_test_topic_recreated_transactional_producer() {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstrap_servers;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        rd_kafka_resp_err_t err;
+
+        SUB_TEST("Testing topic recreation with transactional producer");
+
+        /* Create mock cluster */
+        mcluster = test_mock_cluster_new(3, &bootstrap_servers);
+
+        /* Create topic and change leader to bump leader epoch */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+
+        /* Note that a leader change is NECESSARY for testing a transactional
+         * producer. A NOT_LEADER exception is why a metadata request is
+         * triggered in the first place. Otherwise it just fails with a fatal
+         * error (out of sequence) because the Produce RPC isn't aware of topic
+         * IDs, and thus the client has no way to know. */
+        rd_kafka_mock_partition_set_leader(mcluster, "test_topic", 0, 2);
+
+        /* Create and init a transactional producer */
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstrap_servers);
+        test_conf_set(conf, "enable.idempotence", "true");
+        test_conf_set(conf, "transactional.id", "test_tx");
+        test_conf_set(conf, "max.in.flight", "1");
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+        rd_kafka_init_transactions(rk, 5000);
+
+
+        /* Produce 10 messages */
+        rd_kafka_begin_transaction(rk);
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+        rd_kafka_commit_transaction(rk, 5000);
+
+        /* Delete topic */
+        rd_kafka_mock_topic_delete(mcluster, "test_topic");
+
+        /* Re-create topic */
+        rd_kafka_mock_topic_create(mcluster, "test_topic", 3, 1);
+
+        /* Propagate topic change in metadata*/
+        rd_sleep(2);
+
+        /* Produce messages to rereated topic. */
+        rd_kafka_begin_transaction(rk);
+        /* First message should queue without any problems. */
+        err = rd_kafka_producev(rk, RD_KAFKA_V_TOPIC("test_topic"),
+                                RD_KAFKA_V_VALUE("test", 4), RD_KAFKA_V_END);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR, not %s", rd_kafka_err2str(err));
+
+        /* We might get Success or Purged from Queue, depending on when exactly
+         * the metadata request is made. There's nothing we can do about it
+         * until AK implements produce by topic id. So turn off error checking.
+         */
+        test_curr->ignore_dr_err = rd_true;
+
+        /* Some Nth message should refuse to queue because we're in ERR__STATE
+         * and we need an abort. We don't know exactly at what point it starts
+         * to complain because we're not tracking the metadata request or the
+         * time when epoch_drain_bump is called. So just rely on the test
+         * timeout. */
+        while (err == RD_KAFKA_RESP_ERR_NO_ERROR) {
+                err = rd_kafka_producev(rk, RD_KAFKA_V_TOPIC("test_topic"),
+                                        RD_KAFKA_V_VALUE("test", 4),
+                                        RD_KAFKA_V_END);
+                rd_sleep(1);
+        }
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected ERR__STATE error, not %s", rd_kafka_err2str(err));
+        rd_kafka_abort_transaction(rk, 5000);
+
+        /* Producer should work as normal after abort. */
+        test_curr->ignore_dr_err = rd_false;
+        rd_kafka_begin_transaction(rk);
+        test_produce_msgs2(rk, "test_topic", 0, 0, 0, 10, "test", 10);
+        rd_kafka_commit_transaction(rk, 5000);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0151_topic_recreate_mock(int argc, char **argv) {
+        do_test_topic_recreated_producer(rd_false, rd_false);
+        do_test_topic_recreated_producer(rd_false, rd_true);
+        do_test_topic_recreated_producer(rd_true, rd_false);
+        do_test_topic_recreated_producer(rd_true, rd_true);
+
+        do_test_two_topics_recreated_producer(rd_false);
+        do_test_two_topics_recreated_producer(rd_true);
+
+        do_test_topic_recreated_transactional_producer();
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ set(
     0145-pause_resume_mock.c
     0146-metadata_mock.c
     0150-telemetry_mock.c
+    0151-topic_recreate_mock.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -263,6 +263,7 @@ _TEST_DECL(0144_idempotence_mock);
 _TEST_DECL(0145_pause_resume_mock);
 _TEST_DECL(0146_metadata_mock);
 _TEST_DECL(0150_telemetry_mock);
+_TEST_DECL(0151_topic_recreate_mock);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -475,8 +476,7 @@ struct test tests[] = {
     _TEST(0106_cgrp_sess_timeout, TEST_F_LOCAL, TEST_BRKVER(0, 11, 0, 0)),
     _TEST(0107_topic_recreate,
           0,
-          TEST_BRKVER_TOPIC_ADMINAPI,
-          .scenario = "noautocreate"),
+          TEST_BRKVER_TOPIC_ADMINAPI),
     _TEST(0109_auto_create_topics, 0),
     _TEST(0110_batch_size, 0),
     _TEST(0111_delay_create_topics,
@@ -522,7 +522,7 @@ struct test tests[] = {
     _TEST(0145_pause_resume_mock, TEST_F_LOCAL),
     _TEST(0146_metadata_mock, TEST_F_LOCAL),
     _TEST(0150_telemetry_mock, 0),
-
+    _TEST(0151_topic_recreate_mock, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="..\..\tests\0145-pause_resume_mock.c" />
     <ClCompile Include="..\..\tests\0146-metadata_mock.c" />
     <ClCompile Include="..\..\tests\0150-telemetry_mock.c" />
+    <ClCompile Include="..\..\tests\0151-topic_recreate_mock.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
There is a bunch of things we need to do for producers when topics are recreated (topic id changes). Unfortunately we cannot do it all because the Produce RPC doesn't yet use topic ids. We can make a best-effort from metadata requests. This is still in a draft state.