### PR TITLE
nul-terminate base64-decoded JWT payload before cJSON_Parse

### DIFF
--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -185,7 +185,14 @@ static const char *rd_kafka_jwt_b64_decode_payload(const char *src,
         if (EVP_DecodeBlock((uint8_t *)(*bufplainp), (uint8_t *)payload,
                             (int)payload_len) == -1) {
                 errstr = "Failed to decode base64 payload";
+                goto done;
         }
+
+        /* EVP_DecodeBlock() does not NUL-terminate its output. The decoded
+         * payload is handed to cJSON_Parse() which runs strlen() on it, so a
+         * payload whose base64 length is a multiple of 4 (no '=' padding)
+         * leaves the trailing byte uninitialized and reads past the buffer. */
+        (*bufplainp)[nbytesdecoded] = '\0';
 
 done:
         RD_IF_FREE(payload, rd_free);
@@ -1396,6 +1403,16 @@ static int ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope(void) {
         "Y2xpZW50X2lkXzEyMyJ9"                                                 \
         "."                                                                    \
         "fakesignature"
+/* payload: {"exp":9999999999,"iat":1000000000,"sub":"a"}
+ * The base64url payload segment is 60 chars (a multiple of 4, so no '='
+ * padding), which exercises the case where EVP_DecodeBlock() fills the whole
+ * decode buffer and the result must be NUL-terminated before cJSON_Parse. */
+#define UT_JWT_NO_PADDING                                                      \
+        "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiY2RlZmcifQ"                           \
+        "."                                                                    \
+        "eyJleHAiOjk5OTk5OTk5OTksImlhdCI6MTAwMDAwMDAwMCwic3ViIjoiYSJ9"         \
+        "."                                                                    \
+        "fakesignature"
 
 /**
  * @brief Verifies the extraction logic of the subject from the configured JWT
@@ -1425,6 +1442,7 @@ static int ut_sasl_oauthbearer_oidc_sub_claim_name(void) {
              NULL},
             {"Nonexistent claim name fails", UT_JWT_SUB_ONLY, "nonexistent",
              rd_false, NULL},
+            {"Unpadded base64 payload", UT_JWT_NO_PADDING, "sub", rd_true, "a"},
         };
 
         unsigned int i;


### PR DESCRIPTION
The base64url JWT payload decoded in the OIDC token path is left un-terminated:
- rd_kafka_jwt_b64_decode_payload allocates nbytesdecoded+1 bytes but EVP_DecodeBlock never writes the trailing NUL
- rd_kafka_oidc_token_try_validate hands that buffer straight to cJSON_Parse, which runs strlen() on it
- when the base64 payload length is a multiple of 4 (no "=" padding) EVP_DecodeBlock fills every byte, so the last byte stays uninitialized and strlen reads past the heap allocation (ASAN heap-buffer-overflow read on the token endpoint response)

Terminate after a successful decode, matching rd_base64_decode in rdbase64.c. Added a regression case with an unpadded payload to the existing sub-claim unit test.