### PR TITLE
Handle the DESTROY_BROKER error on SaslAuthenticate RPC

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3327,6 +3327,9 @@ void rd_kafka_handle_SaslAuthenticate(rd_kafka_t *rk,
         rd_kafkap_bytes_t auth_data;
         char errstr[512];
 
+        if (rd_kafka_broker_is_any_err_destroy(err))
+                return;
+
         if (err) {
                 rd_snprintf(errstr, sizeof(errstr),
                             "SaslAuthenticateRequest failed: %s",


### PR DESCRIPTION
by not sending an error message to the user as the authentication will be done on the new broker connection.
Similar to what done on SaslHandshake