### PR TITLE
Fix https://github.com/confluentinc/librdkafka/issues/4348

### DIFF
--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -667,6 +667,10 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                                               md->brokers[i].host);
                 rd_kafka_buf_read_i32a(rkbuf, md->brokers[i].port);
 
+                char* dot = strrchr(md->brokers[i].host, '.');
+                if (dot != NULL && (dot[1] == ':' || dot[1] == '\0'))
+                        memmove(dot, &dot[1], strlen(&dot[1]) + 1);
+
                 mdi->brokers[i].id = md->brokers[i].id;
                 if (ApiVersion >= 1) {
                         rd_kafka_buf_read_str_tmpabuf(rkbuf, &tbuf,

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -593,6 +593,11 @@ void rd_kafka_transport_post_connect_setup(rd_kafka_transport_t *rktrans) {
  * Locality: broker thread
  */
 static void rd_kafka_transport_connected(rd_kafka_transport_t *rktrans) {
+        // If the domain name is an FQDN, remove the trailing dot
+        char* dot = strrchr(rktrans->rktrans_rkb->rkb_nodename, '.');
+        if (dot != NULL && (dot[1] == ':' || dot[1] == '\0'))
+                memmove(dot, &dot[1], strlen(&dot[1]) + 1);
+
         rd_kafka_broker_t *rkb = rktrans->rktrans_rkb;
 
         rd_rkb_dbg(


### PR DESCRIPTION
With this changes we are able to use Redpanda on Kubernetes installed from the operator without any problem.
I seems that solve issue 4348.

Please provides feedback about it