### PR TITLE
[DOCS] Fix trivup example, now requires version flag, update Kafka example test version to current

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -27,10 +27,14 @@ First install required Python packages (trivup with friends):
 
     $ python3 -m pip install -U -r requirements.txt
 
+Note that currently trivup requires Python 3.7 or greater. If you receive
+an error like "ModuleNotFoundError: No module named 'importlib.resources'",
+it's probably due to the version of Python that you're using.
+
 Bring up a Kafka cluster (with the specified version) and start an interactive
 shell, when the shell is exited the cluster is brought down and deleted.
 
-    $ python3 -m trivup.clusters.KafkaCluster 2.3.0   # Broker version
+    $ python3 -m trivup.clusters.KafkaCluster --version 3.9.0   # Broker version
     # You can also try adding:
     #   --ssl    To enable SSL listeners
     #   --sasl <mechanism>   To enable SASL authentication


### PR DESCRIPTION
It looks like the syntax for the trivup module has changed since the README was written, and it now requires a '--version' flag to specify the version.

Also, the example version was very old, so I updated the (example) to a currently supported for (3.9.0).  In testing, the tests that pass correctly under 2.3.0 for me also pass under 3.9.0, so I wouldn't expect this to cause any problems, but users are still fine to specify the old version(s) if necessary.

I also added a warning about Python versions (eg. when trying this example with 3.6.9, it fails with the example error provided - it looks like from the release notes, the importlib feature which trivup relies on was introduced in Python 3.7, and I verified by testing several Python versions).