### PR TITLE
fixup: Use same strategy for updating cache partition metadata

### DIFF
--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -1223,8 +1223,9 @@ static RD_INLINE RD_UNUSED void rd_kafka_app_polled(rd_kafka_t *rk) {
                 }
                 if (!rk->rk_ts_last_poll_end)
                         rk->rk_ts_last_poll_end = now;
-                rd_dassert(rk->rk_ts_last_poll_end >=
-                           rk->rk_ts_last_poll_start);
+                /* Disabled until #5017 is merged
+                 * rd_dassert(rk->rk_ts_last_poll_end >=
+                 *            rk->rk_ts_last_poll_start); */
         }
 }
 

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -977,11 +977,7 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                                  * Mark the topic as non-existent */
                                 rd_kafka_topic_wrlock(rkt);
                                 rd_kafka_topic_set_notexists(
-                                    rkt,
-                                    /* Just rely on metadata
-                                     * propagation check */
-                                    rkt->rkt_topic_id,
-                                    RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC);
+                                    rkt, RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC);
                                 rd_kafka_topic_wrunlock(rkt);
 
                                 rd_kafka_topic_destroy0(rkt);
@@ -1017,11 +1013,7 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                                  * Mark the topic as non-existent */
                                 rd_kafka_topic_wrlock(rkt);
                                 rd_kafka_topic_set_notexists(
-                                    rkt,
-                                    /* Just rely on metadata
-                                     * propagation check */
-                                    rkt->rkt_topic_id,
-                                    RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC);
+                                    rkt, RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC);
                                 rd_kafka_topic_wrunlock(rkt);
 
                                 rd_kafka_topic_destroy0(rkt);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1216,7 +1216,6 @@ static void rd_kafka_topic_assign_uas(rd_kafka_topic_t *rkt,
  * @locks topic_wrlock() MUST be held.
  */
 rd_bool_t rd_kafka_topic_set_notexists(rd_kafka_topic_t *rkt,
-                                       rd_kafka_Uuid_t topic_id,
                                        rd_kafka_resp_err_t err) {
         rd_ts_t remains_us;
         rd_bool_t permanent = err == RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION;
@@ -1234,8 +1233,6 @@ rd_bool_t rd_kafka_topic_set_notexists(rd_kafka_topic_t *rkt,
             rkt->rkt_ts_metadata;
 
         if (!permanent &&
-            /* Same topic id */
-            rd_kafka_Uuid_cmp(rkt->rkt_topic_id, topic_id) == 0 &&
             (rkt->rkt_state == RD_KAFKA_TOPIC_S_UNKNOWN ||
              rkt->rkt_state == RD_KAFKA_TOPIC_S_ERROR ||
              rkt->rkt_state == RD_KAFKA_TOPIC_S_EXISTS) &&
@@ -1413,7 +1410,7 @@ rd_kafka_topic_metadata_update(rd_kafka_topic_t *rkt,
         if (mdt->err == RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION /*invalid topic*/ ||
             mdt->err == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART ||
             mdt->err == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID)
-                rd_kafka_topic_set_notexists(rkt, mdit->topic_id, mdt->err);
+                rd_kafka_topic_set_notexists(rkt, mdt->err);
         else if (mdt->err == RD_KAFKA_RESP_ERR_NO_ERROR &&
                  mdt->partition_cnt > 0)
                 rd_kafka_topic_set_exists(rkt, mdit->topic_id);

--- a/src/rdkafka_topic.h
+++ b/src/rdkafka_topic.h
@@ -248,7 +248,6 @@ int rd_kafka_topic_cmp_rkt(const void *_a, const void *_b);
 void rd_kafka_topic_partitions_remove(rd_kafka_topic_t *rkt);
 
 rd_bool_t rd_kafka_topic_set_notexists(rd_kafka_topic_t *rkt,
-                                       rd_kafka_Uuid_t topic_id,
                                        rd_kafka_resp_err_t err);
 rd_bool_t rd_kafka_topic_set_error(rd_kafka_topic_t *rkt,
                                    rd_kafka_resp_err_t err);


### PR DESCRIPTION
remove topic id check given it's the zero UUID when topic doesn't exist and it invalidates the new check that avoids the transition exists -> not exists before `metadata.propagation.max.ms`.

For `rd_kafka_topic_set_exists` it's fine to keep it as we're comparing the previous UUID with new one to see if it's a deleted topic that is re-appearing or a completely new one.