### PR TITLE
Handle Integer Overflow

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2970,7 +2970,8 @@ void rd_kafka_broker_buf_retry(rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
                 int shift = rkbuf->rkbuf_retries - 1;
 
                 /* Cap shift at 34 to prevent overflow in final calculation.
-                 * Accounts for multiplication by retry_backoff_ms (max 300000) and jitter (max 1200). */
+                 * Accounts for multiplication by retry_backoff_ms (max 300000)
+                 * and jitter (max 1200). */
                 if (shift > 34)
                         shift = 34;
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2967,7 +2967,7 @@ void rd_kafka_broker_buf_retry(rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
         /* In some cases, failed Produce requests do not increment the retry
          * count, see rd_kafka_handle_Produce_error. */
         if (rkbuf->rkbuf_retries > 0)
-                backoff = (1 << (rkbuf->rkbuf_retries - 1)) *
+                backoff = ((int64_t)1 << (rkbuf->rkbuf_retries - 1)) *
                           (rkb->rkb_rk->rk_conf.retry_backoff_ms);
         else
                 backoff = rkb->rkb_rk->rk_conf.retry_backoff_ms;

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2969,10 +2969,10 @@ void rd_kafka_broker_buf_retry(rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
         if (rkbuf->rkbuf_retries > 0) {
                 int shift = rkbuf->rkbuf_retries - 1;
 
-                /* Cap shift at 62 to avoid undefined behavior.
-                 * shift=63 sets sign bit, shift>=64 exceeds type width. */
-                if (shift > 62)
-                        shift = 62;
+                /* Cap shift at 34 to prevent overflow in final calculation.
+                 * Accounts for multiplication by retry_backoff_ms (max 300000) and jitter (max 1200). */
+                if (shift > 34)
+                        shift = 34;
 
                 backoff = ((int64_t)1 << shift) *
                           (rkb->rkb_rk->rk_conf.retry_backoff_ms);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2969,9 +2969,8 @@ void rd_kafka_broker_buf_retry(rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
         if (rkbuf->rkbuf_retries > 0) {
                 int shift = rkbuf->rkbuf_retries - 1;
 
-                /* Cap the shift at 62 to avoid undefined behavior for
-                 * shifts >= 64 and to prevent signed overflow for a shift of 63,
-                 * which would result in a negative backoff. */
+                /* Cap shift at 62 to avoid undefined behavior.
+                 * shift=63 sets sign bit, shift>=64 exceeds type width. */
                 if (shift > 62)
                         shift = 62;
 


### PR DESCRIPTION
In this PR, the cast to int64_t ensures that the left shift operation is performed using 64-bit arithmetic, and the result will not overflow even if rkbuf_retries is equal to INT_MAX. The resulting value of the left shift operation is then multiplied by retry_backoff_ms, which is an int value. The result of the multiplication will be an int64_t value, which can hold the product of the two operands without overflow.