### PR TITLE
Update feature gating versions to max integer value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# librdkafka v2.11.0
+
+librdkafka v2.11.0 is a feature release:
+
+* Fix feature-gating to work with Apache Kafka 4.0 (#).
+
+## Fixes
+
+### General fixes
+
+* Issues: #4948
+  Protocol RPC versions are used to detect broker versions and gate features.
+  In case an old version of a protocol RPC was removed from the broker, a
+  feature gated on the presence of specific versions of the RPC would stop
+  working. Fixes GSSAPI not working with Apache Kafka 4.0.
+
+
 # librdkafka v2.10.1
 
 librdkafka v2.10.1 is a maintenance release:

--- a/src/rdkafka_feature.c
+++ b/src/rdkafka_feature.c
@@ -74,8 +74,8 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_MSGVER1,
         .depends =
             {
-                {RD_KAFKAP_Produce, 2, 2},
-                {RD_KAFKAP_Fetch, 2, 2},
+                {RD_KAFKAP_Produce, 2, INT16_MAX},
+                {RD_KAFKAP_Fetch, 2, INT16_MAX},
                 {-1},
             },
     },
@@ -84,8 +84,8 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_MSGVER2,
         .depends =
             {
-                {RD_KAFKAP_Produce, 3, 3},
-                {RD_KAFKAP_Fetch, 4, 4},
+                {RD_KAFKAP_Produce, 3, INT16_MAX},
+                {RD_KAFKAP_Fetch, 4, INT16_MAX},
                 {-1},
             },
     },
@@ -97,7 +97,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_APIVERSION,
         .depends =
             {
-                {RD_KAFKAP_ApiVersion, 0, 0},
+                {RD_KAFKAP_ApiVersion, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -106,7 +106,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_BROKER_GROUP_COORD,
         .depends =
             {
-                {RD_KAFKAP_FindCoordinator, 0, 0},
+                {RD_KAFKAP_FindCoordinator, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -115,13 +115,13 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_BROKER_BALANCED_CONSUMER,
         .depends =
             {
-                {RD_KAFKAP_FindCoordinator, 0, 0},
-                {RD_KAFKAP_OffsetCommit, 1, 2},
-                {RD_KAFKAP_OffsetFetch, 1, 1},
-                {RD_KAFKAP_JoinGroup, 0, 0},
-                {RD_KAFKAP_SyncGroup, 0, 0},
-                {RD_KAFKAP_Heartbeat, 0, 0},
-                {RD_KAFKAP_LeaveGroup, 0, 0},
+                {RD_KAFKAP_FindCoordinator, 0, INT16_MAX},
+                {RD_KAFKAP_OffsetCommit, 1, INT16_MAX},
+                {RD_KAFKAP_OffsetFetch, 1, INT16_MAX},
+                {RD_KAFKAP_JoinGroup, 0, INT16_MAX},
+                {RD_KAFKAP_SyncGroup, 0, INT16_MAX},
+                {RD_KAFKAP_Heartbeat, 0, INT16_MAX},
+                {RD_KAFKAP_LeaveGroup, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -130,8 +130,8 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_THROTTLETIME,
         .depends =
             {
-                {RD_KAFKAP_Produce, 1, 2},
-                {RD_KAFKAP_Fetch, 1, 2},
+                {RD_KAFKAP_Produce, 1, INT16_MAX},
+                {RD_KAFKAP_Fetch, 1, INT16_MAX},
                 {-1},
             },
 
@@ -145,7 +145,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_SASL_GSSAPI,
         .depends =
             {
-                {RD_KAFKAP_JoinGroup, 0, 0},
+                {RD_KAFKAP_JoinGroup, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -156,7 +156,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_SASL_HANDSHAKE,
         .depends =
             {
-                {RD_KAFKAP_SaslHandshake, 0, 0},
+                {RD_KAFKAP_SaslHandshake, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -170,7 +170,7 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_LZ4,
         .depends =
             {
-                {RD_KAFKAP_FindCoordinator, 0, 0},
+                {RD_KAFKAP_FindCoordinator, 0, INT16_MAX},
                 {-1},
             },
     },
@@ -179,14 +179,14 @@ static const struct rd_kafka_feature_map {
      .feature = RD_KAFKA_FEATURE_OFFSET_TIME,
      .depends =
          {
-             {RD_KAFKAP_ListOffsets, 1, 1},
+             {RD_KAFKAP_ListOffsets, 1, INT16_MAX},
              {-1},
          }},
     {/* @brief >=0.11.0.0: Idempotent Producer*/
      .feature = RD_KAFKA_FEATURE_IDEMPOTENT_PRODUCER,
      .depends =
          {
-             {RD_KAFKAP_InitProducerId, 0, 0},
+             {RD_KAFKAP_InitProducerId, 0, INT16_MAX},
              {-1},
          }},
     {
@@ -194,8 +194,8 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_ZSTD,
         .depends =
             {
-                {RD_KAFKAP_Produce, 7, 7},
-                {RD_KAFKAP_Fetch, 10, 10},
+                {RD_KAFKAP_Produce, 7, INT16_MAX},
+                {RD_KAFKAP_Fetch, 10, INT16_MAX},
                 {-1},
             },
     },
@@ -204,8 +204,8 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_SASL_AUTH_REQ,
         .depends =
             {
-                {RD_KAFKAP_SaslHandshake, 1, 1},
-                {RD_KAFKAP_SaslAuthenticate, 0, 1},
+                {RD_KAFKAP_SaslHandshake, 1, INT16_MAX},
+                {RD_KAFKAP_SaslAuthenticate, 0, INT16_MAX},
                 {-1},
             },
     },


### PR DESCRIPTION
Protocol RPC versions are used to detect broker versions and gate features.
  In case an old version of a protocol RPC was removed from the broker, a
  feature gated on the presence of specific versions of the RPC would stop
  working. Fixes GSSAPI not working with Apache Kafka 4.0.