### PR TITLE
[internal] Add missing wrlock around rd_kafka_metadata_cache_hint call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# librdkafka v2.10.1
+
+librdkafka v2.10.1 is a maintenance release:
+
+ * Fix to add locks when updating the metadata cache for the consumer 
+   after no broker connection is available (@marcin-krystianc, #5066).
+
+
+## Fixes
+
+### Consumer fixes
+
+ * Issues: #5051
+   Fix to add locks when updating the metadata cache for the consumer.
+   It can cause memory corruption or use-after-free in case
+   there's no broker connection and the consumer
+   group metadata needs to be updated.
+   Happens since 2.10.0 (#5066).
+
+
+
 # librdkafka v2.10.0
 
 librdkafka v2.10.0 is a feature release:

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2576,8 +2576,12 @@ static int rd_kafka_cgrp_metadata_refresh(rd_kafka_cgrp_t *rkcg,
                 /* Hint cache that something is interested in
                  * these topics so that they will be included in
                  * a future all known_topics query. */
+
+                rd_kafka_wrlock(rk);
                 rd_kafka_metadata_cache_hint(rk, &topics, NULL,
                                              RD_KAFKA_RESP_ERR__NOENT);
+                rd_kafka_wrunlock(rk);
+
                 rd_kafka_dbg(rk, CGRP | RD_KAFKA_DBG_METADATA, "CGRPMETADATA",
                              "%s: need to refresh metadata (%dms old) "
                              "but no usable brokers available: %s",


### PR DESCRIPTION
Re-open #5055 from an internal branch