### PR TITLE
[KIP-320] Validate assigned partitions before starting to consume from them v2

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2976,6 +2976,10 @@ static RD_UNUSED int rd_kafka_consume_start0(rd_kafka_topic_t *rkt,
                 return -1;
         }
 
+        /*
+         * We cannot validate this offset as the legacy API doesn't
+         * provide the leader epoch.
+         */
         rd_kafka_toppar_op_fetch_start(rktp, RD_KAFKA_FETCH_POS(offset, -1),
                                        rkq, RD_KAFKA_NO_REPLYQ);
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2865,6 +2865,44 @@ void rd_kafka_topic_partition_set_current_leader_epoch(
 }
 
 /**
+ * @brief Marks the fetch position (offset + leader epoch) as validated or not.
+ * @param rktpar Partition object.
+ * @param fetch_pos_validated Whether the fetch position has been validated.
+ *
+ * @remark See KIP-320 for more information.
+ */
+void rd_kafka_topic_partition_set_fetch_pos_validated(
+    rd_kafka_topic_partition_t *rktpar,
+    rd_bool_t fetch_pos_validated) {
+        rd_kafka_topic_partition_private_t *parpriv;
+
+        /* Avoid allocating private_t if clearing the epoch */
+        if (!fetch_pos_validated || !rktpar->_private)
+                return;
+
+        parpriv = rd_kafka_topic_partition_get_private(rktpar);
+        parpriv->fetch_pos_validated = fetch_pos_validated;
+}
+
+/**
+ * @brief Gets the validation status of the fetch position (offset + leader
+ * epoch).
+ * @param rktpar Partition object.
+ * @return Whether the fetch position has been validated.
+ *
+ * @remark See KIP-320 for more information.
+ */
+rd_bool_t rd_kafka_topic_partition_get_fetch_pos_validated(
+    rd_kafka_topic_partition_t *rktpar) {
+        const rd_kafka_topic_partition_private_t *parpriv;
+
+        if (!(parpriv = rktpar->_private))
+                return rd_false;
+
+        return parpriv->fetch_pos_validated;
+}
+
+/**
  * @brief Set offset and leader epoch from a fetchpos.
  */
 void rd_kafka_topic_partition_set_from_fetch_pos(

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -499,6 +499,13 @@ typedef struct rd_kafka_topic_partition_private_s {
         int32_t current_leader_epoch;
         /** Leader epoch if known, else -1. */
         int32_t leader_epoch;
+        /**
+         * Is fetch position (offset + leader_epoch) validated?
+         * This field isn't copied automatically
+         * when copying or updating the struct to avoid unintended
+         * skipped validations.
+         */
+        rd_bool_t fetch_pos_validated;
         /** Topic id. */
         rd_kafka_Uuid_t topic_id;
 } rd_kafka_topic_partition_private_t;
@@ -848,29 +855,20 @@ rd_kafka_topic_partition_get_private(rd_kafka_topic_partition_t *rktpar) {
 }
 
 
-/**
- * @returns the partition leader current epoch, if relevant and known,
- *          else -1.
- *
- * @param rktpar Partition object.
- *
- * @remark See KIP-320 for more information.
- */
 int32_t rd_kafka_topic_partition_get_current_leader_epoch(
     const rd_kafka_topic_partition_t *rktpar);
 
 
-/**
- * @brief Sets the partition leader current epoch (use -1 to clear).
- *
- * @param rktpar Partition object.
- * @param leader_epoch Partition leader current epoch, use -1 to reset.
- *
- * @remark See KIP-320 for more information.
- */
 void rd_kafka_topic_partition_set_current_leader_epoch(
     rd_kafka_topic_partition_t *rktpar,
     int32_t leader_epoch);
+
+void rd_kafka_topic_partition_set_fetch_pos_validated(
+    rd_kafka_topic_partition_t *rktpar,
+    rd_bool_t fetch_pos_validated);
+
+rd_bool_t rd_kafka_topic_partition_get_fetch_pos_validated(
+    rd_kafka_topic_partition_t *rktpar);
 
 /**
  * @returns the partition's rktp if set (no refcnt increase), else NULL.


### PR DESCRIPTION
Second version adding back the partition to the pending list while setting `fetch_pos_validated` to `rd_true'