### PR TITLE
metadata: Fix rd_kafka_metadata_update_op skipping partition update when leader=-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 * Fix duplicate groups in `ListConsumerGroups` when multiple brokers return the same group.
 
+### Producer fixes
+
+* Fix permanent `NO_INFO` state when partition leader is transiently `-1`
+  (e.g. broker fenced by KRaft controller), causing producer to permanently
+  stop delivering to those partitions (#5430).
+
 
 # librdkafka v2.14.1
 

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -572,7 +572,7 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
          * to contain the partition to rack map. */
         rd_bool_t has_client_rack = rk->rk_conf.client_rack &&
                                     RD_KAFKAP_STR_LEN(rk->rk_conf.client_rack);
-        rd_bool_t compute_racks = has_client_rack;
+        rd_bool_t compute_racks   = has_client_rack;
 
         if (request) {
                 requested_topics    = request->rkbuf_u.Metadata.topics;
@@ -2156,16 +2156,29 @@ rd_kafka_metadata_update_op(rd_kafka_t *rk, rd_kafka_metadata_internal_t *mdi) {
                                 continue;
                         }
 
-                        rkb = rd_kafka_broker_find_by_nodeid(rk, mdp->leader);
-                        if (!rkb) {
-                                rd_kafka_log(rk, LOG_WARNING, "METADATAUPDATE",
-                                             "Partition %s(%s)[%" PRId32
-                                             "]: new leader"
-                                             "%" PRId32 " not found in cache",
-                                             topic,
-                                             rd_kafka_Uuid_base64str(&topic_id),
-                                             part, mdp->leader);
-                                continue;
+                        /* leader=-1 means no current leader (transient
+                         * unavailability, e.g. broker fenced by controller).
+                         * Allow NULL broker to flow through so the toppar is
+                         * correctly undelegated via
+                         * rd_kafka_topic_metadata_update2(), mirroring the
+                         * rd_kafka_topic_metadata_update() behaviour. Any other
+                         * missing broker ID is a genuine cache miss. */
+                        if (mdp->leader == -1) {
+                                rkb = NULL;
+                        } else {
+                                rkb = rd_kafka_broker_find_by_nodeid(
+                                    rk, mdp->leader);
+                                if (!rkb) {
+                                        rd_kafka_log(
+                                            rk, LOG_WARNING, "METADATAUPDATE",
+                                            "Partition %s(%s)[%" PRId32
+                                            "]: new leader"
+                                            "%" PRId32 " not found in cache",
+                                            topic,
+                                            rd_kafka_Uuid_base64str(&topic_id),
+                                            part, mdp->leader);
+                                        continue;
+                                }
                         }
 
                         current_leader_epoch =
@@ -2173,7 +2186,7 @@ rd_kafka_metadata_update_op(rd_kafka_t *rk, rd_kafka_metadata_internal_t *mdi) {
                                 .partitions[part]
                                 .leader_epoch;
 
-                        if (mdpi->leader_epoch != -1 &&
+                        if (rkb && mdpi->leader_epoch != -1 &&
                             current_leader_epoch > mdpi->leader_epoch) {
                                 rd_kafka_broker_destroy(rkb);
                                 rd_kafka_dbg(
@@ -2197,7 +2210,8 @@ rd_kafka_metadata_update_op(rd_kafka_t *rk, rd_kafka_metadata_internal_t *mdi) {
                         rkmce->rkmce_mtopic.partitions[part].leader =
                             mdp->leader;
                         rd_kafka_wrunlock(rk);
-                        rd_kafka_broker_destroy(rkb);
+                        if (rkb)
+                                rd_kafka_broker_destroy(rkb);
 
                         rd_kafka_dbg(rk, METADATA, "METADATAUPDATE",
                                      "Partition %s(%s)[%" PRId32

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -49,8 +49,9 @@ void rd_kafka_mock_Produce_reply_tags_partition_write(
     rd_kafka_mock_partition_t *mpart) {
         switch (tagtype) {
         case 0: /* CurrentLeader */
-                /* Leader id */
-                rd_kafka_buf_write_i32(rkbuf, mpart->leader->id);
+                /* Leader id: -1 when there is no current leader */
+                rd_kafka_buf_write_i32(rkbuf,
+                                       mpart->leader ? mpart->leader->id : -1);
                 /* Leader epoch */
                 rd_kafka_buf_write_i32(rkbuf, mpart->leader_epoch);
                 /* Field tags */
@@ -222,23 +223,37 @@ static int rd_kafka_mock_handle_Produce(rd_kafka_mock_connection_t *mconn,
 
                         if (rkbuf->rkbuf_reqhdr.ApiVersion >= 10 &&
                             err == RD_KAFKA_RESP_ERR_NOT_LEADER_FOR_PARTITION) {
-                                int changed_leader_idx;
-                                /* See if this leader is already included */
-                                for (changed_leader_idx = 0;
-                                     changed_leader_idx < changed_leaders_cnt;
-                                     changed_leader_idx++) {
-                                        if (changed_leaders[changed_leader_idx]
-                                                ->id == mpart->leader->id)
-                                                break;
-                                }
-                                if (changed_leader_idx == changed_leaders_cnt) {
-                                        /* Add the new leader that wasn't
-                                         * present */
-                                        changed_leaders[changed_leaders_cnt] =
-                                            mpart->leader;
-                                        changed_leaders_cnt++;
+                                /* Only track the new leader in NodeEndpoints
+                                 * if there is one (leader may be -1 when the
+                                 * partition is transiently leaderless). */
+                                if (mpart->leader) {
+                                        int changed_leader_idx;
+                                        /* See if this leader is already
+                                         * included */
+                                        for (changed_leader_idx = 0;
+                                             changed_leader_idx <
+                                             changed_leaders_cnt;
+                                             changed_leader_idx++) {
+                                                if (changed_leaders
+                                                        [changed_leader_idx]
+                                                            ->id ==
+                                                    mpart->leader->id)
+                                                        break;
+                                        }
+                                        if (changed_leader_idx ==
+                                            changed_leaders_cnt) {
+                                                /* Add the new leader that
+                                                 * wasn't present */
+                                                changed_leaders
+                                                    [changed_leaders_cnt] =
+                                                        mpart->leader;
+                                                changed_leaders_cnt++;
+                                        }
                                 }
 
+                                /* Always write CurrentLeader partition tag so
+                                 * the client receives leader_id=-1 and can
+                                 * correctly undelegate the toppar. */
                                 partition_tags_to_write
                                     [partition_tags_to_write_cnt] =
                                         0 /* CurrentLeader */;

--- a/tests/0146-metadata_mock.c
+++ b/tests/0146-metadata_mock.c
@@ -477,6 +477,89 @@ static void do_test_metadata_update_operation(rd_bool_t producer,
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Verify that a producer recovers after the partition leader is
+ *        transiently set to -1 (no leader), as happens when a KRaft
+ *        controller GC pause causes the broker to be fenced.
+ *
+ * The scenario exercises rd_kafka_metadata_update_op(): when a Produce
+ * response carries a KIP-951 CurrentLeader tag with leader_id=-1, that op
+ * must correctly undelegate the toppar rather than skipping it entirely.
+ * Without the fix the toppar remains permanently stuck in NO_INFO even after
+ * the broker recovers.
+ *
+ * Mock changes required: rd_kafka_mock_Produce_reply_tags_partition_write
+ * and rd_kafka_mock_handle_Produce must handle mpart->leader == NULL so that
+ * NOT_LEADER_FOR_PARTITION responses carry CurrentLeader=-1 correctly.
+ */
+static void do_test_metadata_update_op_transient_no_leader(void) {
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        rd_kafka_conf_t *conf;
+        rd_bool_t found;
+        int remaining                       = 2;
+        expected_request_t expected_request = {.api_key = RD_KAFKAP_Produce,
+                                               .broker  = 2};
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(2, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 2);
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 1);
+
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "batch.num.messages", "1");
+        /* Allow enough time for the retry cycle: NOT_LEADER_FOR_PARTITION
+         * with leader=-1 -> metadata refresh -> leader=2 -> delivery. */
+        test_conf_set(conf, "message.timeout.ms", "15000");
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        /* Establish partition 0 on broker 1 in the client's metadata cache. */
+        test_produce_msgs2(rk, topic, 0, 0, 0, 1, NULL, 0);
+        rd_kafka_flush(rk, 5000);
+
+        rd_kafka_mock_start_request_tracking(mcluster);
+
+        /* Simulate broker fencing by the KRaft controller: set leader to -1.
+         * The next Produce to broker 1 will get NOT_LEADER_FOR_PARTITION
+         * with a KIP-951 CurrentLeader tag carrying leader_id=-1.  This
+         * triggers rd_kafka_metadata_update_op() with leader=-1, which must
+         * correctly undelegate the toppar so it can recover. */
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, -1);
+
+        /* Enqueue messages.  They will fail initially and be retried by the
+         * producer's retry logic. */
+        test_produce_msgs2_nowait(rk, topic, 0, 0, 1, 2, NULL, 0, &remaining);
+
+        /* Allow the NOT_LEADER_FOR_PARTITION + CurrentLeader=-1 response to
+         * be received and processed by rd_kafka_metadata_update_op(). */
+        rd_usleep(500 * 1000, 0);
+
+        /* Simulate ELR re-election: broker 2 becomes the new leader. */
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 2);
+
+        /* All messages must be delivered successfully to broker 2. */
+        rd_kafka_flush(rk, 15000);
+
+        found = verify_requests_after_metadata_update_operation(
+            mcluster, &expected_request);
+        TEST_ASSERT(found,
+                    "Produce requests were not found on broker %" PRId32
+                    " after transient leader=-1 recovery",
+                    expected_request.broker);
+
+        rd_kafka_mock_stop_request_tracking(mcluster);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        TEST_LATER_CHECK();
+        SUB_TEST_PASS();
+}
+
 int main_0146_metadata_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
         int variation;
@@ -500,6 +583,8 @@ int main_0146_metadata_mock(int argc, char **argv) {
                         variation % 2  /* 1-3: second leader change,
                                         * 0-2: single leader change */);
         }
+
+        do_test_metadata_update_op_transient_no_leader();
 
         return 0;
 }


### PR DESCRIPTION
## Root Cause

The bug is in `rd_kafka_metadata_update_op()` (`src/rdkafka_metadata.c`, around line 2159).

### Buggy code path (`rd_kafka_metadata_update_op`)

```c
// rdkafka_metadata.c ~line 2159
rkb = rd_kafka_broker_find_by_nodeid(rk, mdp->leader);
if (!rkb) {
    rd_kafka_log(rk, LOG_WARNING, "METADATAUPDATE",
                 "Partition %s(%s)[%" PRId32 "]: new leader"
                 "%" PRId32 " not found in cache",
                 topic, rd_kafka_Uuid_base64str(&topic_id),
                 part, mdp->leader);
    continue;   // <-- BUG: skips partition entirely
}
// ... (never reached for leader=-1)
partition_cache_changes++;
```

When `mdp->leader == -1`, `rd_kafka_broker_find_by_nodeid(rk, -1)` returns `NULL`
(no broker with node-id -1 exists). The `if (!rkb)` branch fires, logs a WARNING, and
`continue`s. As a result:

- `partition_cache_changes` stays `0`
- `rd_kafka_topic_metadata_update2()` at line 2213 is **never called**
- The toppar's cached leader is **never updated** with the `-1` leader info
- `rd_kafka_toppar_leader_update()` / `rd_kafka_toppar_broker_update()` are **never called**
- The topic-partition stays stuck in `RD_KAFKA_TOPIC_S_NOINFO` forever

### Correct code path (`rd_kafka_topic_metadata_update`)

The full-metadata-response path in `src/rdkafka_topic.c` handles `leader=-1` correctly:

```c
// rdkafka_topic.c ~line 1392
for (j = 0; j < mdt->partition_cnt; j++) {
    if (mdt->partitions[j].leader == -1) {
        partbrokers[j] = NULL;   // explicitly allow NULL broker
        continue;
    }
    partbrokers[j] = rd_kafka_broker_find_by_nodeid(rk, mdt->partitions[j].leader);
}
// ... later at ~line 1490:
rd_kafka_toppar_leader_update(rkt, j, leader_id=-1, rkb=NULL, epoch);
```

With `rkb=NULL`, `rd_kafka_toppar_leader_update()` (`rdkafka_topic.c:662`) clears
`rktp->rktp_leader`, sets `rktp->rktp_leader_id = -1`, and calls
`rd_kafka_toppar_broker_update()` with a NULL broker — putting the toppar into an
undelegated state that re-queried once valid metadata arrives.

**The full response path recovers correctly. The incremental update path does not.**

### Why the bug persists after recovery

Once the broker recovers, `QRYLEADER` re-queries fire every
`topic.metadata.refresh.interval.ms` and valid metadata responses are received. But
because `partition_cache_changes` was `0` when `leader=-1` arrived, the toppar was
never undelegated — so the valid responses have nothing to re-attach to. The `NO_INFO`
flag never clears.

---

## Proposed Fix

Mirror the logic from `rdkafka_topic.c`: treat `leader=-1` as a valid "no leader" signal
and let it flow through the partition update rather than treating it as a cache miss.

**In `src/rdkafka_metadata.c`, `rd_kafka_metadata_update_op()`, around line 2159:**

```c
// Before (buggy):
rkb = rd_kafka_broker_find_by_nodeid(rk, mdp->leader);
if (!rkb) {
    rd_kafka_log(rk, LOG_WARNING, "METADATAUPDATE",
                 "Partition %s(%s)[%" PRId32 "]: new leader"
                 "%" PRId32 " not found in cache",
                 topic, rd_kafka_Uuid_base64str(&topic_id),
                 part, mdp->leader);
    continue;
}
```

```c
// After (proposed fix):
if (mdp->leader == -1) {
    /* leader=-1 means no current leader (transient unavailability).
     * Treat as NULL broker so toppar is correctly undelegated and
     * re-queried on recovery, mirroring rdkafka_topic.c behavior. */
    rkb = NULL;
} else {
    rkb = rd_kafka_broker_find_by_nodeid(rk, mdp->leader);
    if (!rkb) {
        rd_kafka_log(rk, LOG_WARNING, "METADATAUPDATE",
                     "Partition %s(%s)[%" PRId32 "]: new leader"
                     "%" PRId32 " not found in cache",
                     topic, rd_kafka_Uuid_base64str(&topic_id),
                     part, mdp->leader);
        continue;
    }
}
```

Two additional `rkb` NULL-guards required in the same function:

1. **Epoch staleness check** (~line 2178): `rd_kafka_broker_destroy(rkb)` must be guarded
   with `if (rkb)`. (Alternatively, skip the epoch check entirely when `leader=-1` since
   no epoch is meaningful for a no-leader state.)

2. **Cache update** (~line 2200): `rd_kafka_broker_destroy(rkb)` must be guarded with
   `if (rkb)`.

With this fix, `partition_cache_changes` increments for `leader=-1` partitions,
`rd_kafka_topic_metadata_update2()` is called, and `rd_kafka_toppar_leader_update()`
receives a NULL broker — correctly undelegating the toppar and allowing recovery once a
valid leader is elected.

Fixes: https://github.com/confluentinc/librdkafka/issues/5430