### PR TITLE
Fix for KIP-1102 time based re-bootstrap condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ librdkafka v2.12.0 is a feature release:
 
 * Fix compression types read issue in GetTelemetrySubscriptions response
   for big-endian architectures (#5183, @paravoid).
+* Fix for KIP-1102 time based re-bootstrap condition (#5177).
+* Fix for discarding the member epoch in a consumer group heartbeat response when leaving with an inflight HB (#4672).
+* Fix for an error being raised after a commit due to an existing error in the topic partition (#4672).
 
 
 ## Fixes
 
 ### General fixes
-* Fix for discarding the member epoch in a consumer group heartbeat response when leaving with an inflight HB (#4672).
-* Fix for an error being raised after a commit due to an existing error in the topic partition (#4672).
+
+* Issues: #5178.
+  Fix for KIP-1102 time based re-bootstrap condition.
+  Re-bootstrap is now triggered only after `metadata.recovery.rebootstrap.trigger.ms`
+  have passed since first metadata refresh request after last successful
+  metadata response. The calculation was since last successful metadata response
+  so it's possible it did overlap with the periodic `topic.metadata.refresh.interval.ms`
+  and cause a re-bootstrap even if not needed.
+  Happening since 2.11.0 (#5177).
 
 ### Telemetry fixes
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2855,14 +2855,14 @@ void rd_kafka_rebootstrap(rd_kafka_t *rk) {
 }
 
 /**
- * Restarts rebootstrap timer with the configured interval. Only if not
+ * Starts rebootstrap timer with the configured interval. Only if not
  * started or stopped.
  *
  * @locks none
  * @locks_acquired rd_kafka_timers_lock()
  * @locality any
  */
-void rd_kafka_rebootstrap_tmr_restart(rd_kafka_t *rk) {
+void rd_kafka_rebootstrap_tmr_start_maybe(rd_kafka_t *rk) {
         if (rk->rk_conf.metadata_recovery_strategy ==
             RD_KAFKA_METADATA_RECOVERY_STRATEGY_NONE)
                 return;

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2154,11 +2154,6 @@ static void rd_kafka_metadata_refresh_cb(rd_kafka_timers_t *rkts, void *arg) {
         rd_kafka_t *rk = rkts->rkts_rk;
         rd_kafka_resp_err_t err;
 
-        /* Restart the rebootstrap timer only if it's the first
-         * metadata refresh request after last successful response,
-         * so the timer is not reset if already scheduled. */
-        rd_kafka_rebootstrap_tmr_restart(rk);
-
         /* High-level consumer:
          * We need to query both locally known topics and subscribed topics
          * so that we can detect locally known topics changing partition

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -1253,6 +1253,8 @@ void rd_kafka_rebootstrap(rd_kafka_t *rk);
 
 void rd_kafka_rebootstrap_tmr_restart(rd_kafka_t *rk);
 
+int rd_kafka_rebootstrap_tmr_stop(rd_kafka_t *rk);
+
 void rd_kafka_reset_any_broker_down_reported(rd_kafka_t *rk);
 
 #endif /* _RDKAFKA_INT_H_ */

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -1251,7 +1251,7 @@ rd_kafka_resp_err_t rd_kafka_background_thread_create(rd_kafka_t *rk,
 
 void rd_kafka_rebootstrap(rd_kafka_t *rk);
 
-void rd_kafka_rebootstrap_tmr_restart(rd_kafka_t *rk);
+void rd_kafka_rebootstrap_tmr_start_maybe(rd_kafka_t *rk);
 
 int rd_kafka_rebootstrap_tmr_stop(rd_kafka_t *rk);
 

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1033,7 +1033,6 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
         rd_kafka_wrlock(rkb->rkb_rk);
 
         rkb->rkb_rk->rk_ts_metadata = rd_clock();
-        rd_kafka_rebootstrap_tmr_restart(rkb->rkb_rk);
 
         /* Update cached cluster id. */
         if (RD_KAFKAP_STR_LEN(&cluster_id) > 0 &&

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2620,6 +2620,7 @@ static void rd_kafka_handle_Metadata(rd_kafka_t *rk,
         if (err)
                 goto err;
 
+        rd_kafka_rebootstrap_tmr_stop(rk);
         if (rko && rko->rko_replyq.q) {
                 /* Reply to metadata requester, passing on the metadata.
                  * Reuse requesting rko for the reply. */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2745,6 +2745,18 @@ done:
  *
  * @sa rd_kafka_MetadataRequest().
  * @sa rd_kafka_MetadataRequest_resp_cb().
+ *
+ * @locality any
+ * @locks none
+ * @locks_acquired
+ *  - mtx_lock(&rkb->rkb_rk->rk_metadata_cache.rkmc_full_lock) in
+ *    this function
+ *  - rd_kafka_broker_lock() in
+ *    rd_kafka_broker_ApiVersion_supported()
+ *  - rd_kafka_timers_lock() in
+ *    rd_kafka_rebootstrap_tmr_start_maybe()
+ *  - mtx_lock(&rkq->rkq_lock) in
+ *    rd_kafka_broker_buf_enq_replyq()
  */
 static rd_kafka_resp_err_t
 rd_kafka_MetadataRequest0(rd_kafka_broker_t *rkb,
@@ -2879,20 +2891,25 @@ rd_kafka_MetadataRequest0(rd_kafka_broker_t *rkb,
                 rkbuf->rkbuf_u.Metadata.decr_lock =
                     &rkb->rkb_rk->rk_metadata_cache.rkmc_full_lock;
         } else if (!resp_cb) {
-                /* In case it's a full request, forced or not, it won't be
+                /*
+                 * Conditions for starting the rebootstrap timer:
+                 *
+                 * !full_incr:
+                 * In case it's a full request, forced or not, it won't be
                  * retried on the same broker to avoid blocking metadata
                  * requests, because of the lock, when that broker isn't
                  * available. We don't start the timer as we cannot ensure the
                  * request is retried for the duration of
                  * `metadata.recovery.rebootstrap.trigger.ms`.
                  *
+                 * !resp_cb:
                  * Same reasoning applies when we use a custom callback, for the
                  * AdminClient requests for example.
                  *
-                 * Restart the rebootstrap timer only if it's the first
+                 * Start the rebootstrap timer only if it's the first
                  * metadata refresh request after last successful response,
                  * so the timer is not reset if already scheduled. */
-                rd_kafka_rebootstrap_tmr_restart(rkb->rkb_rk);
+                rd_kafka_rebootstrap_tmr_start_maybe(rkb->rkb_rk);
         }
 
         if (topic_cnt > 0) {


### PR DESCRIPTION
Closes #5178 .

Re-bootstrap is now triggered only after `metadata.recovery.rebootstrap.trigger.ms`
have passed since first metadata refresh request after last successful
metadata response. The calculation was since last successful metadata response
so it's possible it did overlap with the periodic `topic.metadata.refresh.interval.ms`
and cause a re-bootstrap even if not needed.

It's now more similar to the Java implementation here:
https://github.com/apache/kafka/blob/49ee1fb4f9deb326d82b86d3a047182f7d96ddfa/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L1222