### PR TITLE
Fix deadlock in `rd_kafka_reset_any_broker_down_reported` 

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -407,8 +407,12 @@ void rd_kafka_broker_set_state(rd_kafka_broker_t *rkb, int state) {
                                  * broker connections. */
                                 rd_atomic32_add(&rkb->rkb_rk->rk_broker_up_cnt,
                                                 1);
+                                rd_kafka_broker_unlock(rkb);
+                                /* Releases rkb->rkb_lock to respect
+                                 * lock ordering and avoid deadlocks */
                                 rd_kafka_reset_any_broker_down_reported(
                                     rkb->rkb_rk);
+                                rd_kafka_broker_lock(rkb);
                         }
 
                         trigger_monitors = rd_true;


### PR DESCRIPTION
by releasing and reacquiring the broker lock, to respect lock ordering and avoid deadlocks.

Fix is for #5126 , not released still. To be merged before releasing.