### PR TITLE
[KIP-714] Fix for duplicate metrics when multiple prefixes are matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ librdkafka v2.11.0 is a feature release:
    with particular metric configurations (#4912).
  * Avoid copy outside boundaries when reading metric names in telemetry
    subscription (#5105)
+ * Metrics aren't duplicated when multiple prefixes match them (#5104)
 
 
 ## Fixes
@@ -25,6 +26,10 @@ librdkafka v2.11.0 is a feature release:
   Avoid copy outside boundaries when reading metric names in telemetry
   subscription. It can cause that some metrics aren't matched.
   Happens since 2.5.0 (#5105).
+* Issues: #5103
+  Metrics aren't duplicated when multiple prefixes match them.
+  Fixed by keeping track of the metrics that already matched.
+  Happens since 2.5.0 (#5104).
 
 
 

--- a/src/rdkafka_telemetry.c
+++ b/src/rdkafka_telemetry.c
@@ -174,6 +174,9 @@ static void update_matched_metrics(rd_kafka_t *rk, size_t j) {
 
 static void rd_kafka_match_requested_metrics(rd_kafka_t *rk) {
         size_t metrics_cnt = RD_KAFKA_TELEMETRY_METRIC_CNT(rk), i;
+        rd_bool_t is_metric_included[RD_MAX(
+            (int)RD_KAFKA_TELEMETRY_PRODUCER_METRIC__CNT,
+            (int)RD_KAFKA_TELEMETRY_CONSUMER_METRIC__CNT)] = {0};
         const rd_kafka_telemetry_metric_info_t *info =
             RD_KAFKA_TELEMETRY_METRIC_INFO(rk);
 
@@ -194,6 +197,9 @@ static void rd_kafka_match_requested_metrics(rd_kafka_t *rk) {
                        j;
 
                 for (j = 0; j < metrics_cnt; j++) {
+                        if (is_metric_included[j])
+                                continue;
+
                         /* Prefix matching the requested metrics with the
                          * available metrics. */
                         char full_metric_name
@@ -206,8 +212,10 @@ static void rd_kafka_match_requested_metrics(rd_kafka_t *rk) {
                                     rk->rk_telemetry.requested_metrics[i],
                                     name_len) == 0;
 
-                        if (name_matches)
+                        if (name_matches) {
                                 update_matched_metrics(rk, j);
+                                is_metric_included[j] = rd_true;
+                        }
                 }
         }
 

--- a/src/rdkafka_telemetry.c
+++ b/src/rdkafka_telemetry.c
@@ -33,6 +33,7 @@
 #include "nanopb/pb.h"
 #include "rdkafka_lz4.h"
 #include "snappy.h"
+#include "rdunittest.h"
 
 #if WITH_ZSTD
 #include "rdkafka_zstd.h"
@@ -720,4 +721,34 @@ void rd_kafka_set_telemetry_broker_maybe(rd_kafka_t *rk,
         rd_kafka_timer_start_oneshot(
             &rk->rk_timers, &rk->rk_telemetry.request_timer, rd_false,
             0 /* immediate */, rd_kafka_telemetry_fsm_tmr_cb, (void *)rk);
+}
+
+/**
+ * @brief Overlapping prefixes should not match the metrics
+ *        multiple times.
+ */
+int unit_test_telemetry_match_requested_metrics_no_duplicates(void) {
+        rd_kafka_t *rk = rd_kafka_new(RD_KAFKA_PRODUCER, NULL, NULL, 0);
+        rk->rk_telemetry.requested_metrics_cnt = 3;
+        rk->rk_telemetry.requested_metrics =
+            rd_calloc(rk->rk_telemetry.requested_metrics_cnt, sizeof(char *));
+        rk->rk_telemetry.requested_metrics[0] = rd_strdup("org");
+        rk->rk_telemetry.requested_metrics[1] = rd_strdup("org.apache");
+        rk->rk_telemetry.requested_metrics[2] = rd_strdup("org.apache.kafka");
+        rd_kafka_match_requested_metrics(rk);
+
+        RD_UT_ASSERT(rk->rk_telemetry.matched_metrics_cnt ==
+                         RD_KAFKA_TELEMETRY_PRODUCER_METRIC__CNT,
+                     "Expected %d matched metrics, got %" PRIusz,
+                     RD_KAFKA_TELEMETRY_PRODUCER_METRIC__CNT,
+                     rk->rk_telemetry.matched_metrics_cnt);
+        rd_kafka_destroy(rk);
+        return 0;
+}
+
+
+int unittest_telemetry(void) {
+        int fails = 0;
+        fails += unit_test_telemetry_match_requested_metrics_no_duplicates();
+        return fails;
 }

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -429,6 +429,7 @@ extern int unittest_http(void);
 #if WITH_OAUTHBEARER_OIDC
 extern int unittest_sasl_oauthbearer_oidc(void);
 #endif
+extern int unittest_telemetry(void);
 extern int unittest_telemetry_decode(void);
 
 int rd_unittest(void) {
@@ -471,7 +472,8 @@ int rd_unittest(void) {
 #if WITH_OAUTHBEARER_OIDC
             {"sasl_oauthbearer_oidc", unittest_sasl_oauthbearer_oidc},
 #endif
-            {"telemetry", unittest_telemetry_decode},
+            {"telemetry", unittest_telemetry},
+            {"telemetry_decode", unittest_telemetry_decode},
             {NULL}};
         int i;
         const char *match = rd_getenv("RD_UT_TEST", NULL);


### PR DESCRIPTION
Closes #5103

Metrics aren't duplicated when multiple prefixes match them.
Fixed by keeping track of the metrics that already matched.