### PR TITLE
metadata: Fix metadata request topic list length incorrect issue (#5049)

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2822,6 +2822,10 @@ rd_kafka_MetadataRequest0(rd_kafka_broker_t *rkb,
                         rd_kafka_buf_update_i32(rkbuf, of_TopicArrayCnt, -1);
                 }
                 /* v9+: keep 0, varint encoded null, all topics */
+                else if (ApiVersion >= 9) {
+                        /* v9+: varint encoded empty array (1), brokers only */
+                        rd_kafka_buf_finalize_null_arraycnt(rkbuf, of_TopicArrayCnt);
+                }
 
                 rkbuf->rkbuf_u.Metadata.all_topics = 1;
                 rd_rkb_dbg(rkb, METADATA, "METADATA",


### PR DESCRIPTION
For metadata request API version >= 9, Null array length is not correctly set, the 4 bytes int should be replaced by 1 byte varint.