### PR TITLE
[hdrhistogram]: Prevent an FPE in rd_hdr_histogram_new (#4949)

### DIFF
--- a/src/rdhdrhistogram.c
+++ b/src/rdhdrhistogram.c
@@ -73,6 +73,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <fenv.h>
 
 #include "rdhdrhistogram.h"
 #include "rdunittest.h"
@@ -89,6 +90,7 @@ rd_hdr_histogram_t *rd_hdr_histogram_new(int64_t minValue,
         int64_t largestValueWithSingleUnitResolution;
         int32_t subBucketCountMagnitude;
         int32_t subBucketHalfCountMagnitude;
+        double potentialUnitMagnitude;
         int32_t unitMagnitude;
         int32_t subBucketCount;
         int32_t subBucketHalfCount;
@@ -109,7 +111,8 @@ rd_hdr_histogram_t *rd_hdr_histogram_new(int64_t minValue,
 
         subBucketHalfCountMagnitude = RD_MAX(subBucketCountMagnitude, 1) - 1;
 
-        unitMagnitude = (int32_t)RD_MAX(floor(log2((double)minValue)), 0);
+        potentialUnitMagnitude = minValue == 0 ? 0 : log2((double)minValue);
+        unitMagnitude = (int32_t)RD_MAX(floor(potentialUnitMagnitude), 0);
 
         subBucketCount =
             (int32_t)pow(2, (double)subBucketHalfCountMagnitude + 1.0);
@@ -656,10 +659,17 @@ static int ut_minmax_trackable(void) {
 
 
 static int ut_unitmagnitude_overflow(void) {
-        rd_hdr_histogram_t *hdr = rd_hdr_histogram_new(0, 200, 4);
-        int r                   = rd_hdr_histogram_record(hdr, 11);
-        RD_UT_ASSERT(r, "record(11) failed\n");
+        rd_hdr_histogram_t *hdr;
+        int r;
 
+        feclearexcept(FE_DIVBYZERO | FE_INVALID);
+        hdr = rd_hdr_histogram_new(0, 200, 4);
+        RD_UT_ASSERT(
+            !fetestexcept(FE_DIVBYZERO | FE_INVALID),
+            "rd_hdr_histogram_new(0,...) raised an FP exception (#4949)");
+
+        r = rd_hdr_histogram_record(hdr, 11);
+        RD_UT_ASSERT(r, "record(11) failed\n");
         rd_hdr_histogram_destroy(hdr);
         RD_UT_PASS();
 }


### PR DESCRIPTION
## Commit message:
> The Floating Point Exception (FPE) `FE_DIVBYZERO` is flagged in `rd_hdr_histogram_new` when `log2()` is called with `0`. This is done in `rd_avg_init` numerous times, some of which cannot be disabled in recent versions.
>
> Consumers of librdkakfa may enable the raising of exceptions when FPEs occur, including `FE_DIVBYZERO`, which causes the function to fail.
>
> It is reasonable for the callers of `rd_hdr_histogram_new` to pass `0` for the `minValue` parameter, and the intention of the calculation of `unitMagnitude` is also reasonable. As such, fixing the maths there is the correct approach. `unitMagnitude` being `0` in this case is an apt choice based on how log2(n) works for n near `0`, and that the caluclation already minimises to `0`.
>
> A simple test was included that resets the flags, runs the offending function, and observes the new set flags. Appropriately, it fails before the fix, and passes after.

## Description
First time doing a Pull Request on an open source project so please bear with me. :) Fixes https://github.com/confluentinc/librdkafka/issues/4949

I believe I have followed the contributing guidelines correctly; I have:
- [x] Read the contributing guidelines and code of conduct.
- [x] Followed the style guide and run `make style-check-changed` on the source file I changed and the source file I added.
- [x] Added a test.
- [x] Updated `CHANGELOG.md`.
- [ ] Run `make release-test`. (TODO - I need to install trivup for that).

### Potential issue in build config
One potential issue is that I had to modify the build process to link `test-runner` with `-lrdkafka-static` because it did not find the definition for `rd_hdr_histogram_new`. I assume this is something wrong with my build configuration, but if not we will need to do something to rectify it.