### PR TITLE
Fix int_latency calculation for infinite timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# librdkafka v2.15.1
+
+librdkafka v2.15.1 is a maintenance release:
+
+* Fix `int_latency` metric calculation, that was reporting bogus values when
+  `message.timeout.ms` is set to 0 (infinite) (#5335).
+
+
+## Fixes
+
+### Producer fixes
+
+* Issues: #5555.
+  Fix `int_latency` metric calculation. It was derived from the message
+  timeout timestamp (`now + message.timeout.ms - rkm_ts_timeout`), which
+  yields a large negative value when `message.timeout.ms` is 0 (infinite)
+  and `rkm_ts_timeout` is `INT64_MAX`. It's now computed directly as
+  `now - rkm_ts_enq`, the actual time the message spent in the queue,
+  regardless of the timeout setting.
+  Happening since 0.11.0 (#5335).
+
+
+
 # librdkafka v2.15.0
 
 librdkafka v2.15.0 is a feature release:

--- a/tests/0055-producer_latency.c
+++ b/tests/0055-producer_latency.c
@@ -621,7 +621,7 @@ static void test_int_latency(const char *message_timeout_ms) {
         int64_t abs_timeout;
         int i;
 
-        SUB_TEST("message.timeout.ms=%s", message_timeout_ms);
+        SUB_TEST_QUICK("message.timeout.ms=%s", message_timeout_ms);
 
         mcluster = test_mock_cluster_new(1, &bootstrap_servers);
         rd_kafka_mock_topic_create(mcluster, topic, 1, 1);

--- a/tests/0055-producer_latency.c
+++ b/tests/0055-producer_latency.c
@@ -527,6 +527,145 @@ static void test_producer_latency_first_message(int case_number) {
         SUB_TEST_PASS();
 }
 
+struct int_latency_stats {
+        int64_t minv; /**< Lowest int_latency.min seen */
+        int64_t avgv; /**< Last int_latency.avg seen */
+        int cnt;      /**< Total number of int_latency samples */
+};
+
+
+/**
+ * @brief Crude extraction of the integer JSON field \p field following
+ *        \p start.
+ */
+static int64_t find_json_int(const char *start, const char *field) {
+        char search[64];
+        const char *t;
+
+        rd_snprintf(search, sizeof(search), "\"%s\":", field);
+
+        t = strstr(start, search);
+        TEST_ASSERT(t, "Field %s not found in stats", field);
+
+        t += strlen(search);
+        while (isspace((int)*t))
+                t++;
+
+        return strtoll(t, NULL, 0);
+}
+
+
+/**
+ * @brief Collect the per-broker int_latency gauges from the stats.
+ */
+static int int_latency_stats_cb(rd_kafka_t *rk,
+                                char *json,
+                                size_t json_len,
+                                void *opaque) {
+        struct int_latency_stats *stats = opaque;
+        const char *t                   = json;
+
+        while ((t = strstr(t, "\"int_latency\":"))) {
+                int64_t minv, avgv;
+                int cnt;
+
+                t += strlen("\"int_latency\":");
+
+                /* Brokers that haven't produced anything during this
+                 * window have no samples. */
+                cnt = (int)find_json_int(t, "cnt");
+                if (cnt == 0)
+                        continue;
+
+                minv = find_json_int(t, "min");
+                avgv = find_json_int(t, "avg");
+
+                TEST_SAY("int_latency: min %" PRId64 "us, avg %" PRId64
+                         "us, cnt %d\n",
+                         minv, avgv, cnt);
+
+                if (stats->cnt == 0 || minv < stats->minv)
+                        stats->minv = minv;
+                stats->avgv = avgv;
+                stats->cnt += cnt;
+        }
+
+        return 0;
+}
+
+
+static void dr_msg_cb_expect_success(rd_kafka_t *rk,
+                                     const rd_kafka_message_t *rkmessage,
+                                     void *opaque) {
+        TEST_ASSERT(!rkmessage->err, "Message delivery failed: %s",
+                    rd_kafka_err2str(rkmessage->err));
+}
+
+
+/**
+ * @brief Verify that the per-broker int_latency metric holds a sane
+ *        (non-negative) value regardless of the configured
+ *        `message.timeout.ms`.
+ *
+ * int_latency used to be derived from the message timeout timestamp, which
+ * is INT64_MAX for an infinite (0) timeout, yielding a large negative value.
+ */
+static void test_int_latency(const char *message_timeout_ms) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstrap_servers;
+        const char *topic              = test_mk_topic_name("0055_int_lat", 1);
+        struct int_latency_stats stats = RD_ZERO_INIT;
+        const int msgcnt               = 10;
+        int64_t abs_timeout;
+        int i;
+
+        SUB_TEST("message.timeout.ms=%s", message_timeout_ms);
+
+        mcluster = test_mock_cluster_new(1, &bootstrap_servers);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstrap_servers);
+        test_conf_set(conf, "statistics.interval.ms", "100");
+        /* Linger so the messages spend measurable time on the queue. */
+        test_conf_set(conf, "linger.ms", "50");
+        test_conf_set(conf, "message.timeout.ms", message_timeout_ms);
+        rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb_expect_success);
+        rd_kafka_conf_set_stats_cb(conf, int_latency_stats_cb);
+        rd_kafka_conf_set_opaque(conf, &stats);
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        for (i = 0; i < msgcnt; i++)
+                TEST_CALL_ERR__(rd_kafka_producev(
+                    rk, RD_KAFKA_V_TOPIC(topic), RD_KAFKA_V_PARTITION(0),
+                    RD_KAFKA_V_VALUE("hi", 2),
+                    RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY), RD_KAFKA_V_END));
+
+        TEST_CALL_ERR__(rd_kafka_flush(rk, tmout_multip(10 * 1000)));
+
+        /* Wait for a stats emission covering the produced messages. */
+        abs_timeout = test_clock() + (tmout_multip(10 * 1000) * 1000);
+        while (stats.cnt == 0 && test_clock() < abs_timeout)
+                rd_kafka_poll(rk, 100);
+
+        TEST_ASSERT(stats.cnt > 0, "Expected int_latency samples in stats");
+        TEST_ASSERT(stats.minv >= 0,
+                    "Expected non-negative int_latency, got min %" PRId64 "us",
+                    stats.minv);
+        TEST_ASSERT(stats.avgv >= 0,
+                    "Expected non-negative int_latency, got avg %" PRId64 "us",
+                    stats.avgv);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0055_producer_latency_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -534,6 +673,11 @@ int main_0055_producer_latency_mock(int argc, char **argv) {
         for (case_number = 0; case_number < 4; case_number++) {
                 test_producer_latency_first_message(case_number);
         }
+
+        /* 0 = infinite message timeout, the case that used to report
+         * a bogus int_latency. */
+        test_int_latency("0");
+        test_int_latency("5000");
 
         return 0;
 }

--- a/tests/0055-producer_latency.c
+++ b/tests/0055-producer_latency.c
@@ -618,6 +618,7 @@ static void test_int_latency(const char *message_timeout_ms) {
         const char *topic              = test_mk_topic_name("0055_int_lat", 1);
         struct int_latency_stats stats = RD_ZERO_INIT;
         const int msgcnt               = 10;
+        rd_kafka_resp_err_t err;
         int64_t abs_timeout;
         int i;
 
@@ -638,11 +639,14 @@ static void test_int_latency(const char *message_timeout_ms) {
 
         rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
 
-        for (i = 0; i < msgcnt; i++)
-                TEST_CALL_ERR__(rd_kafka_producev(
+        for (i = 0; i < msgcnt; i++) {
+                err = rd_kafka_producev(
                     rk, RD_KAFKA_V_TOPIC(topic), RD_KAFKA_V_PARTITION(0),
                     RD_KAFKA_V_VALUE("hi", 2),
-                    RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY), RD_KAFKA_V_END));
+                    RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY), RD_KAFKA_V_END);
+                TEST_ASSERT(!err, "producev #%d failed: %s", i,
+                            rd_kafka_err2str(err));
+        }
 
         TEST_CALL_ERR__(rd_kafka_flush(rk, tmout_multip(10 * 1000)));
 


### PR DESCRIPTION
### Before the fix:
```
int_latency_base = now + (message_timeout_ms * 1000);
rd_avg_add(&rkb->rkb_avg_int_latency, int_latency_base - rkm->rkm_ts_timeout);
```
When message_timeout_ms = 0:
int_latency_base = now + 0 = now
rkm_ts_timeout = INT64_MAX (for infinite timeout)
Result: now - INT64_MAX = massive negative number

### After the fix:
```
rd_avg_add(&rkb->rkb_avg_int_latency, now - rkm->rkm_ts_enq);
```
Always works regardless of timeout setting:
now - rkm_ts_enq = current_time - enqueue_time = actual queue time