### PR TITLE
[KIP-482] Upgrade Admin Apis to flexible versions

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2161,13 +2161,13 @@ release of librdkafka.
 | 12      | Heartbeat                     | 4          | 3              |
 | 13      | LeaveGroup                    | 5          | 1              |
 | 14      | SyncGroup                     | 5          | 3              |
-| 15      | DescribeGroups                | 6          | 4              |
+| 15      | DescribeGroups                | 6          | 5              |
 | 16      | ListGroups                    | 5          | 4              |
 | 17      | SaslHandshake                 | 1          | 1              |
 | 18      | ApiVersions                   | 4          | 3              |
 | 19      | CreateTopics                  | 7          | 4              |
-| 20      | DeleteTopics                  | 6          | 1              |
-| 21      | DeleteRecords                 | 2          | 1              |
+| 20      | DeleteTopics                  | 6          | 4              |
+| 21      | DeleteRecords                 | 2          | 2              |
 | 22      | InitProducerId                | 5          | 4              |
 | 23      | OffsetForLeaderEpoch          | 4          | 2              |
 | 24      | AddPartitionsToTxn            | 5          | 0              |
@@ -2180,8 +2180,8 @@ release of librdkafka.
 | 32      | DescribeConfigs               | 4          | 1              |
 | 33      | AlterConfigs                  | 2          | 2              |
 | 36      | SaslAuthenticate              | 2          | 1              |
-| 37      | CreatePartitions              | 3          | 0              |
-| 42      | DeleteGroups                  | 2          | 1              |
+| 37      | CreatePartitions              | 3          | 2              |
+| 42      | DeleteGroups                  | 2          | 2              |
 | 43      | ElectLeaders                  | 2          | 2              |
 | 44      | IncrementalAlterConfigs       | 1          | 1              |
 | 47      | OffsetDelete                  | 0          | 0              |

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -231,12 +231,11 @@ static const char *rd_kafka_admin_state_desc[] = {
  * @enum Admin request target broker. Must be negative values since the field
  *       used is broker_id.
  */
-enum {
-        RD_KAFKA_ADMIN_TARGET_CONTROLLER  = -1, /**< Cluster controller */
-        RD_KAFKA_ADMIN_TARGET_COORDINATOR = -2, /**< (Group) Coordinator */
-        RD_KAFKA_ADMIN_TARGET_FANOUT      = -3, /**< This rko is a fanout and
-                                                 *   and has no target broker */
-        RD_KAFKA_ADMIN_TARGET_ALL = -4,         /**< All available brokers */
+enum { RD_KAFKA_ADMIN_TARGET_CONTROLLER  = -1, /**< Cluster controller */
+       RD_KAFKA_ADMIN_TARGET_COORDINATOR = -2, /**< (Group) Coordinator */
+       RD_KAFKA_ADMIN_TARGET_FANOUT      = -3, /**< This rko is a fanout and
+                                                *   and has no target broker */
+       RD_KAFKA_ADMIN_TARGET_ALL = -4,         /**< All available brokers */
 };
 
 /**
@@ -2155,7 +2154,7 @@ rd_kafka_CreateTopicsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                           &skel, rd_kafka_NewTopic_cmp);
+                                         &skel, rd_kafka_NewTopic_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -2368,7 +2367,7 @@ rd_kafka_DeleteTopicsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                           &skel, rd_kafka_DeleteTopic_cmp);
+                                         &skel, rd_kafka_DeleteTopic_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -2656,7 +2655,7 @@ rd_kafka_CreatePartitionsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                           &skel, rd_kafka_NewPartitions_cmp);
+                                         &skel, rd_kafka_NewPartitions_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -7570,8 +7569,8 @@ err_parse:
                 error      = rd_kafka_error_new(
                     error_code,
                     "Broker [%d"
-                         "] "
-                         "ListConsumerGroups response protocol parse failure: %s",
+                    "] "
+                    "ListConsumerGroups response protocol parse failure: %s",
                     rd_kafka_broker_id(rkb), rd_kafka_err2str(error_code));
                 rd_list_add(&errors, error);
         }
@@ -8333,7 +8332,7 @@ rd_kafka_DescribeConsumerGroupsResponse_parse(rd_kafka_op_t *rko_req,
                                             "Error reading topic partitions");
                         }
 
-                        if(api_version >= 5) {
+                        if (api_version >= 5) {
                                 rd_kafka_buf_skip_tags(reply);
                         }
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -231,11 +231,12 @@ static const char *rd_kafka_admin_state_desc[] = {
  * @enum Admin request target broker. Must be negative values since the field
  *       used is broker_id.
  */
-enum { RD_KAFKA_ADMIN_TARGET_CONTROLLER  = -1, /**< Cluster controller */
-       RD_KAFKA_ADMIN_TARGET_COORDINATOR = -2, /**< (Group) Coordinator */
-       RD_KAFKA_ADMIN_TARGET_FANOUT      = -3, /**< This rko is a fanout and
-                                                *   and has no target broker */
-       RD_KAFKA_ADMIN_TARGET_ALL = -4,         /**< All available brokers */
+enum {
+        RD_KAFKA_ADMIN_TARGET_CONTROLLER  = -1, /**< Cluster controller */
+        RD_KAFKA_ADMIN_TARGET_COORDINATOR = -2, /**< (Group) Coordinator */
+        RD_KAFKA_ADMIN_TARGET_FANOUT      = -3, /**< This rko is a fanout and
+                                                 *   and has no target broker */
+        RD_KAFKA_ADMIN_TARGET_ALL = -4,         /**< All available brokers */
 };
 
 /**
@@ -2154,7 +2155,7 @@ rd_kafka_CreateTopicsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                         &skel, rd_kafka_NewTopic_cmp);
+                                           &skel, rd_kafka_NewTopic_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -2367,7 +2368,7 @@ rd_kafka_DeleteTopicsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                         &skel, rd_kafka_DeleteTopic_cmp);
+                                           &skel, rd_kafka_DeleteTopic_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -2655,7 +2656,7 @@ rd_kafka_CreatePartitionsResponse_parse(rd_kafka_op_t *rko_req,
                  * does not maintain ordering unfortunately. */
                 skel.topic = terr->topic;
                 orig_pos   = rd_list_index(&rko_result->rko_u.admin_result.args,
-                                         &skel, rd_kafka_NewPartitions_cmp);
+                                           &skel, rd_kafka_NewPartitions_cmp);
                 if (orig_pos == -1) {
                         rd_kafka_topic_result_destroy(terr);
                         rd_kafka_buf_parse_fail(
@@ -7569,8 +7570,8 @@ err_parse:
                 error      = rd_kafka_error_new(
                     error_code,
                     "Broker [%d"
-                    "] "
-                    "ListConsumerGroups response protocol parse failure: %s",
+                         "] "
+                         "ListConsumerGroups response protocol parse failure: %s",
                     rd_kafka_broker_id(rkb), rd_kafka_err2str(error_code));
                 rd_list_add(&errors, error);
         }

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2535,7 +2535,7 @@ rd_kafka_DescribeGroupsRequest(rd_kafka_broker_t *rkb,
         size_t of_GroupsArrayCnt;
 
         if (max_ApiVersion < 0)
-                max_ApiVersion = 4;
+                max_ApiVersion = 5;
 
         if (max_ApiVersion > ApiVersion) {
                 /* Remark: don't check if max_ApiVersion is zero.
@@ -2556,7 +2556,7 @@ rd_kafka_DescribeGroupsRequest(rd_kafka_broker_t *rkb,
             4 /* rd_kafka_buf_write_arraycnt_pos */ +
                 1 /* IncludeAuthorizedOperations */ + 1 /* tags */ +
                 32 * group_cnt /* Groups */,
-            rd_false);
+            ApiVersion >= 5 /* is_flexver */);
 
         /* write Groups */
         of_GroupsArrayCnt = rd_kafka_buf_write_arraycnt_pos(rkbuf);
@@ -5080,7 +5080,7 @@ rd_kafka_DeleteTopicsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DeleteTopics, 0, 1, &features);
+            rkb, RD_KAFKAP_DeleteTopics, 0, 4, &features);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "Topic Admin API (KIP-4) not supported "
@@ -5090,12 +5090,12 @@ rd_kafka_DeleteTopicsRequest(rd_kafka_broker_t *rkb,
         }
 
         rkbuf =
-            rd_kafka_buf_new_request(rkb, RD_KAFKAP_DeleteTopics, 1,
+            rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteTopics, 1,
                                      /* FIXME */
-                                     4 + (rd_list_cnt(del_topics) * 100) + 4);
+                                     4 + (rd_list_cnt(del_topics) * 100) + 4, ApiVersion >= 4);
 
         /* #topics */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(del_topics));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_topics));
 
         while ((delt = rd_list_elem(del_topics, i++)))
                 rd_kafka_buf_write_str(rkbuf, delt->topic, -1);
@@ -5149,7 +5149,7 @@ rd_kafka_DeleteRecordsRequest(rd_kafka_broker_t *rkb,
         partitions = rd_list_elem(offsets_list, 0);
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DeleteRecords, 0, 1, &features);
+            rkb, RD_KAFKAP_DeleteRecords, 0, 2, &features);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "DeleteRecords Admin API (KIP-107) not supported "
@@ -5157,8 +5157,8 @@ rd_kafka_DeleteRecordsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_DeleteRecords, 1,
-                                         4 + (partitions->cnt * 100) + 4);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteRecords, 1,
+                                         4 + (partitions->cnt * 100) + 4, ApiVersion >= 2);
 
         const rd_kafka_topic_partition_field_t fields[] = {
             RD_KAFKA_TOPIC_PARTITION_FIELD_PARTITION,
@@ -5219,7 +5219,7 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_CreatePartitions, 0, 0, NULL);
+            rkb, RD_KAFKAP_CreatePartitions, 0, 2, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "CreatePartitions (KIP-195) not supported "
@@ -5228,12 +5228,12 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_CreatePartitions, 1,
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_CreatePartitions, 1,
                                          4 + (rd_list_cnt(new_parts) * 200) +
-                                             4 + 1);
+                                             4 + 1, ApiVersion >= 2);
 
         /* #topics */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(new_parts));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(new_parts));
 
         while ((newp = rd_list_elem(new_parts, i++))) {
                 /* topic */
@@ -5244,12 +5244,12 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
 
                 /* #replica_assignment */
                 if (rd_list_empty(&newp->replicas)) {
-                        rd_kafka_buf_write_i32(rkbuf, -1);
+                        rd_kafka_buf_write_arraycnt(rkbuf, -1);
                 } else {
                         const rd_list_t *replicas;
                         int pi = -1;
 
-                        rd_kafka_buf_write_i32(rkbuf,
+                        rd_kafka_buf_write_arraycnt(rkbuf,
                                                rd_list_cnt(&newp->replicas));
 
                         while (
@@ -5257,7 +5257,7 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
                                 int ri = 0;
 
                                 /* replica count */
-                                rd_kafka_buf_write_i32(rkbuf,
+                                rd_kafka_buf_write_arraycnt(rkbuf,
                                                        rd_list_cnt(replicas));
 
                                 /* replica */
@@ -5266,7 +5266,15 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
                                             rkbuf,
                                             rd_list_get_int32(replicas, ri));
                                 }
+
+                                if (ApiVersion >= 2) {
+                                        rd_kafka_buf_write_tags_empty(rkbuf);
+                                }
                         }
+                }
+
+                if (ApiVersion >= 2) {
+                        rd_kafka_buf_write_tags_empty(rkbuf);
                 }
         }
 
@@ -5595,7 +5603,7 @@ rd_kafka_DeleteGroupsRequest(rd_kafka_broker_t *rkb,
         rd_kafka_DeleteGroup_t *delt;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DeleteGroups, 0, 1, &features);
+            rkb, RD_KAFKAP_DeleteGroups, 0, 2, &features);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "DeleteGroups Admin API (KIP-229) not supported "
@@ -5605,11 +5613,11 @@ rd_kafka_DeleteGroupsRequest(rd_kafka_broker_t *rkb,
         }
 
         rkbuf =
-            rd_kafka_buf_new_request(rkb, RD_KAFKAP_DeleteGroups, 1,
-                                     4 + (rd_list_cnt(del_groups) * 100) + 4);
+            rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteGroups, 1,
+                                     4 + (rd_list_cnt(del_groups) * 100) + 4, ApiVersion >= 2);
 
         /* #groups */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(del_groups));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_groups));
 
         while ((delt = rd_list_elem(del_groups, i++)))
                 rd_kafka_buf_write_str(rkbuf, delt->group, -1);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5089,10 +5089,10 @@ rd_kafka_DeleteTopicsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf =
-            rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteTopics, 1,
-                                     /* FIXME */
-                                     4 + (rd_list_cnt(del_topics) * 100) + 4, ApiVersion >= 4);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_DeleteTopics, 1,
+            /* FIXME */
+            4 + (rd_list_cnt(del_topics) * 100) + 4, ApiVersion >= 4);
 
         /* #topics */
         rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_topics));
@@ -5157,8 +5157,9 @@ rd_kafka_DeleteRecordsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteRecords, 1,
-                                         4 + (partitions->cnt * 100) + 4, ApiVersion >= 2);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_DeleteRecords, 1, 4 + (partitions->cnt * 100) + 4,
+            ApiVersion >= 2);
 
         const rd_kafka_topic_partition_field_t fields[] = {
             RD_KAFKA_TOPIC_PARTITION_FIELD_PARTITION,
@@ -5228,9 +5229,9 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_CreatePartitions, 1,
-                                         4 + (rd_list_cnt(new_parts) * 200) +
-                                             4 + 1, ApiVersion >= 2);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_CreatePartitions, 1,
+            4 + (rd_list_cnt(new_parts) * 200) + 4 + 1, ApiVersion >= 2);
 
         /* #topics */
         rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(new_parts));
@@ -5249,16 +5250,16 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
                         const rd_list_t *replicas;
                         int pi = -1;
 
-                        rd_kafka_buf_write_arraycnt(rkbuf,
-                                               rd_list_cnt(&newp->replicas));
+                        rd_kafka_buf_write_arraycnt(
+                            rkbuf, rd_list_cnt(&newp->replicas));
 
                         while (
                             (replicas = rd_list_elem(&newp->replicas, ++pi))) {
                                 int ri = 0;
 
                                 /* replica count */
-                                rd_kafka_buf_write_arraycnt(rkbuf,
-                                                       rd_list_cnt(replicas));
+                                rd_kafka_buf_write_arraycnt(
+                                    rkbuf, rd_list_cnt(replicas));
 
                                 /* replica */
                                 for (ri = 0; ri < rd_list_cnt(replicas); ri++) {
@@ -5612,9 +5613,9 @@ rd_kafka_DeleteGroupsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf =
-            rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DeleteGroups, 1,
-                                     4 + (rd_list_cnt(del_groups) * 100) + 4, ApiVersion >= 2);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_DeleteGroups, 1,
+            4 + (rd_list_cnt(del_groups) * 100) + 4, ApiVersion >= 2);
 
         /* #groups */
         rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_groups));


### PR DESCRIPTION
This PR intends to upgrade the following Admin Apis to the first flexible available version in accordance with KIP 482.

- DescribeGroups(4->5)
- DeleteTopics(1->4)
- DeleteRecords(1->2)
- CreatePartitions(0->2)
- DeleteGroups(1->2)