### PR TITLE
[KIP 482]: Upgrade ACL APis to Version 2(First flexible version)

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2174,9 +2174,9 @@ release of librdkafka.
 | 25      | AddOffsetsToTxn               | 4          | 0              |
 | 26      | EndTxn                        | 5          | 1              |
 | 28      | TxnOffsetCommit               | 5          | 3              |
-| 29      | DescribeAcls                  | 3          | 1              |
-| 30      | CreateAcls                    | 3          | 1              |
-| 31      | DeleteAcls                    | 3          | 1              |
+| 29      | DescribeAcls                  | 3          | 2              |
+| 30      | CreateAcls                    | 3          | 2              |
+| 31      | DeleteAcls                    | 3          | 2              |
 | 32      | DescribeConfigs               | 4          | 1              |
 | 33      | AlterConfigs                  | 2          | 2              |
 | 36      | SaslAuthenticate              | 2          | 1              |

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -5457,12 +5457,20 @@ rd_kafka_CreateAclsResponse_parse(rd_kafka_op_t *rko_req,
                                 RD_KAFKAP_STR_DUPA(&errstr, &error_msg);
                 }
 
+                if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                        rd_kafka_buf_skip_tags(reply);
+                }
+
                 acl_res = rd_kafka_acl_result_new(
                     error_code ? rd_kafka_error_new(error_code, "%s", errstr)
                                : NULL);
 
                 rd_list_set(&rko_result->rko_u.admin_result.results, i,
                             acl_res);
+        }
+
+        if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                rd_kafka_buf_skip_tags(reply);
         }
 
         *rko_resultp = rko_result;
@@ -5620,6 +5628,10 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_str(reply, &khost);
                         rd_kafka_buf_read_i8(reply, &operation);
                         rd_kafka_buf_read_i8(reply, &permission_type);
+
+                        if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                                rd_kafka_buf_skip_tags(reply);
+                        }
                         RD_KAFKAP_STR_DUPA(&principal, &kprincipal);
                         RD_KAFKAP_STR_DUPA(&host, &khost);
 
@@ -5653,6 +5665,14 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_list_add(&rko_result->rko_u.admin_result.results,
                                     acl);
                 }
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                        rd_kafka_buf_skip_tags(reply);
+                }
+        }
+
+        if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                rd_kafka_buf_skip_tags(reply);
         }
 
         *rko_resultp = rko_result;
@@ -6661,6 +6681,11 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_str(reply, &khost);
                         rd_kafka_buf_read_i8(reply, &operation);
                         rd_kafka_buf_read_i8(reply, &permission_type);
+
+                        if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                                rd_kafka_buf_skip_tags(reply);
+                        }
+
                         RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                         RD_KAFKAP_STR_DUPA(&principal, &kprincipal);
                         RD_KAFKAP_STR_DUPA(&host, &khost);
@@ -6718,8 +6743,16 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                             (void *)matching_acl);
                 }
 
+                if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                        rd_kafka_buf_skip_tags(reply);
+                }
+
                 rd_list_add(&rko_result->rko_u.admin_result.results,
                             (void *)result_response);
+        }
+
+        if (rd_kafka_buf_ApiVersion(reply) >= 2) {
+                rd_kafka_buf_skip_tags(reply);
         }
 
         *rko_resultp = rko_result;

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5672,7 +5672,7 @@ rd_kafka_CreateAclsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_CreateAcls, 0, 1, NULL);
+            rkb, RD_KAFKAP_CreateAcls, 0, 2, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "ACLs Admin API (KIP-140) not supported "
@@ -5713,28 +5713,41 @@ rd_kafka_CreateAclsRequest(rd_kafka_broker_t *rkb,
                 len += rd_kafka_AclBinding_request_size(new_acl, ApiVersion);
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_CreateAcls, 1, len);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_CreateAcls, 1,
+                                                 len, ApiVersion >= 2);
 
         /* #acls */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(new_acls));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(new_acls));
 
         RD_LIST_FOREACH(new_acl, new_acls, i) {
+                rd_kafkap_str_t *acl_name, *acl_principal, *acl_host;
+
                 rd_kafka_buf_write_i8(rkbuf, new_acl->restype);
 
-                rd_kafka_buf_write_str(rkbuf, new_acl->name, -1);
+                acl_name = rd_kafkap_str_new(new_acl->name, -1);
+                rd_kafka_buf_write_kstr(rkbuf, acl_name);
+                rd_kafkap_str_destroy(acl_name);
 
                 if (ApiVersion >= 1) {
                         rd_kafka_buf_write_i8(rkbuf,
                                               new_acl->resource_pattern_type);
                 }
 
-                rd_kafka_buf_write_str(rkbuf, new_acl->principal, -1);
+                acl_principal = rd_kafkap_str_new(new_acl->principal, -1);
+                rd_kafka_buf_write_kstr(rkbuf, acl_principal);
+                rd_kafkap_str_destroy(acl_principal);
 
-                rd_kafka_buf_write_str(rkbuf, new_acl->host, -1);
+                acl_host = rd_kafkap_str_new(new_acl->host, -1);
+                rd_kafka_buf_write_kstr(rkbuf, acl_host);
+                rd_kafkap_str_destroy(acl_host);
 
                 rd_kafka_buf_write_i8(rkbuf, new_acl->operation);
 
                 rd_kafka_buf_write_i8(rkbuf, new_acl->permission_type);
+
+                if (ApiVersion >= 2) {
+                        rd_kafka_buf_write_tags_empty(rkbuf);
+                }
         }
 
         /* timeout */
@@ -5773,6 +5786,7 @@ rd_kafka_resp_err_t rd_kafka_DescribeAclsRequest(
         rd_kafka_buf_t *rkbuf;
         int16_t ApiVersion = 0;
         const rd_kafka_AclBindingFilter_t *acl;
+        rd_kafkap_str_t *acl_name, *acl_principal, *acl_host;
         int op_timeout;
 
         if (rd_list_cnt(acls) == 0) {
@@ -5791,7 +5805,7 @@ rd_kafka_resp_err_t rd_kafka_DescribeAclsRequest(
         acl = rd_list_elem(acls, 0);
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DescribeAcls, 0, 1, NULL);
+            rkb, RD_KAFKAP_DescribeAcls, 0, 2, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "ACLs Admin API (KIP-140) not supported "
@@ -5821,15 +5835,21 @@ rd_kafka_resp_err_t rd_kafka_DescribeAclsRequest(
                 }
         }
 
-        rkbuf = rd_kafka_buf_new_request(
+        rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_DescribeAcls, 1,
-            rd_kafka_AclBinding_request_size(acl, ApiVersion));
+            rd_kafka_AclBinding_request_size(acl, ApiVersion), ApiVersion >= 2);
 
         /* resource_type */
         rd_kafka_buf_write_i8(rkbuf, acl->restype);
 
         /* resource_name filter */
-        rd_kafka_buf_write_str(rkbuf, acl->name, -1);
+        if (!acl->name) {
+                acl_name = rd_kafkap_str_new(NULL, -1);
+        } else {
+                acl_name = rd_kafkap_str_new(acl->name, -1);
+        }
+        rd_kafka_buf_write_kstr(rkbuf, acl_name);
+        rd_kafkap_str_destroy(acl_name);
 
         if (ApiVersion > 0) {
                 /* resource_pattern_type (rd_kafka_ResourcePatternType_t) */
@@ -5837,10 +5857,22 @@ rd_kafka_resp_err_t rd_kafka_DescribeAclsRequest(
         }
 
         /* principal filter */
-        rd_kafka_buf_write_str(rkbuf, acl->principal, -1);
+        if (!acl->principal) {
+                acl_principal = rd_kafkap_str_new(NULL, -1);
+        } else {
+                acl_principal = rd_kafkap_str_new(acl->principal, -1);
+        }
+        rd_kafka_buf_write_kstr(rkbuf, acl_principal);
+        rd_kafkap_str_destroy(acl_principal);
 
         /* host filter */
-        rd_kafka_buf_write_str(rkbuf, acl->host, -1);
+        if (!acl->host) {
+                acl_host = rd_kafkap_str_new(NULL, -1);
+        } else {
+                acl_host = rd_kafkap_str_new(acl->host, -1);
+        }
+        rd_kafka_buf_write_kstr(rkbuf, acl_host);
+        rd_kafkap_str_destroy(acl_host);
 
         /* operation (rd_kafka_AclOperation_t) */
         rd_kafka_buf_write_i8(rkbuf, acl->operation);
@@ -5896,7 +5928,7 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DeleteAcls, 0, 1, NULL);
+            rkb, RD_KAFKAP_DeleteAcls, 0, 2, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "ACLs Admin API (KIP-140) not supported "
@@ -5932,17 +5964,26 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
                 len += rd_kafka_AclBinding_request_size(acl, ApiVersion);
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_DeleteAcls, 1, len);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteAcls, 1,
+                                                 len, ApiVersion >= 2);
 
         /* #acls */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(del_acls));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_acls));
 
         RD_LIST_FOREACH(acl, del_acls, i) {
+                rd_kafkap_str_t *acl_name, *acl_principal, *acl_host;
+
                 /* resource_type */
                 rd_kafka_buf_write_i8(rkbuf, acl->restype);
 
                 /* resource_name filter */
-                rd_kafka_buf_write_str(rkbuf, acl->name, -1);
+                if (!acl->name) {
+                        acl_name = rd_kafkap_str_new(NULL, -1);
+                } else {
+                        acl_name = rd_kafkap_str_new(acl->name, -1);
+                }
+                rd_kafka_buf_write_kstr(rkbuf, acl_name);
+                rd_kafkap_str_destroy(acl_name);
 
                 if (ApiVersion > 0) {
                         /* resource_pattern_type
@@ -5952,16 +5993,32 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
                 }
 
                 /* principal filter */
-                rd_kafka_buf_write_str(rkbuf, acl->principal, -1);
+                if (!acl->principal) {
+                        acl_principal = rd_kafkap_str_new(NULL, -1);
+                } else {
+                        acl_principal = rd_kafkap_str_new(acl->principal, -1);
+                }
+                rd_kafka_buf_write_kstr(rkbuf, acl_principal);
+                rd_kafkap_str_destroy(acl_principal);
 
                 /* host filter */
-                rd_kafka_buf_write_str(rkbuf, acl->host, -1);
+                if (!acl->host) {
+                        acl_host = rd_kafkap_str_new(NULL, -1);
+                } else {
+                        acl_host = rd_kafkap_str_new(acl->host, -1);
+                }
+                rd_kafka_buf_write_kstr(rkbuf, acl_host);
+                rd_kafkap_str_destroy(acl_host);
 
                 /* operation (rd_kafka_AclOperation_t) */
                 rd_kafka_buf_write_i8(rkbuf, acl->operation);
 
                 /* permission type (rd_kafka_AclPermissionType_t) */
                 rd_kafka_buf_write_i8(rkbuf, acl->permission_type);
+
+                if (ApiVersion >= 2) {
+                        rd_kafka_buf_write_tags_empty(rkbuf);
+                }
         }
 
         /* timeout */


### PR DESCRIPTION
This PR intends to upgrade ACL Apis to v2(first flexible version) in accordance with KIP 482.