### PR TITLE
Features `BROKER_BALANCED_CONSUMER` and `SASL_GSSAPI` don't depend on `JoinGroup v0` anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ librdkafka v2.11.0 is a feature release:
 * Fix for poll ratio calculation in case the queues are forwarded (#5017).
 * Fix data race when buffer queues are being reset instead of being
   initialized (#4718).
+* Features BROKER_BALANCED_CONSUMER and SASL_GSSAPI don't depend on
+  JoinGroup v0 anymore, missing in AK 4.0 and CP 8.0 (#).
 
 
 ## Fixes
@@ -17,6 +19,12 @@ librdkafka v2.11.0 is a feature release:
   with the statistics callback in main thread gathering the buffer counts.
   Solved by resetting the atomic counters instead of initializing them.
   Happening since 1.x (#4718).
+* Issues: #4948
+  Features BROKER_BALANCED_CONSUMER and SASL_GSSAPI don't depend on
+  JoinGroup v0 anymore, missing in AK 4.0 and CP 8.0. This PR partially
+  fixes the linked issue, a complete fix for all features will follow.
+  Rest of fixes are necessary only in a subsequent major version (e.g. AK 5.x) .
+  Happening since 1.x (#).
 
 ### Telemetry fixes
 

--- a/src/rdkafka_feature.c
+++ b/src/rdkafka_feature.c
@@ -111,17 +111,28 @@ static const struct rd_kafka_feature_map {
             },
     },
     {
-        /* @brief >=0.9.0: Broker-based balanced consumer groups. */
+        /* @brief >=0.9.0: Broker-based balanced consumer groups (classic). */
         .feature = RD_KAFKA_FEATURE_BROKER_BALANCED_CONSUMER,
         .depends =
             {
-                {RD_KAFKAP_FindCoordinator, 0, 0},
-                {RD_KAFKAP_OffsetCommit, 1, 2},
-                {RD_KAFKAP_OffsetFetch, 1, 1},
-                {RD_KAFKAP_JoinGroup, 0, 0},
-                {RD_KAFKAP_SyncGroup, 0, 0},
-                {RD_KAFKAP_Heartbeat, 0, 0},
-                {RD_KAFKAP_LeaveGroup, 0, 0},
+                {RD_KAFKAP_FindCoordinator, 0, INT16_MAX},
+                {RD_KAFKAP_OffsetCommit, 1, INT16_MAX},
+                {RD_KAFKAP_OffsetFetch, 1, INT16_MAX},
+                {RD_KAFKAP_JoinGroup, 0, INT16_MAX},
+                {RD_KAFKAP_SyncGroup, 0, INT16_MAX},
+                {RD_KAFKAP_Heartbeat, 0, INT16_MAX},
+                {RD_KAFKAP_LeaveGroup, 0, INT16_MAX},
+                {-1},
+            },
+    },
+    {
+        /* @brief Broker-based balanced consumer groups (KIP 848). */
+        .feature = RD_KAFKA_FEATURE_BROKER_BALANCED_CONSUMER,
+        .depends =
+            {
+                {RD_KAFKAP_ConsumerGroupHeartbeat, 0, INT16_MAX},
+                {RD_KAFKAP_OffsetCommit, 9, INT16_MAX},
+                {RD_KAFKAP_OffsetFetch, 9, INT16_MAX},
                 {-1},
             },
     },
@@ -145,7 +156,18 @@ static const struct rd_kafka_feature_map {
         .feature = RD_KAFKA_FEATURE_SASL_GSSAPI,
         .depends =
             {
-                {RD_KAFKAP_JoinGroup, 0, 0},
+                {RD_KAFKAP_JoinGroup, 0, INT16_MAX},
+                {-1},
+            },
+    },
+    {
+        /* @brief >=0.10.0: SASL (GSSAPI) authentication.
+         * Fallback in case JoinGroup is removed along with the
+         * "classic" consumer group protocol. */
+        .feature = RD_KAFKA_FEATURE_SASL_GSSAPI,
+        .depends =
+            {
+                {RD_KAFKAP_SaslHandshake, 0, INT16_MAX},
                 {-1},
             },
     },


### PR DESCRIPTION
missing in AK 4.0 and CP 8.0.

This is part of #5130 , rest of fixes will be done together in a second PR.

This PR partially fixes #5130, a complete fix for all features will follow.
Rest of fixes are necessary only for a subsequent Apache Kafka major version (e.g. AK 5.x)