### PR TITLE
build: MSVC: fixed linking with OpenSSL

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -41,8 +41,6 @@
 #ifdef _WIN32
 #include <wincrypt.h>
 #pragma comment(lib, "crypt32.lib")
-#pragma comment(lib, "libcrypto.lib")
-#pragma comment(lib, "libssl.lib")
 #endif
 
 #include <openssl/x509.h>


### PR DESCRIPTION
Port of changes from https://github.com/fluent/fluent-bit/pull/11397.

Changes:

* build: MSVC: fixed linking with OpenSSL in debug build configuration. Debug version of OpenSSL has `d` suffix in its name when built for / with MSVC. Correct OpenSSL libraries are already added into linker options by CMake project which uses [FindOpenSSL](https://cmake.org/cmake/help/v3.20/module/FindOpenSSL.html) CMake module: https://github.com/confluentinc/librdkafka/blob/901af7c79c0ca5877ed187c4452820aecf51430c/CMakeLists.txt#L110 so there is no need to use `pragma` added in #3490 (https://github.com/confluentinc/librdkafka/pull/3490/changes#r2864071512).