### PR TITLE
Fix reboostrapping with no boostrap servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# librdkafka v2.10.1
+
+librdkafka v2.10.1 is a maintenance release:
+
+ * Fix to the re-bootstrap case when `boostrap.servers` is `NULL` and
+   brokers were added manually through `rd_kafka_brokers_add` (#5067).
+
+
+## Fixes
+
+### Consumer fixes
+
+ * Issues: #5057
+   Fix to the re-bootstrap case when `boostrap.servers` is `NULL` and
+   brokers were added manually through `rd_kafka_brokers_add`.
+   Avoids a segmentation fault in this case.
+   Happens since 2.10.0 (#5067).
+
+
+
 # librdkafka v2.10.0
 
 librdkafka v2.10.0 is a feature release:

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2089,9 +2089,13 @@ static void rd_kafka_rebootstrap_tmr_cb(rd_kafka_timers_t *rkts, void *arg) {
 
         rd_kafka_dbg(rk, ALL, "REBOOTSTRAP", "Starting re-bootstrap sequence");
 
-        rd_kafka_brokers_add0(
-            rk, rk->rk_conf.brokerlist, rd_true
-            /*resolve canonical bootstrap server list names if requested*/);
+        if (rk->rk_conf.brokerlist) {
+                rd_kafka_brokers_add0(
+                        rk,
+                        rk->rk_conf.brokerlist, rd_true
+                        /* resolve canonical bootstrap server
+                         * list names if requested*/);
+        }
 
         rd_kafka_rdlock(rk);
         if (rd_list_cnt(&rk->additional_brokerlists) == 0) {

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -525,7 +525,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         }
 
         rkcg->rkcg_subscribed_topics =
-            rd_list_new(0, (void *)rd_kafka_topic_info_destroy);
+            rd_list_new(0, rd_kafka_topic_info_destroy_free);
         rd_interval_init(&rkcg->rkcg_coord_query_intvl);
         rd_interval_init(&rkcg->rkcg_heartbeat_intvl);
         rd_interval_init(&rkcg->rkcg_join_intvl);
@@ -2741,7 +2741,7 @@ static rd_bool_t rd_kafka_cgrp_update_subscribed_topics(rd_kafka_cgrp_t *rkcg,
                                      "clearing subscribed topics list (%d)",
                                      RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
                                      rd_list_cnt(rkcg->rkcg_subscribed_topics));
-                tinfos = rd_list_new(0, (void *)rd_kafka_topic_info_destroy);
+                tinfos = rd_list_new(0, rd_kafka_topic_info_destroy_free);
 
         } else {
                 if (rd_list_cnt(tinfos) == 0)
@@ -5465,7 +5465,7 @@ rd_kafka_cgrp_modify_subscription(rd_kafka_cgrp_t *rkcg,
         /* Create a list of the topics in metadata that matches the new
          * subscription */
         tinfos = rd_list_new(rkcg->rkcg_subscription->cnt,
-                             (void *)rd_kafka_topic_info_destroy);
+                             rd_kafka_topic_info_destroy_free);
 
         /* Unmatched topics will be added to the errored list. */
         errored = rd_kafka_topic_partition_list_new(0);
@@ -6903,7 +6903,7 @@ void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
          * Create a list of the topics in metadata that matches our subscription
          */
         tinfos = rd_list_new(rkcg->rkcg_subscription->cnt,
-                             (void *)rd_kafka_topic_info_destroy);
+                             rd_kafka_topic_info_destroy_free);
 
         if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_WILDCARD_SUBSCRIPTION)
                 rd_kafka_metadata_topic_match(rkcg->rkcg_rk, tinfos,
@@ -7480,7 +7480,7 @@ static int unittest_list_to_map(void) {
 }
 
 int unittest_member_metadata_serdes(void) {
-        rd_list_t *topics = rd_list_new(0, (void *)rd_kafka_topic_info_destroy);
+        rd_list_t *topics = rd_list_new(0, rd_kafka_topic_info_destroy_free);
         rd_kafka_topic_partition_list_t *owned_partitions =
             rd_kafka_topic_partition_list_new(0);
         rd_kafkap_str_t *rack_id    = rd_kafkap_str_new("myrack", -1);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -2048,7 +2048,7 @@ rd_kafka_topic_info_t *rd_kafka_topic_info_new_with_rack(
 /**
  * Destroy/free topic_info
  */
-void rd_kafka_topic_info_destroy(rd_kafka_topic_info_t *ti) {
+void rd_kafka_topic_info_destroy_free(void *ti) {
         rd_free(ti);
 }
 

--- a/src/rdkafka_topic.h
+++ b/src/rdkafka_topic.h
@@ -291,7 +291,7 @@ rd_kafka_topic_info_t *rd_kafka_topic_info_new_with_rack(
     const char *topic,
     int partition_cnt,
     const rd_kafka_metadata_partition_internal_t *mdpi);
-void rd_kafka_topic_info_destroy(rd_kafka_topic_info_t *ti);
+void rd_kafka_topic_info_destroy_free(void *ti);
 
 int rd_kafka_topic_match(rd_kafka_t *rk,
                          const char *pattern,

--- a/tests/0152-rebootstrap.c
+++ b/tests/0152-rebootstrap.c
@@ -1,0 +1,59 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2025, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+/**
+ * @brief Verify the case where there are no bootstrap servers
+ *        and the client is re-bootstrapped after brokers were added
+ *        manually.
+ */
+static void
+do_test_rebootstrap_local_no_bootstrap_servers(rd_kafka_type_t rk_type) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+
+        SUB_TEST_QUICK("%s",
+                       rk_type == RD_KAFKA_PRODUCER ? "producer" : "consumer");
+        test_conf_init(&conf, NULL, 30);
+        rk = test_create_handle(rk_type, conf);
+        rd_kafka_brokers_add(rk, "localhost:9999");
+
+        /* Give it time to trigger ALL_BROKERS_DOWN */
+        rd_sleep(1);
+        rd_kafka_destroy(rk);
+        SUB_TEST_PASS();
+}
+
+int main_0152_rebootstrap_local(int argc, char **argv) {
+
+        do_test_rebootstrap_local_no_bootstrap_servers(RD_KAFKA_PRODUCER);
+        do_test_rebootstrap_local_no_bootstrap_servers(RD_KAFKA_CONSUMER);
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,7 @@ set(
     0149-broker-same-host-port.c
     0150-telemetry_mock.c
     0151-purge-brokers.c
+    0152-rebootstrap.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -266,6 +266,7 @@ _TEST_DECL(0146_metadata_mock);
 _TEST_DECL(0149_broker_same_host_port_mock);
 _TEST_DECL(0150_telemetry_mock);
 _TEST_DECL(0151_purge_brokers_mock);
+_TEST_DECL(0152_rebootstrap_local);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -528,6 +529,7 @@ struct test tests[] = {
     _TEST(0149_broker_same_host_port_mock, TEST_F_LOCAL),
     _TEST(0150_telemetry_mock, 0),
     _TEST(0151_purge_brokers_mock, TEST_F_LOCAL),
+    _TEST(0152_rebootstrap_local, TEST_F_LOCAL),
 
 
     /* Manual tests */

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="..\..\tests\0149-broker-same-host-port.c" />
     <ClCompile Include="..\..\tests\0150-telemetry_mock.c" />
     <ClCompile Include="..\..\tests\0151-purge-brokers.c" />
+    <ClCompile Include="..\..\tests\0152-rebootstrap.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
when brokers were added only through `rd_kafka_brokers_add`.