### PR TITLE
Raise API version ceilings to match the Apache Kafka 2.8.0 Java client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ librdkafka v2.15.0 is a feature release:
 
 ## Enhancements
 * Add `aws_iam` option to `sasl.oauthbearer.metadata.authentication.type`, with a defensive stub that fails when no token-refresh callback is registered.
+* Raise API version ceilings to match the Apache Kafka 2.8.0 Java client (#5566).
 
 ## Fixes
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2663,7 +2663,7 @@ release of librdkafka.
 | 22     | InitProducerId               | 5         | 4              |
 | 23     | OffsetForLeaderEpoch         | 4         | 2              |
 | 24     | AddPartitionsToTxn           | 5         | 3              |
-| 25     | AddOffsetsToTxn              | 4         | 0              |
+| 25     | AddOffsetsToTxn              | 4         | 3              |
 | 26     | EndTxn                       | 5         | 1              |
 | 28     | TxnOffsetCommit              | 5         | 3              |
 | 29     | DescribeAcls                 | 3         | 2              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2657,7 +2657,7 @@ release of librdkafka.
 | 16     | ListGroups                   | 5         | 4              |
 | 17     | SaslHandshake                | 1         | 1              |
 | 18     | ApiVersions                  | 4         | 3              |
-| 19     | CreateTopics                 | 7         | 4              |
+| 19     | CreateTopics                 | 7         | 7              |
 | 20     | DeleteTopics                 | 6         | 4              |
 | 21     | DeleteRecords                | 2         | 2              |
 | 22     | InitProducerId               | 5         | 4              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2650,7 +2650,7 @@ release of librdkafka.
 | 9      | OffsetFetch                  | 9         | 9              |
 | 10     | FindCoordinator              | 6         | 2              |
 | 11     | JoinGroup                    | 9         | 5              |
-| 12     | Heartbeat                    | 4         | 3              |
+| 12     | Heartbeat                    | 4         | 4              |
 | 13     | LeaveGroup                   | 5         | 1              |
 | 14     | SyncGroup                    | 5         | 3              |
 | 15     | DescribeGroups               | 6         | 5              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2662,7 +2662,7 @@ release of librdkafka.
 | 21     | DeleteRecords                | 2         | 2              |
 | 22     | InitProducerId               | 5         | 4              |
 | 23     | OffsetForLeaderEpoch         | 4         | 2              |
-| 24     | AddPartitionsToTxn           | 5         | 0              |
+| 24     | AddPartitionsToTxn           | 5         | 3              |
 | 25     | AddOffsetsToTxn              | 4         | 0              |
 | 26     | EndTxn                       | 5         | 1              |
 | 28     | TxnOffsetCommit              | 5         | 3              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2649,7 +2649,7 @@ release of librdkafka.
 | 8      | OffsetCommit                 | 9         | 9              |
 | 9      | OffsetFetch                  | 9         | 9              |
 | 10     | FindCoordinator              | 6         | 3              |
-| 11     | JoinGroup                    | 9         | 5              |
+| 11     | JoinGroup                    | 9         | 7              |
 | 12     | Heartbeat                    | 4         | 4              |
 | 13     | LeaveGroup                   | 5         | 4              |
 | 14     | SyncGroup                    | 5         | 5              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2664,7 +2664,7 @@ release of librdkafka.
 | 23     | OffsetForLeaderEpoch         | 4         | 2              |
 | 24     | AddPartitionsToTxn           | 5         | 3              |
 | 25     | AddOffsetsToTxn              | 4         | 3              |
-| 26     | EndTxn                       | 5         | 1              |
+| 26     | EndTxn                       | 5         | 3              |
 | 28     | TxnOffsetCommit              | 5         | 3              |
 | 29     | DescribeAcls                 | 3         | 2              |
 | 30     | CreateAcls                   | 3         | 2              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2661,7 +2661,7 @@ release of librdkafka.
 | 20     | DeleteTopics                 | 6         | 4              |
 | 21     | DeleteRecords                | 2         | 2              |
 | 22     | InitProducerId               | 5         | 4              |
-| 23     | OffsetForLeaderEpoch         | 4         | 2              |
+| 23     | OffsetForLeaderEpoch         | 4         | 4              |
 | 24     | AddPartitionsToTxn           | 5         | 3              |
 | 25     | AddOffsetsToTxn              | 4         | 3              |
 | 26     | EndTxn                       | 5         | 3              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2651,7 +2651,7 @@ release of librdkafka.
 | 10     | FindCoordinator              | 6         | 3              |
 | 11     | JoinGroup                    | 9         | 5              |
 | 12     | Heartbeat                    | 4         | 4              |
-| 13     | LeaveGroup                   | 5         | 1              |
+| 13     | LeaveGroup                   | 5         | 4              |
 | 14     | SyncGroup                    | 5         | 3              |
 | 15     | DescribeGroups               | 6         | 5              |
 | 16     | ListGroups                   | 5         | 4              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2652,7 +2652,7 @@ release of librdkafka.
 | 11     | JoinGroup                    | 9         | 5              |
 | 12     | Heartbeat                    | 4         | 4              |
 | 13     | LeaveGroup                   | 5         | 4              |
-| 14     | SyncGroup                    | 5         | 3              |
+| 14     | SyncGroup                    | 5         | 5              |
 | 15     | DescribeGroups               | 6         | 5              |
 | 16     | ListGroups                   | 5         | 4              |
 | 17     | SaslHandshake                | 1         | 1              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2672,7 +2672,7 @@ release of librdkafka.
 | 32     | DescribeConfigs              | 4         | 4              |
 | 33     | AlterConfigs                 | 2         | 2              |
 | 36     | SaslAuthenticate             | 2         | 2              |
-| 37     | CreatePartitions             | 3         | 2              |
+| 37     | CreatePartitions             | 3         | 3              |
 | 42     | DeleteGroups                 | 2         | 2              |
 | 43     | ElectLeaders                 | 2         | 2              |
 | 44     | IncrementalAlterConfigs      | 1         | 1              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2648,7 +2648,7 @@ release of librdkafka.
 | 3      | Metadata                     | 13        | 13             |
 | 8      | OffsetCommit                 | 9         | 9              |
 | 9      | OffsetFetch                  | 9         | 9              |
-| 10     | FindCoordinator              | 6         | 2              |
+| 10     | FindCoordinator              | 6         | 3              |
 | 11     | JoinGroup                    | 9         | 5              |
 | 12     | Heartbeat                    | 4         | 4              |
 | 13     | LeaveGroup                   | 5         | 1              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2658,7 +2658,7 @@ release of librdkafka.
 | 17     | SaslHandshake                | 1         | 1              |
 | 18     | ApiVersions                  | 4         | 3              |
 | 19     | CreateTopics                 | 7         | 7              |
-| 20     | DeleteTopics                 | 6         | 4              |
+| 20     | DeleteTopics                 | 6         | 6              |
 | 21     | DeleteRecords                | 2         | 2              |
 | 22     | InitProducerId               | 5         | 4              |
 | 23     | OffsetForLeaderEpoch         | 4         | 4              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2669,7 +2669,7 @@ release of librdkafka.
 | 29     | DescribeAcls                 | 3         | 2              |
 | 30     | CreateAcls                   | 3         | 2              |
 | 31     | DeleteAcls                   | 3         | 2              |
-| 32     | DescribeConfigs              | 4         | 1              |
+| 32     | DescribeConfigs              | 4         | 4              |
 | 33     | AlterConfigs                 | 2         | 2              |
 | 36     | SaslAuthenticate             | 2         | 2              |
 | 37     | CreatePartitions             | 3         | 2              |

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2671,7 +2671,7 @@ release of librdkafka.
 | 31     | DeleteAcls                   | 3         | 2              |
 | 32     | DescribeConfigs              | 4         | 1              |
 | 33     | AlterConfigs                 | 2         | 2              |
-| 36     | SaslAuthenticate             | 2         | 1              |
+| 36     | SaslAuthenticate             | 2         | 2              |
 | 37     | CreatePartitions             | 3         | 2              |
 | 42     | DeleteGroups                 | 2         | 2              |
 | 43     | ElectLeaders                 | 2         | 2              |

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2094,7 +2094,7 @@ rd_kafka_CreateTopicsResponse_parse(rd_kafka_op_t *rko_req,
         }
 
         /* #topics */
-        rd_kafka_buf_read_i32(reply, &topic_cnt);
+        rd_kafka_buf_read_arraycnt(reply, &topic_cnt, 100000);
 
         if (topic_cnt > rd_list_cnt(&rko_req->rko_u.admin_request.args))
                 rd_kafka_buf_parse_fail(
@@ -2120,10 +2120,50 @@ rd_kafka_CreateTopicsResponse_parse(rd_kafka_op_t *rko_req,
                 int orig_pos;
 
                 rd_kafka_buf_read_str(reply, &ktopic);
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 7) {
+                        /* TopicId: not exposed to the caller. */
+                        rd_kafka_Uuid_t TopicId = RD_KAFKA_UUID_ZERO;
+                        rd_kafka_buf_read_uuid(reply, &TopicId);
+                }
+
                 rd_kafka_buf_read_i16(reply, &error_code);
 
                 if (rd_kafka_buf_ApiVersion(reply) >= 1)
                         rd_kafka_buf_read_str(reply, &error_msg);
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 5) {
+                        int32_t NumPartitions, ReplicationFactor;
+                        int32_t ConfigCnt;
+
+                        /* NumPartitions, ReplicationFactor: not exposed to
+                         * the caller. */
+                        rd_kafka_buf_read_i32(reply, &NumPartitions);
+                        rd_kafka_buf_read_i32(reply, &ReplicationFactor);
+
+                        /* Configs: not exposed to the caller. */
+                        rd_kafka_buf_read_arraycnt(reply, &ConfigCnt, 100000);
+                        while (ConfigCnt-- > 0) {
+                                rd_kafkap_str_t ConfigName, ConfigValue;
+                                int8_t ConfigSource;
+                                rd_bool_t ConfigReadOnly, ConfigIsSensitive;
+
+                                rd_kafka_buf_read_str(reply, &ConfigName);
+                                rd_kafka_buf_read_str(reply, &ConfigValue);
+                                rd_kafka_buf_read_bool(reply, &ConfigReadOnly);
+                                rd_kafka_buf_read_i8(reply, &ConfigSource);
+                                rd_kafka_buf_read_bool(reply,
+                                                       &ConfigIsSensitive);
+                                rd_kafka_buf_skip_tags(reply); /* Config
+                                                                * tags */
+                        }
+                }
+
+                rd_kafka_buf_skip_tags(reply); /* Topic-result tags,
+                                                * including the tagged
+                                                * TopicConfigErrorCode
+                                                * (v5+), which is not
+                                                * exposed to the caller. */
 
                 /* For non-blocking CreateTopicsRequests the broker
                  * will returned REQUEST_TIMED_OUT for topics

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -3671,7 +3671,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
         rd_kafka_op_throttle_time(rkb, rk->rk_rep, Throttle_Time);
 
         /* #resources */
-        rd_kafka_buf_read_i32(reply, &res_cnt);
+        rd_kafka_buf_read_arraycnt(reply, &res_cnt, 100000);
 
         if (res_cnt > rd_list_cnt(&rko_req->rko_u.admin_request.args))
                 rd_kafka_buf_parse_fail(
@@ -3732,7 +3732,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                         config->errstr = rd_strdup(this_errstr);
 
                 /* #config_entries */
-                rd_kafka_buf_read_i32(reply, &entry_cnt);
+                rd_kafka_buf_read_arraycnt(reply, &entry_cnt, 100000);
 
                 for (ci = 0; ci < (int)entry_cnt; ci++) {
                         rd_kafkap_str_t config_name, config_value;
@@ -3749,7 +3749,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_bool(reply, &entry->a.is_readonly);
 
                         /* ApiVersion 0 has is_default field, while
-                         * ApiVersion 1 has source field.
+                         * ApiVersion 1+ has source field.
                          * Convert between the two so they look the same
                          * to the caller. */
                         if (rd_kafka_buf_ApiVersion(reply) == 0) {
@@ -3771,23 +3771,10 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_bool(reply, &entry->a.is_sensitive);
 
 
-                        if (rd_kafka_buf_ApiVersion(reply) == 1) {
-                                /* #config_synonyms (ApiVersion 1) */
-                                rd_kafka_buf_read_i32(reply, &syn_cnt);
-
-                                if (syn_cnt > 100000)
-                                        rd_kafka_buf_parse_fail(
-                                            reply,
-                                            "Broker returned %" PRId32
-                                            " config synonyms for "
-                                            "ConfigResource %d,%s: "
-                                            "limit is 100000",
-                                            syn_cnt, config->restype,
-                                            config->name);
-
-                                if (syn_cnt > 0)
-                                        rd_list_grow(&entry->synonyms, syn_cnt);
-
+                        if (rd_kafka_buf_ApiVersion(reply) >= 1) {
+                                /* #config_synonyms (ApiVersion 1+) */
+                                rd_kafka_buf_read_arraycnt(reply, &syn_cnt,
+                                                           100000);
                         } else {
                                 /* No synonyms in ApiVersion 0 */
                                 syn_cnt = 0;
@@ -3795,7 +3782,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
 
 
 
-                        /* Read synonyms (ApiVersion 1) */
+                        /* Read synonyms (ApiVersion 1+) */
                         for (si = 0; si < (int)syn_cnt; si++) {
                                 rd_kafkap_str_t syn_name, syn_value;
                                 int8_t syn_source;
@@ -3804,6 +3791,7 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                                 rd_kafka_buf_read_str(reply, &syn_name);
                                 rd_kafka_buf_read_str(reply, &syn_value);
                                 rd_kafka_buf_read_i8(reply, &syn_source);
+                                rd_kafka_buf_skip_tags(reply);
 
                                 syn_entry = rd_kafka_ConfigEntry_new0(
                                     syn_name.str, RD_KAFKAP_STR_LEN(&syn_name),
@@ -3829,9 +3817,24 @@ rd_kafka_DescribeConfigsResponse_parse(rd_kafka_op_t *rko_req,
                                 rd_list_add(&entry->synonyms, syn_entry);
                         }
 
+                        if (rd_kafka_buf_ApiVersion(reply) >= 3) {
+                                int8_t ConfigType;
+                                rd_kafkap_str_t Documentation;
+
+                                /* ConfigType: not exposed to the caller. */
+                                rd_kafka_buf_read_i8(reply, &ConfigType);
+                                /* Documentation: not exposed to the
+                                 * caller. */
+                                rd_kafka_buf_read_str(reply, &Documentation);
+                        }
+
+                        rd_kafka_buf_skip_tags(reply); /* ConfigEntry tags */
+
                         rd_kafka_ConfigResource_add_ConfigEntry(config, entry);
                         entry = NULL;
                 }
+
+                rd_kafka_buf_skip_tags(reply); /* DescribeConfigsResult tags */
 
                 /* As a convenience to the application we insert result
                  * in the same order as they were requested. The broker

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -2377,12 +2377,25 @@ rd_kafka_DeleteTopicsResponse_parse(rd_kafka_op_t *rko_req,
         for (i = 0; i < (int)topic_cnt; i++) {
                 rd_kafkap_str_t ktopic;
                 int16_t error_code;
+                rd_kafkap_str_t error_msg = RD_KAFKAP_STR_INITIALIZER;
+                char *this_errstr         = NULL;
                 rd_kafka_topic_result_t *terr;
                 rd_kafka_NewTopic_t skel;
                 int orig_pos;
 
                 rd_kafka_buf_read_str(reply, &ktopic);
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 6) {
+                        /* TopicId: not exposed to the caller. */
+                        rd_kafka_Uuid_t TopicId = RD_KAFKA_UUID_ZERO;
+                        rd_kafka_buf_read_uuid(reply, &TopicId);
+                }
+
                 rd_kafka_buf_read_i16(reply, &error_code);
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 5)
+                        rd_kafka_buf_read_str(reply, &error_msg);
+
                 rd_kafka_buf_skip_tags(reply);
 
                 /* For non-blocking DeleteTopicsRequests the broker
@@ -2394,12 +2407,22 @@ rd_kafka_DeleteTopicsResponse_parse(rd_kafka_op_t *rko_req,
                     rd_kafka_confval_get_int(&rko_req->rko_u.admin_request
                                                   .options.operation_timeout) <=
                         0) {
-                        error_code = RD_KAFKA_RESP_ERR_NO_ERROR;
+                        error_code  = RD_KAFKA_RESP_ERR_NO_ERROR;
+                        this_errstr = NULL;
                 }
 
-                terr = rd_kafka_topic_result_new(
-                    ktopic.str, RD_KAFKAP_STR_LEN(&ktopic), error_code,
-                    error_code ? rd_kafka_err2str(error_code) : NULL);
+                if (error_code) {
+                        if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||
+                            RD_KAFKAP_STR_LEN(&error_msg) == 0)
+                                this_errstr =
+                                    (char *)rd_kafka_err2str(error_code);
+                        else
+                                RD_KAFKAP_STR_DUPA(&this_errstr, &error_msg);
+                }
+
+                terr = rd_kafka_topic_result_new(ktopic.str,
+                                                 RD_KAFKAP_STR_LEN(&ktopic),
+                                                 error_code, this_errstr);
 
                 /* As a convenience to the application we insert topic result
                  * in the same order as they were requested. The broker

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -1240,6 +1240,7 @@ static void rd_kafka_cgrp_leave(rd_kafka_cgrp_t *rkcg) {
                            "Leaving group");
                 rd_kafka_LeaveGroupRequest(
                     rkcg->rkcg_coord, rkcg->rkcg_group_id->str, member_id,
+                    rkcg->rkcg_group_instance_id,
                     RD_KAFKA_REPLYQ(rkcg->rkcg_ops, 0),
                     rd_kafka_cgrp_handle_LeaveGroup, rkcg);
         } else

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2030,6 +2030,13 @@ static void rd_kafka_cgrp_handle_SyncGroup(rd_kafka_t *rk,
                 rd_kafka_buf_read_throttle_time(rkbuf);
 
         rd_kafka_buf_read_i16(rkbuf, &ErrorCode);
+
+        if (request->rkbuf_reqhdr.ApiVersion >= 5) {
+                rd_kafkap_str_t ProtocolType, ProtocolName;
+                rd_kafka_buf_read_str(rkbuf, &ProtocolType);
+                rd_kafka_buf_read_str(rkbuf, &ProtocolName);
+        }
+
         rd_kafka_buf_read_kbytes(rkbuf, &MemberState);
 
 err:

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2315,10 +2315,14 @@ static void rd_kafka_cgrp_handle_JoinGroup(rd_kafka_t *rk,
 
         rd_kafka_buf_read_i16(rkbuf, &ErrorCode);
         rd_kafka_buf_read_i32(rkbuf, &GenerationId);
+        if (request->rkbuf_reqhdr.ApiVersion >= 7) {
+                rd_kafkap_str_t ProtocolType;
+                rd_kafka_buf_read_str(rkbuf, &ProtocolType);
+        }
         rd_kafka_buf_read_str(rkbuf, &Protocol);
         rd_kafka_buf_read_str(rkbuf, &LeaderId);
         rd_kafka_buf_read_str(rkbuf, &MyMemberId);
-        rd_kafka_buf_read_i32(rkbuf, &member_cnt);
+        rd_kafka_buf_read_arraycnt(rkbuf, &member_cnt, 100000);
 
         if (!ErrorCode && RD_KAFKAP_STR_IS_NULL(&Protocol)) {
                 /* Protocol not set, we will not be able to find
@@ -2414,6 +2418,7 @@ static void rd_kafka_cgrp_handle_JoinGroup(rd_kafka_t *rk,
                         if (request->rkbuf_reqhdr.ApiVersion >= 5)
                                 rd_kafka_buf_read_str(rkbuf, &GroupInstanceId);
                         rd_kafka_buf_read_kbytes(rkbuf, &MemberMetadata);
+                        rd_kafka_buf_skip_tags(rkbuf);
 
                         rkgm                 = &members[sub_cnt];
                         rkgm->rkgm_member_id = rd_kafkap_str_copy(&MemberId);

--- a/src/rdkafka_mock_cgrp.c
+++ b/src/rdkafka_mock_cgrp.c
@@ -180,6 +180,12 @@ rd_kafka_mock_cgrp_classic_sync_done(rd_kafka_mock_cgrp_classic_t *mcgrp,
                                   RD_KAFKAP_SyncGroup);
 
                         rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
+                        if (resp->rkbuf_reqhdr.ApiVersion >= 5) {
+                                rd_kafka_buf_write_kstr(
+                                    resp, NULL); /* ProtocolType */
+                                rd_kafka_buf_write_kstr(
+                                    resp, NULL); /* ProtocolName */
+                        }
                         /* MemberState */
                         rd_kafka_buf_write_kbytes(
                             resp, !err ? member->assignment : NULL);

--- a/src/rdkafka_mock_cgrp.c
+++ b/src/rdkafka_mock_cgrp.c
@@ -361,10 +361,12 @@ rd_kafka_mock_cgrp_classic_elect_leader(rd_kafka_mock_cgrp_classic_t *mcgrp) {
 
                 rd_kafka_buf_write_i16(resp, 0); /* ErrorCode */
                 rd_kafka_buf_write_i32(resp, mcgrp->generation_id);
+                if (resp->rkbuf_reqhdr.ApiVersion >= 7)
+                        rd_kafka_buf_write_kstr(resp, NULL); /* ProtocolType */
                 rd_kafka_buf_write_str(resp, mcgrp->protocol_name, -1);
                 rd_kafka_buf_write_str(resp, mcgrp->leader->id, -1);
                 rd_kafka_buf_write_str(resp, member->id, -1);
-                rd_kafka_buf_write_i32(resp, member_cnt);
+                rd_kafka_buf_write_arraycnt(resp, member_cnt);
 
                 /* Send full member list to leader */
                 if (member_cnt > 0) {
@@ -381,6 +383,8 @@ rd_kafka_mock_cgrp_classic_elect_leader(rd_kafka_mock_cgrp_classic_t *mcgrp) {
 
                                 rd_kafka_buf_write_kbytes(
                                     resp, member2->protos[0].metadata);
+                                rd_kafka_buf_write_tags_empty(
+                                    resp); /* Member tags */
                         }
                 }
 

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -2234,10 +2234,10 @@ rd_kafka_mock_handle_AddPartitionsToTxn(rd_kafka_mock_connection_t *mconn,
         /* Epoch */
         rd_kafka_buf_read_i16(rkbuf, &pid.epoch);
         /* #Topics */
-        rd_kafka_buf_read_i32(rkbuf, &TopicsCnt);
+        rd_kafka_buf_read_arraycnt(rkbuf, &TopicsCnt, 100000);
 
         /* Response: #Results */
-        rd_kafka_buf_write_i32(resp, TopicsCnt);
+        rd_kafka_buf_write_arraycnt(resp, TopicsCnt);
 
         /* Inject error */
         all_err = rd_kafka_mock_next_request_error(mconn, resp);
@@ -2271,9 +2271,9 @@ rd_kafka_mock_handle_AddPartitionsToTxn(rd_kafka_mock_connection_t *mconn,
                 rd_kafka_buf_write_kstr(resp, &Topic);
 
                 /* #Partitions */
-                rd_kafka_buf_read_i32(rkbuf, &PartsCnt);
+                rd_kafka_buf_read_arraycnt(rkbuf, &PartsCnt, 100000);
                 /* Response: #Partitions */
-                rd_kafka_buf_write_i32(resp, PartsCnt);
+                rd_kafka_buf_write_arraycnt(resp, PartsCnt);
 
                 mtopic = rd_kafka_mock_topic_find_by_kstr(mcluster, &Topic);
 
@@ -2304,7 +2304,11 @@ rd_kafka_mock_handle_AddPartitionsToTxn(rd_kafka_mock_connection_t *mconn,
 
                         /* Response: ErrorCode */
                         rd_kafka_buf_write_i16(resp, err);
+                        rd_kafka_buf_write_tags_empty(resp); /* Result tags */
                 }
+
+                rd_kafka_buf_skip_tags(rkbuf);       /* Topic tags */
+                rd_kafka_buf_write_tags_empty(resp); /* Result-topic tags */
         }
 
         rd_kafka_mock_connection_send_response(mconn, resp);
@@ -5212,7 +5216,7 @@ const struct rd_kafka_mock_api_handler
         [RD_KAFKAP_LeaveGroup] = {0, 4, 4, rd_kafka_mock_handle_LeaveGroup},
         [RD_KAFKAP_SyncGroup]  = {0, 5, 4, rd_kafka_mock_handle_SyncGroup},
         [RD_KAFKAP_AddPartitionsToTxn] =
-            {0, 1, -1, rd_kafka_mock_handle_AddPartitionsToTxn},
+            {0, 3, 3, rd_kafka_mock_handle_AddPartitionsToTxn},
         [RD_KAFKAP_AddOffsetsToTxn] = {0, 1, -1,
                                        rd_kafka_mock_handle_AddOffsetsToTxn},
         [RD_KAFKAP_TxnOffsetCommit] = {0, 3, 3,

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -1765,12 +1765,18 @@ static int rd_kafka_mock_handle_LeaveGroup(rd_kafka_mock_connection_t *mconn,
         const rd_bool_t log_decode_errors = rd_true;
         rd_kafka_buf_t *resp = rd_kafka_mock_buf_new_response(rkbuf);
         rd_kafkap_str_t GroupId, MemberId;
-        rd_kafka_resp_err_t err;
-        rd_kafka_mock_cgrp_classic_t *mcgrp;
-        rd_kafka_mock_cgrp_classic_member_t *member = NULL;
+        rd_kafka_resp_err_t err, group_err;
+        rd_kafka_mock_cgrp_classic_t *mcgrp = NULL;
+        rd_bool_t is_batch = rkbuf->rkbuf_reqhdr.ApiVersion >= 3;
+        int32_t member_cnt = 1;
+        int32_t i;
 
         rd_kafka_buf_read_str(rkbuf, &GroupId);
-        rd_kafka_buf_read_str(rkbuf, &MemberId);
+
+        if (!is_batch)
+                rd_kafka_buf_read_str(rkbuf, &MemberId);
+        else
+                rd_kafka_buf_read_arraycnt(rkbuf, &member_cnt, 1000000);
 
         /*
          * Construct response
@@ -1782,38 +1788,79 @@ static int rd_kafka_mock_handle_LeaveGroup(rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mconn, resp);
-        if (!err) {
+        group_err = rd_kafka_mock_next_request_error(mconn, resp);
+        if (!group_err) {
                 mrkb = rd_kafka_mock_cluster_get_coord(
                     mcluster, RD_KAFKA_COORD_GROUP, &GroupId);
 
                 if (!mrkb)
-                        err = RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE;
+                        group_err = RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE;
                 else if (mrkb != mconn->broker)
-                        err = RD_KAFKA_RESP_ERR_NOT_COORDINATOR;
+                        group_err = RD_KAFKA_RESP_ERR_NOT_COORDINATOR;
         }
 
-        if (!err) {
+        if (!group_err) {
                 mcgrp = rd_kafka_mock_cgrp_classic_find(mcluster, &GroupId);
                 if (!mcgrp)
-                        err = RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND;
+                        group_err = RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND;
         }
 
-        if (!err) {
-                member =
-                    rd_kafka_mock_cgrp_classic_member_find(mcgrp, &MemberId);
-                if (!member)
-                        err = RD_KAFKA_RESP_ERR_UNKNOWN_MEMBER_ID;
+        if (!is_batch) {
+                rd_kafka_mock_cgrp_classic_member_t *member = NULL;
+
+                err = group_err;
+                if (!err) {
+                        member = rd_kafka_mock_cgrp_classic_member_find(
+                            mcgrp, &MemberId);
+                        if (!member)
+                                err = RD_KAFKA_RESP_ERR_UNKNOWN_MEMBER_ID;
+                }
+
+                if (!err)
+                        err = rd_kafka_mock_cgrp_classic_check_state(
+                            mcgrp, member, rkbuf, -1);
+
+                if (!err)
+                        rd_kafka_mock_cgrp_classic_member_leave(mcgrp, member);
+
+                rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
+        } else {
+                rd_kafka_buf_write_i16(resp, group_err); /* ErrorCode */
+
+                /* #Members */
+                rd_kafka_buf_write_arraycnt(resp, member_cnt);
+
+                for (i = 0; i < member_cnt; i++) {
+                        rd_kafkap_str_t GroupInstanceId;
+                        rd_kafka_mock_cgrp_classic_member_t *member = NULL;
+
+                        rd_kafka_buf_read_str(rkbuf, &MemberId);
+                        rd_kafka_buf_read_str(rkbuf, &GroupInstanceId);
+                        rd_kafka_buf_skip_tags(rkbuf);
+
+                        err = group_err;
+                        if (!err) {
+                                member = rd_kafka_mock_cgrp_classic_member_find(
+                                    mcgrp, &MemberId);
+                                if (!member)
+                                        err =
+                                            RD_KAFKA_RESP_ERR_UNKNOWN_MEMBER_ID;
+                        }
+
+                        if (!err)
+                                err = rd_kafka_mock_cgrp_classic_check_state(
+                                    mcgrp, member, rkbuf, -1);
+
+                        if (!err)
+                                rd_kafka_mock_cgrp_classic_member_leave(mcgrp,
+                                                                        member);
+
+                        rd_kafka_buf_write_kstr(resp, &MemberId);
+                        rd_kafka_buf_write_kstr(resp, &GroupInstanceId);
+                        rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
+                        rd_kafka_buf_write_tags_empty(resp);
+                }
         }
-
-        if (!err)
-                err = rd_kafka_mock_cgrp_classic_check_state(mcgrp, member,
-                                                             rkbuf, -1);
-
-        if (!err)
-                rd_kafka_mock_cgrp_classic_member_leave(mcgrp, member);
-
-        rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
 
         rd_kafka_mock_connection_send_response(mconn, resp);
 

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -1599,7 +1599,7 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
         if (rkbuf->rkbuf_reqhdr.ApiVersion >= 5)
                 rd_kafka_buf_read_str(rkbuf, &GroupInstanceId);
         rd_kafka_buf_read_str(rkbuf, &ProtocolType);
-        rd_kafka_buf_read_i32(rkbuf, &ProtocolCnt);
+        rd_kafka_buf_read_arraycnt(rkbuf, &ProtocolCnt, 1000);
 
         if (ProtocolCnt > 1000) {
                 rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
@@ -1616,6 +1616,7 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
                 rd_kafkap_bytes_t Metadata;
                 rd_kafka_buf_read_str(rkbuf, &ProtocolName);
                 rd_kafka_buf_read_kbytes(rkbuf, &Metadata);
+                rd_kafka_buf_skip_tags(rkbuf);
                 protos[i].name     = rd_kafkap_str_copy(&ProtocolName);
                 protos[i].metadata = rd_kafkap_bytes_copy(&Metadata);
         }
@@ -1662,12 +1663,14 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
         rd_kafka_mock_cgrp_classic_protos_destroy(protos, ProtocolCnt);
 
         /* Error case */
-        rd_kafka_buf_write_i16(resp, err);      /* ErrorCode */
-        rd_kafka_buf_write_i32(resp, -1);       /* GenerationId */
-        rd_kafka_buf_write_str(resp, NULL, -1); /* ProtocolName */
-        rd_kafka_buf_write_str(resp, NULL, -1); /* LeaderId */
-        rd_kafka_buf_write_kstr(resp, NULL);    /* MemberId */
-        rd_kafka_buf_write_i32(resp, 0);        /* MemberCnt */
+        rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
+        rd_kafka_buf_write_i32(resp, -1);  /* GenerationId */
+        if (rkbuf->rkbuf_reqhdr.ApiVersion >= 7)
+                rd_kafka_buf_write_kstr(resp, NULL); /* ProtocolType */
+        rd_kafka_buf_write_str(resp, NULL, -1);      /* ProtocolName */
+        rd_kafka_buf_write_str(resp, NULL, -1);      /* LeaderId */
+        rd_kafka_buf_write_kstr(resp, NULL);         /* MemberId */
+        rd_kafka_buf_write_arraycnt(resp, 0);        /* MemberCnt */
 
         rd_kafka_mock_connection_send_response(mconn, resp);
 
@@ -5204,7 +5207,7 @@ const struct rd_kafka_mock_api_handler
                                        rd_kafka_mock_handle_FindCoordinator},
         [RD_KAFKAP_InitProducerId]  = {0, 4, 2,
                                        rd_kafka_mock_handle_InitProducerId},
-        [RD_KAFKAP_JoinGroup]       = {0, 6, 6, rd_kafka_mock_handle_JoinGroup},
+        [RD_KAFKAP_JoinGroup]       = {0, 7, 6, rd_kafka_mock_handle_JoinGroup},
         [RD_KAFKAP_Heartbeat]       = {0, 5, 4, rd_kafka_mock_handle_Heartbeat},
         [RD_KAFKAP_LeaveGroup] = {0, 4, 4, rd_kafka_mock_handle_LeaveGroup},
         [RD_KAFKAP_SyncGroup]  = {0, 5, 4, rd_kafka_mock_handle_SyncGroup},

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -1895,7 +1895,12 @@ static int rd_kafka_mock_handle_SyncGroup(rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_read_str(rkbuf, &MemberId);
         if (rkbuf->rkbuf_reqhdr.ApiVersion >= 3)
                 rd_kafka_buf_read_str(rkbuf, &GroupInstanceId);
-        rd_kafka_buf_read_i32(rkbuf, &AssignmentCnt);
+        if (rkbuf->rkbuf_reqhdr.ApiVersion >= 5) {
+                rd_kafkap_str_t ProtocolType, ProtocolName;
+                rd_kafka_buf_read_str(rkbuf, &ProtocolType);
+                rd_kafka_buf_read_str(rkbuf, &ProtocolName);
+        }
+        rd_kafka_buf_read_arraycnt(rkbuf, &AssignmentCnt, 100000);
 
         /*
          * Construct response
@@ -1955,6 +1960,7 @@ static int rd_kafka_mock_handle_SyncGroup(rd_kafka_mock_connection_t *mconn,
 
                 rd_kafka_buf_read_str(rkbuf, &MemberId2);
                 rd_kafka_buf_read_kbytes(rkbuf, &Metadata);
+                rd_kafka_buf_skip_tags(rkbuf);
 
                 if (err)
                         continue;
@@ -1979,8 +1985,12 @@ static int rd_kafka_mock_handle_SyncGroup(rd_kafka_mock_connection_t *mconn,
         }
 
         /* Error case */
-        rd_kafka_buf_write_i16(resp, err);        /* ErrorCode */
-        rd_kafka_buf_write_bytes(resp, NULL, -1); /* MemberState */
+        rd_kafka_buf_write_i16(resp, err); /* ErrorCode */
+        if (rkbuf->rkbuf_reqhdr.ApiVersion >= 5) {
+                rd_kafka_buf_write_kstr(resp, NULL); /* ProtocolType */
+                rd_kafka_buf_write_kstr(resp, NULL); /* ProtocolName */
+        }
+        rd_kafka_buf_write_kbytes(resp, NULL); /* MemberState */
 
         rd_kafka_mock_connection_send_response(mconn, resp);
 
@@ -5197,7 +5207,7 @@ const struct rd_kafka_mock_api_handler
         [RD_KAFKAP_JoinGroup]       = {0, 6, 6, rd_kafka_mock_handle_JoinGroup},
         [RD_KAFKAP_Heartbeat]       = {0, 5, 4, rd_kafka_mock_handle_Heartbeat},
         [RD_KAFKAP_LeaveGroup] = {0, 4, 4, rd_kafka_mock_handle_LeaveGroup},
-        [RD_KAFKAP_SyncGroup]  = {0, 4, 4, rd_kafka_mock_handle_SyncGroup},
+        [RD_KAFKAP_SyncGroup]  = {0, 5, 4, rd_kafka_mock_handle_SyncGroup},
         [RD_KAFKAP_AddPartitionsToTxn] =
             {0, 1, -1, rd_kafka_mock_handle_AddPartitionsToTxn},
         [RD_KAFKAP_AddOffsetsToTxn] = {0, 1, -1,

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -2646,6 +2646,12 @@ rd_kafka_mock_handle_OffsetForLeaderEpoch(rd_kafka_mock_connection_t *mconn,
         /* Response: ThrottleTimeMs */
         rd_kafka_buf_write_i32(resp, 0);
 
+        if (rkbuf->rkbuf_reqhdr.ApiVersion >= 3) {
+                int32_t ReplicaId;
+                /* ReplicaId */
+                rd_kafka_buf_read_i32(rkbuf, &ReplicaId);
+        }
+
         /* #Topics */
         rd_kafka_buf_read_arraycnt(rkbuf, &TopicsCnt, RD_KAFKAP_TOPICS_MAX);
 
@@ -2686,6 +2692,7 @@ rd_kafka_mock_handle_OffsetForLeaderEpoch(rd_kafka_mock_connection_t *mconn,
                         rd_kafka_buf_read_i32(rkbuf, &CurrentLeaderEpoch);
                         /* LeaderEpoch */
                         rd_kafka_buf_read_i32(rkbuf, &LeaderEpoch);
+                        rd_kafka_buf_skip_tags(rkbuf); /* Partition tags */
 
                         mpart = rd_kafka_mock_partition_find(mtopic, Partition);
                         if (!err && !mpart)
@@ -2710,7 +2717,12 @@ rd_kafka_mock_handle_OffsetForLeaderEpoch(rd_kafka_mock_connection_t *mconn,
                         rd_kafka_buf_write_i32(resp, LeaderEpoch);
                         /* Response: Partition */
                         rd_kafka_buf_write_i64(resp, EndOffset);
+                        rd_kafka_buf_write_tags_empty(
+                            resp); /* Partition-result tags */
                 }
+
+                rd_kafka_buf_skip_tags(rkbuf);       /* Topic tags */
+                rd_kafka_buf_write_tags_empty(resp); /* Topic-result tags */
         }
 
         rd_kafka_mock_connection_send_response(mconn, resp);
@@ -5223,7 +5235,7 @@ const struct rd_kafka_mock_api_handler
                                        rd_kafka_mock_handle_TxnOffsetCommit},
         [RD_KAFKAP_EndTxn]          = {0, 3, 3, rd_kafka_mock_handle_EndTxn},
         [RD_KAFKAP_OffsetForLeaderEpoch] =
-            {2, 2, -1, rd_kafka_mock_handle_OffsetForLeaderEpoch},
+            {2, 4, 4, rd_kafka_mock_handle_OffsetForLeaderEpoch},
         [RD_KAFKAP_ConsumerGroupHeartbeat] =
             {1, 1, 1, rd_kafka_mock_handle_ConsumerGroupHeartbeat},
         [RD_KAFKAP_ShareGroupHeartbeat] =

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -5217,7 +5217,7 @@ const struct rd_kafka_mock_api_handler
         [RD_KAFKAP_SyncGroup]  = {0, 5, 4, rd_kafka_mock_handle_SyncGroup},
         [RD_KAFKAP_AddPartitionsToTxn] =
             {0, 3, 3, rd_kafka_mock_handle_AddPartitionsToTxn},
-        [RD_KAFKAP_AddOffsetsToTxn] = {0, 1, -1,
+        [RD_KAFKAP_AddOffsetsToTxn] = {0, 3, 3,
                                        rd_kafka_mock_handle_AddOffsetsToTxn},
         [RD_KAFKAP_TxnOffsetCommit] = {0, 3, 3,
                                        rd_kafka_mock_handle_TxnOffsetCommit},

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -5221,7 +5221,7 @@ const struct rd_kafka_mock_api_handler
                                        rd_kafka_mock_handle_AddOffsetsToTxn},
         [RD_KAFKAP_TxnOffsetCommit] = {0, 3, 3,
                                        rd_kafka_mock_handle_TxnOffsetCommit},
-        [RD_KAFKAP_EndTxn]          = {0, 1, -1, rd_kafka_mock_handle_EndTxn},
+        [RD_KAFKAP_EndTxn]          = {0, 3, 3, rd_kafka_mock_handle_EndTxn},
         [RD_KAFKAP_OffsetForLeaderEpoch] =
             {2, 2, -1, rd_kafka_mock_handle_OffsetForLeaderEpoch},
         [RD_KAFKAP_ConsumerGroupHeartbeat] =

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3594,22 +3594,26 @@ void rd_kafka_SaslAuthenticateRequest(rd_kafka_broker_t *rkb,
         rd_kafka_buf_t *rkbuf;
         int16_t ApiVersion;
         int features;
+        /* Broker does not support -1 (Null) for this field */
+        const rd_kafkap_bytes_t AuthBytes = {.len  = (int32_t)size,
+                                             .data = buf ? buf : ""};
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_SaslAuthenticate, 0, 0);
+        ApiVersion = rd_kafka_broker_ApiVersion_supported(
+            rkb, RD_KAFKAP_SaslAuthenticate, 0, 2, &features);
+
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_SaslAuthenticate, 0, 0, ApiVersion >= 2);
 
         /* Should be sent before any other requests since it is part of
          * the initial connection handshake. */
         rkbuf->rkbuf_prio = RD_KAFKA_PRIO_FLASH;
 
-        /* Broker does not support -1 (Null) for this field */
-        rd_kafka_buf_write_bytes(rkbuf, buf ? buf : "", size);
+        rd_kafka_buf_write_kbytes(rkbuf, &AuthBytes);
 
         /* There are no errors that can be retried, instead
          * close down the connection and reconnect on failure. */
         rkbuf->rkbuf_max_retries = RD_KAFKA_REQUEST_NO_RETRIES;
 
-        ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_SaslAuthenticate, 0, 1, &features);
         rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
 
         if (replyq.q)

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1960,6 +1960,7 @@ rd_kafka_group_MemberState_consumer_write(rd_kafka_buf_t *env_rkbuf,
                                           const rd_kafka_group_member_t *rkgm) {
         rd_kafka_buf_t *rkbuf;
         rd_slice_t slice;
+        size_t len;
 
         rkbuf = rd_kafka_buf_new(1, 100);
         rd_kafka_buf_write_i16(rkbuf, 0); /* Version */
@@ -1976,9 +1977,15 @@ rd_kafka_group_MemberState_consumer_write(rd_kafka_buf_t *env_rkbuf,
 
         /* Get pointer to binary buffer */
         rd_slice_init_full(&slice, &rkbuf->rkbuf_buf);
+        len = rd_slice_remains(&slice);
 
-        /* Write binary buffer as Kafka Bytes to enveloping buffer. */
-        rd_kafka_buf_write_i32(env_rkbuf, (int32_t)rd_slice_remains(&slice));
+        /* Write binary buffer as Kafka Bytes, or KIP-482 COMPACT_BYTES if
+         * the enveloping buffer is a flexible-version request, to the
+         * enveloping buffer. */
+        if (env_rkbuf->rkbuf_flags & RD_KAFKA_OP_F_FLEXVER)
+                rd_kafka_buf_write_uvarint(env_rkbuf, (uint64_t)(len + 1));
+        else
+                rd_kafka_buf_write_i32(env_rkbuf, (int32_t)len);
         rd_buf_write_slice(&env_rkbuf->rkbuf_buf, &slice);
 
         rd_kafka_buf_destroy(rkbuf);
@@ -2003,27 +2010,33 @@ void rd_kafka_SyncGroupRequest(rd_kafka_broker_t *rkb,
         int features;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_SyncGroup, 0, 3, &features);
+            rkb, RD_KAFKAP_SyncGroup, 0, 5, &features);
 
-        rkbuf = rd_kafka_buf_new_request(
+        rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_SyncGroup, 1,
             RD_KAFKAP_STR_SIZE(group_id) + 4 /* GenerationId */ +
                 RD_KAFKAP_STR_SIZE(member_id) +
                 RD_KAFKAP_STR_SIZE(group_instance_id) +
                 4 /* array size group_assignment */ +
-                (assignment_cnt * 100 /*guess*/));
+                (assignment_cnt * 100 /*guess*/),
+            ApiVersion >= 4);
         rd_kafka_buf_write_kstr(rkbuf, group_id);
         rd_kafka_buf_write_i32(rkbuf, generation_id);
         rd_kafka_buf_write_kstr(rkbuf, member_id);
         if (ApiVersion >= 3)
                 rd_kafka_buf_write_kstr(rkbuf, group_instance_id);
-        rd_kafka_buf_write_i32(rkbuf, assignment_cnt);
+        if (ApiVersion >= 5) {
+                rd_kafka_buf_write_kstr(rkbuf, NULL); /* ProtocolType */
+                rd_kafka_buf_write_kstr(rkbuf, NULL); /* ProtocolName */
+        }
+        rd_kafka_buf_write_arraycnt(rkbuf, assignment_cnt);
 
         for (i = 0; i < assignment_cnt; i++) {
                 const rd_kafka_group_member_t *rkgm = &assignments[i];
 
                 rd_kafka_buf_write_kstr(rkbuf, rkgm->rkgm_member_id);
                 rd_kafka_group_MemberState_consumer_write(rkbuf, rkgm);
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Assignment tags */
         }
 
         /* This is a blocking request */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2074,17 +2074,18 @@ void rd_kafka_JoinGroupRequest(rd_kafka_broker_t *rkb,
         int features;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_JoinGroup, 0, 5, &features);
+            rkb, RD_KAFKAP_JoinGroup, 0, 7, &features);
 
 
-        rkbuf = rd_kafka_buf_new_request(
+        rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_JoinGroup, 1,
             RD_KAFKAP_STR_SIZE(group_id) + 4 /* sessionTimeoutMs */ +
                 4 /* rebalanceTimeoutMs */ + RD_KAFKAP_STR_SIZE(member_id) +
                 RD_KAFKAP_STR_SIZE(group_instance_id) +
                 RD_KAFKAP_STR_SIZE(protocol_type) +
                 4 /* array count GroupProtocols */ +
-                (rd_list_cnt(topics) * 100));
+                (rd_list_cnt(topics) * 100),
+            ApiVersion >= 6);
         rd_kafka_buf_write_kstr(rkbuf, group_id);
         rd_kafka_buf_write_i32(rkbuf, rk->rk_conf.group_session_timeout_ms);
         if (ApiVersion >= 1)
@@ -2093,7 +2094,7 @@ void rd_kafka_JoinGroupRequest(rd_kafka_broker_t *rkb,
         if (ApiVersion >= 5)
                 rd_kafka_buf_write_kstr(rkbuf, group_instance_id);
         rd_kafka_buf_write_kstr(rkbuf, protocol_type);
-        rd_kafka_buf_write_i32(rkbuf, rk->rk_conf.enabled_assignor_cnt);
+        rd_kafka_buf_write_arraycnt(rkbuf, rk->rk_conf.enabled_assignor_cnt);
 
         RD_LIST_FOREACH(rkas, &rk->rk_conf.partition_assignors, i) {
                 rd_kafkap_bytes_t *member_metadata;
@@ -2106,6 +2107,7 @@ void rd_kafka_JoinGroupRequest(rd_kafka_broker_t *rkb,
                     rk->rk_conf.client_rack);
                 rd_kafka_buf_write_kbytes(rkbuf, member_metadata);
                 rd_kafkap_bytes_destroy(member_metadata);
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Protocol tags */
         }
 
         rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6678,7 +6678,7 @@ rd_kafka_AddOffsetsToTxnRequest(rd_kafka_broker_t *rkb,
         int16_t ApiVersion = 0;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_AddOffsetsToTxn, 0, 0, NULL);
+            rkb, RD_KAFKAP_AddOffsetsToTxn, 0, 3, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "AddOffsetsToTxnRequest (KIP-98) not supported "
@@ -6687,8 +6687,8 @@ rd_kafka_AddOffsetsToTxnRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf =
-            rd_kafka_buf_new_request(rkb, RD_KAFKAP_AddOffsetsToTxn, 1, 100);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_AddOffsetsToTxn,
+                                                 1, 100, ApiVersion >= 3);
 
         /* transactional_id */
         rd_kafka_buf_write_str(rkbuf, transactional_id, -1);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2247,16 +2247,17 @@ void rd_kafka_HeartbeatRequest(rd_kafka_broker_t *rkb,
         int features;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_Heartbeat, 0, 3, &features);
+            rkb, RD_KAFKAP_Heartbeat, 0, 4, &features);
 
         rd_rkb_dbg(rkb, CGRP, "HEARTBEAT",
                    "Heartbeat for group \"%s\" generation id %" PRId32,
                    group_id->str, generation_id);
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_Heartbeat, 1,
-                                         RD_KAFKAP_STR_SIZE(group_id) +
-                                             4 /* GenerationId */ +
-                                             RD_KAFKAP_STR_SIZE(member_id));
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_Heartbeat, 1,
+            RD_KAFKAP_STR_SIZE(group_id) + 4 /* GenerationId */ +
+                RD_KAFKAP_STR_SIZE(member_id),
+            ApiVersion >= 4);
 
         rd_kafka_buf_write_kstr(rkbuf, group_id);
         rd_kafka_buf_write_i32(rkbuf, generation_id);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -604,13 +604,14 @@ rd_kafka_FindCoordinatorRequest(rd_kafka_broker_t *rkb,
         int16_t ApiVersion;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_FindCoordinator, 0, 2, NULL);
+            rkb, RD_KAFKAP_FindCoordinator, 0, 3, NULL);
 
         if (coordtype != RD_KAFKA_COORD_GROUP && ApiVersion < 1)
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_FindCoordinator, 1,
-                                         1 + 2 + strlen(coordkey));
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_FindCoordinator,
+                                                 1, 1 + 2 + strlen(coordkey),
+                                                 ApiVersion >= 3);
 
         rd_kafka_buf_write_str(rkbuf, coordkey, -1);
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2152,6 +2152,7 @@ void rd_kafka_JoinGroupRequest(rd_kafka_broker_t *rkb,
 void rd_kafka_LeaveGroupRequest(rd_kafka_broker_t *rkb,
                                 const char *group_id,
                                 const char *member_id,
+                                const rd_kafkap_str_t *group_instance_id,
                                 rd_kafka_replyq_t replyq,
                                 rd_kafka_resp_cb_t *resp_cb,
                                 void *opaque) {
@@ -2160,12 +2161,22 @@ void rd_kafka_LeaveGroupRequest(rd_kafka_broker_t *rkb,
         int features;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_LeaveGroup, 0, 1, &features);
+            rkb, RD_KAFKAP_LeaveGroup, 0, 4, &features);
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_LeaveGroup, 1, 300);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_LeaveGroup, 1,
+                                                 300, ApiVersion >= 4);
 
         rd_kafka_buf_write_str(rkbuf, group_id, -1);
-        rd_kafka_buf_write_str(rkbuf, member_id, -1);
+
+        if (ApiVersion <= 2) {
+                rd_kafka_buf_write_str(rkbuf, member_id, -1);
+        } else {
+                /* #Members */
+                rd_kafka_buf_write_arraycnt(rkbuf, 1);
+                rd_kafka_buf_write_str(rkbuf, member_id, -1);
+                rd_kafka_buf_write_kstr(rkbuf, group_instance_id);
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Member tags */
+        }
 
         rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
 
@@ -2200,7 +2211,30 @@ void rd_kafka_handle_LeaveGroup(rd_kafka_t *rk,
                 goto err;
         }
 
+        if (request->rkbuf_reqhdr.ApiVersion >= 1)
+                rd_kafka_buf_read_throttle_time(rkbuf);
+
         rd_kafka_buf_read_i16(rkbuf, &ErrorCode);
+
+        if (request->rkbuf_reqhdr.ApiVersion >= 3) {
+                int32_t member_cnt;
+                int32_t i;
+
+                rd_kafka_buf_read_arraycnt(rkbuf, &member_cnt, 1000000);
+
+                for (i = 0; i < member_cnt; i++) {
+                        rd_kafkap_str_t MemberId, GroupInstanceId;
+                        int16_t MemberErrorCode;
+
+                        rd_kafka_buf_read_str(rkbuf, &MemberId);
+                        rd_kafka_buf_read_str(rkbuf, &GroupInstanceId);
+                        rd_kafka_buf_read_i16(rkbuf, &MemberErrorCode);
+                        rd_kafka_buf_skip_tags(rkbuf);
+
+                        if (MemberErrorCode && !ErrorCode)
+                                ErrorCode = MemberErrorCode;
+                }
+        }
 
 err:
         actions = rd_kafka_err_action(rkb, ErrorCode, request,

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6585,7 +6585,7 @@ rd_kafka_AddPartitionsToTxnRequest(rd_kafka_broker_t *rkb,
         int TopicCnt = 0, PartCnt = 0;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_AddPartitionsToTxn, 0, 0, NULL);
+            rkb, RD_KAFKAP_AddPartitionsToTxn, 0, 3, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "AddPartitionsToTxnRequest (KIP-98) not supported "
@@ -6594,8 +6594,8 @@ rd_kafka_AddPartitionsToTxnRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf =
-            rd_kafka_buf_new_request(rkb, RD_KAFKAP_AddPartitionsToTxn, 1, 500);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_AddPartitionsToTxn, 1, 500, ApiVersion >= 3);
 
         /* transactional_id */
         rd_kafka_buf_write_str(rkbuf, transactional_id, -1);
@@ -6605,15 +6605,17 @@ rd_kafka_AddPartitionsToTxnRequest(rd_kafka_broker_t *rkb,
         rd_kafka_buf_write_i16(rkbuf, pid.epoch);
 
         /* Topics/partitions array (count updated later) */
-        of_TopicCnt = rd_kafka_buf_write_i32(rkbuf, 0);
+        of_TopicCnt = rd_kafka_buf_write_arraycnt_pos(rkbuf);
 
         TAILQ_FOREACH(rktp, rktps, rktp_txnlink) {
                 if (last_rkt != rktp->rktp_rkt) {
 
                         if (last_rkt) {
                                 /* Update last topic's partition count field */
-                                rd_kafka_buf_update_i32(rkbuf, of_PartCnt,
-                                                        PartCnt);
+                                rd_kafka_buf_finalize_arraycnt(
+                                    rkbuf, of_PartCnt, PartCnt);
+                                rd_kafka_buf_write_tags_empty(
+                                    rkbuf); /* Topic tags */
                                 of_PartCnt = -1;
                         }
 
@@ -6621,7 +6623,7 @@ rd_kafka_AddPartitionsToTxnRequest(rd_kafka_broker_t *rkb,
                         rd_kafka_buf_write_kstr(rkbuf,
                                                 rktp->rktp_rkt->rkt_topic);
                         /* Partition count, updated later */
-                        of_PartCnt = rd_kafka_buf_write_i32(rkbuf, 0);
+                        of_PartCnt = rd_kafka_buf_write_arraycnt_pos(rkbuf);
 
                         PartCnt = 0;
                         TopicCnt++;
@@ -6634,9 +6636,12 @@ rd_kafka_AddPartitionsToTxnRequest(rd_kafka_broker_t *rkb,
         }
 
         /* Update last partition and topic count fields */
-        if (of_PartCnt != -1)
-                rd_kafka_buf_update_i32(rkbuf, (size_t)of_PartCnt, PartCnt);
-        rd_kafka_buf_update_i32(rkbuf, of_TopicCnt, TopicCnt);
+        if (of_PartCnt != -1) {
+                rd_kafka_buf_finalize_arraycnt(rkbuf, (size_t)of_PartCnt,
+                                               PartCnt);
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Topic tags */
+        }
+        rd_kafka_buf_finalize_arraycnt(rkbuf, of_TopicCnt, TopicCnt);
 
         rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5809,7 +5809,7 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DescribeConfigs, 0, 1, NULL);
+            rkb, RD_KAFKAP_DescribeConfigs, 0, 4, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "DescribeConfigs (KIP-133) not supported "
@@ -5818,11 +5818,12 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_DescribeConfigs, 1,
-                                         rd_list_cnt(configs) * 200);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DescribeConfigs,
+                                                 1, rd_list_cnt(configs) * 200,
+                                                 ApiVersion >= 4);
 
         /* #resources */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(configs));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(configs));
 
         RD_LIST_FOREACH(config, configs, i) {
                 const rd_kafka_ConfigEntry_t *entry;
@@ -5839,23 +5840,31 @@ rd_kafka_resp_err_t rd_kafka_DescribeConfigsRequest(
                 /* #config */
                 if (rd_list_empty(&config->config)) {
                         /* Get all configs */
-                        rd_kafka_buf_write_i32(rkbuf, -1);
+                        rd_kafka_buf_write_arraycnt(rkbuf, -1);
                 } else {
                         /* Get requested configs only */
-                        rd_kafka_buf_write_i32(rkbuf,
-                                               rd_list_cnt(&config->config));
+                        rd_kafka_buf_write_arraycnt(
+                            rkbuf, rd_list_cnt(&config->config));
                 }
 
                 RD_LIST_FOREACH(entry, &config->config, ei) {
                         /* config_name */
                         rd_kafka_buf_write_str(rkbuf, entry->kv->name, -1);
                 }
+
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Resource tags */
         }
 
 
-        if (ApiVersion == 1) {
+        if (ApiVersion >= 1) {
                 /* include_synonyms */
                 rd_kafka_buf_write_i8(rkbuf, 1);
+        }
+
+        if (ApiVersion >= 3) {
+                /* include_documentation: not exposed to the caller, so
+                 * don't ask the broker to include it. */
+                rd_kafka_buf_write_i8(rkbuf, 0);
         }
 
         /* timeout */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1130,7 +1130,7 @@ void rd_kafka_OffsetForLeaderEpochRequest(
         int16_t ApiVersion;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_OffsetForLeaderEpoch, 2, 2, NULL);
+            rkb, RD_KAFKAP_OffsetForLeaderEpoch, 2, 4, NULL);
         /* If the supported ApiVersions are not yet known,
          * or this broker doesn't support it, we let this request
          * succeed or fail later from the broker thread where the
@@ -1141,6 +1141,10 @@ void rd_kafka_OffsetForLeaderEpochRequest(
         rkbuf = rd_kafka_buf_new_flexver_request(
             rkb, RD_KAFKAP_OffsetForLeaderEpoch, 1, 4 + (parts->cnt * 64),
             ApiVersion >= 4 /*flexver*/);
+
+        if (ApiVersion >= 3)
+                /* ReplicaId: -1 for a normal consumer/client. */
+                rd_kafka_buf_write_i32(rkbuf, -1);
 
         /* Sort partitions by topic */
         rd_kafka_topic_partition_list_sort_by_topic(parts);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5387,7 +5387,7 @@ rd_kafka_DeleteTopicsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_DeleteTopics, 0, 4, &features);
+            rkb, RD_KAFKAP_DeleteTopics, 0, 6, &features);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "Topic Admin API (KIP-4) not supported "
@@ -5404,8 +5404,15 @@ rd_kafka_DeleteTopicsRequest(rd_kafka_broker_t *rkb,
         /* #topics */
         rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(del_topics));
 
-        while ((delt = rd_list_elem(del_topics, i++)))
+        while ((delt = rd_list_elem(del_topics, i++))) {
                 rd_kafka_buf_write_str(rkbuf, delt->topic, -1);
+                if (ApiVersion >= 6) {
+                        rd_kafka_Uuid_t zero_uuid = RD_KAFKA_UUID_ZERO;
+                        /* TopicId: librdkafka only deletes by name. */
+                        rd_kafka_buf_write_uuid(rkbuf, &zero_uuid);
+                        rd_kafka_buf_write_tags_empty(rkbuf);
+                }
+        }
 
         /* timeout */
         op_timeout = rd_kafka_confval_get_int(&options->operation_timeout);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5214,7 +5214,7 @@ rd_kafka_CreateTopicsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_CreateTopics, 0, 4, &features);
+            rkb, RD_KAFKAP_CreateTopics, 0, 7, &features);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "Topic Admin API (KIP-4) not supported "
@@ -5232,12 +5232,12 @@ rd_kafka_CreateTopicsRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_CreateTopics, 1,
-                                         4 + (rd_list_cnt(new_topics) * 200) +
-                                             4 + 1);
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_CreateTopics, 1,
+            4 + (rd_list_cnt(new_topics) * 200) + 4 + 1, ApiVersion >= 5);
 
         /* #topics */
-        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(new_topics));
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(new_topics));
 
         while ((newt = rd_list_elem(new_topics, i++))) {
                 int partition;
@@ -5287,7 +5287,8 @@ rd_kafka_CreateTopicsRequest(rd_kafka_broker_t *rkb,
                 }
 
                 /* #replica_assignment */
-                rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(&newt->replicas));
+                rd_kafka_buf_write_arraycnt(rkbuf,
+                                            rd_list_cnt(&newt->replicas));
 
                 /* Replicas per partition, see rdkafka_admin.[ch]
                  * for how these are constructed. */
@@ -5303,24 +5304,31 @@ rd_kafka_CreateTopicsRequest(rd_kafka_broker_t *rkb,
                         /* partition */
                         rd_kafka_buf_write_i32(rkbuf, partition);
                         /* #replicas */
-                        rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(replicas));
+                        rd_kafka_buf_write_arraycnt(rkbuf,
+                                                    rd_list_cnt(replicas));
 
                         for (ri = 0; ri < rd_list_cnt(replicas); ri++) {
                                 /* replica */
                                 rd_kafka_buf_write_i32(
                                     rkbuf, rd_list_get_int32(replicas, ri));
                         }
+
+                        rd_kafka_buf_write_tags_empty(
+                            rkbuf); /* Assignment tags */
                 }
 
                 /* #config_entries */
-                rd_kafka_buf_write_i32(rkbuf, rd_list_cnt(&newt->config));
+                rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(&newt->config));
 
                 RD_LIST_FOREACH(entry, &newt->config, ei) {
                         /* config_name */
                         rd_kafka_buf_write_str(rkbuf, entry->kv->name, -1);
                         /* config_value (nullable) */
                         rd_kafka_buf_write_str(rkbuf, entry->kv->value, -1);
+                        rd_kafka_buf_write_tags_empty(rkbuf); /* Config tags */
                 }
+
+                rd_kafka_buf_write_tags_empty(rkbuf); /* Topic tags */
         }
 
         /* timeout */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6733,7 +6733,7 @@ rd_kafka_resp_err_t rd_kafka_EndTxnRequest(rd_kafka_broker_t *rkb,
         int16_t ApiVersion = 0;
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(rkb, RD_KAFKAP_EndTxn,
-                                                          0, 1, NULL);
+                                                          0, 3, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "EndTxnRequest (KIP-98) not supported "
@@ -6742,7 +6742,8 @@ rd_kafka_resp_err_t rd_kafka_EndTxnRequest(rd_kafka_broker_t *rkb,
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 
-        rkbuf = rd_kafka_buf_new_request(rkb, RD_KAFKAP_EndTxn, 1, 500);
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_EndTxn, 1, 500,
+                                                 ApiVersion >= 3);
 
         /* transactional_id */
         rd_kafka_buf_write_str(rkbuf, transactional_id, -1);

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -5534,7 +5534,7 @@ rd_kafka_CreatePartitionsRequest(rd_kafka_broker_t *rkb,
         }
 
         ApiVersion = rd_kafka_broker_ApiVersion_supported(
-            rkb, RD_KAFKAP_CreatePartitions, 0, 2, NULL);
+            rkb, RD_KAFKAP_CreatePartitions, 0, 3, NULL);
         if (ApiVersion == -1) {
                 rd_snprintf(errstr, errstr_size,
                             "CreatePartitions (KIP-195) not supported "

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -327,6 +327,7 @@ void rd_kafka_JoinGroupRequest(rd_kafka_broker_t *rkb,
 void rd_kafka_LeaveGroupRequest(rd_kafka_broker_t *rkb,
                                 const char *group_id,
                                 const char *member_id,
+                                const rd_kafkap_str_t *group_instance_id,
                                 rd_kafka_replyq_t replyq,
                                 rd_kafka_resp_cb_t *resp_cb,
                                 void *opaque);

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -842,7 +842,7 @@ static void rd_kafka_txn_handle_AddPartitionsToTxn(rd_kafka_t *rk,
 
         rd_kafka_buf_read_throttle_time(rkbuf);
 
-        rd_kafka_buf_read_i32(rkbuf, &TopicCnt);
+        rd_kafka_buf_read_arraycnt(rkbuf, &TopicCnt, 100000);
 
         while (TopicCnt-- > 0) {
                 rd_kafkap_str_t Topic;
@@ -851,7 +851,7 @@ static void rd_kafka_txn_handle_AddPartitionsToTxn(rd_kafka_t *rk,
                 rd_bool_t request_error = rd_false;
 
                 rd_kafka_buf_read_str(rkbuf, &Topic);
-                rd_kafka_buf_read_i32(rkbuf, &PartCnt);
+                rd_kafka_buf_read_arraycnt(rkbuf, &PartCnt, 100000);
 
                 rkt = rd_kafka_topic_find0(rk, &Topic);
                 if (rkt)
@@ -865,6 +865,7 @@ static void rd_kafka_txn_handle_AddPartitionsToTxn(rd_kafka_t *rk,
 
                         rd_kafka_buf_read_i32(rkbuf, &Partition);
                         rd_kafka_buf_read_i16(rkbuf, &ErrorCode);
+                        rd_kafka_buf_skip_tags(rkbuf);
 
                         if (rkt)
                                 rktp = rd_kafka_toppar_get(rkt, Partition,
@@ -983,6 +984,9 @@ static void rd_kafka_txn_handle_AddPartitionsToTxn(rd_kafka_t *rk,
                         rd_kafka_topic_rdunlock(rkt);
                         rd_kafka_topic_destroy0(rkt);
                 }
+
+                if (!request_error)
+                        rd_kafka_buf_skip_tags(rkbuf);
 
                 if (request_error)
                         break; /* Request-level error seen, bail out */

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3828,6 +3828,59 @@ do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_bool_t times_out) {
 }
 
 
+/**
+ * @brief Verify that a full transaction (AddPartitionsToTxn,
+ *        AddOffsetsToTxn, EndTxn) completes successfully when the mock
+ *        transaction coordinator only accepts the raised protocol version
+ *        ceiling (v3, the first KIP-482 flexible version) for those three
+ *        APIs, proving librdkafka actually emits, and can parse the
+ *        response of, that exact version end-to-end.
+ */
+static void do_test_txn_flexver(void) {
+        rd_kafka_t *rk;
+        rd_kafka_mock_cluster_t *mcluster;
+        rd_kafka_topic_partition_list_t *offsets;
+        rd_kafka_consumer_group_metadata_t *cgmetadata;
+        const char *groupid = "myGroupId";
+        const char *txnid   = "flexverTxnId";
+
+        SUB_TEST_QUICK();
+
+        rk = create_txn_producer(&mcluster, txnid, 3, NULL);
+
+        TEST_CALL_ERR__(rd_kafka_mock_set_apiversion(
+            mcluster, RD_KAFKAP_AddPartitionsToTxn, 3, 3));
+        TEST_CALL_ERR__(rd_kafka_mock_set_apiversion(
+            mcluster, RD_KAFKAP_AddOffsetsToTxn, 3, 3));
+        TEST_CALL_ERR__(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_EndTxn, 3, 3));
+
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, 5000));
+
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(rk));
+
+        TEST_CALL_ERR__(rd_kafka_producev(
+            rk, RD_KAFKA_V_TOPIC("mytopic"), RD_KAFKA_V_PARTITION(0),
+            RD_KAFKA_V_VALUE("hi", 2), RD_KAFKA_V_END));
+
+        offsets = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(offsets, "srctopic4", 0)->offset =
+            123;
+
+        cgmetadata = rd_kafka_consumer_group_metadata_new(groupid);
+        TEST_CALL_ERROR__(
+            rd_kafka_send_offsets_to_transaction(rk, offsets, cgmetadata, -1));
+        rd_kafka_consumer_group_metadata_destroy(cgmetadata);
+        rd_kafka_topic_partition_list_destroy(offsets);
+
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(rk, -1));
+
+        rd_kafka_destroy(rk);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0105_transactions_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -3844,6 +3897,8 @@ int main_0105_transactions_mock(int argc, char **argv) {
 
         do_test_txn_slow_reinit(rd_false);
         do_test_txn_slow_reinit(rd_true);
+
+        do_test_txn_flexver();
 
         /* Just do a subset of tests in quick mode */
         if (test_quick)

--- a/tests/0139-offset_validation_mock.c
+++ b/tests/0139-offset_validation_mock.c
@@ -924,6 +924,68 @@ static void do_test_list_offsets_leader_change(int variation) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Verify that OffsetForLeaderEpoch validation still works, end to
+ *        end, when the mock broker only accepts the raised protocol
+ *        version ceiling (v4, the first KIP-482 flexible version and the
+ *        version that adds the ReplicaId field).
+ */
+static void do_test_offset_for_leader_epoch_flexver(void) {
+        const char *topic      = test_mk_topic_name(__FUNCTION__, 1);
+        const char *c1_groupid = topic;
+        rd_kafka_t *c1;
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        int msg_cnt     = 5;
+        uint64_t testid = test_id_generate();
+        rd_kafka_conf_t *conf;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(2, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 2);
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 1);
+
+        TEST_CALL_ERR__(rd_kafka_mock_set_apiversion(
+            mcluster, RD_KAFKAP_OffsetForLeaderEpoch, 4, 4));
+
+        test_produce_msgs_easy_v(topic, testid, 0, 0, msg_cnt, 10,
+                                 "bootstrap.servers", bootstraps,
+                                 "batch.num.messages", "1", NULL);
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+
+        c1 = test_create_consumer(c1_groupid, NULL, conf, NULL);
+        test_consumer_subscribe(c1, topic);
+
+        /* Consume initial messages and join the group, etc. */
+        test_consumer_poll("MSG_INIT", c1, testid, 0, 0, msg_cnt, NULL);
+
+        /* Trigger a leader change, which causes an OffsetForLeaderEpoch
+         * request (at the pinned v4) to be sent to validate the new
+         * leader's epoch before resuming fetches. */
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 2);
+        rd_kafka_poll(c1, 1000);
+        rd_sleep(1);
+
+        test_produce_msgs_easy_v(topic, testid, 0, 0, msg_cnt, 10,
+                                 "bootstrap.servers", bootstraps,
+                                 "batch.num.messages", "1", NULL);
+
+        test_consumer_poll("MSG_AFTER_LEADER_CHANGE", c1, testid, 0, 0, msg_cnt,
+                           NULL);
+
+        rd_kafka_destroy(c1);
+
+        test_mock_cluster_destroy(mcluster);
+
+        TEST_LATER_CHECK();
+        SUB_TEST_PASS();
+}
+
+
 int main_0139_offset_validation_mock(int argc, char **argv) {
 
         TEST_SKIP_MOCK_CLUSTER(0);
@@ -945,6 +1007,8 @@ int main_0139_offset_validation_mock(int argc, char **argv) {
 
         do_test_list_offsets_leader_change(0);
         do_test_list_offsets_leader_change(1);
+
+        do_test_offset_for_leader_epoch_flexver();
 
         return 0;
 }

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -43,8 +43,9 @@
  * parses the response of, that exact version end-to-end rather than just
  * negotiating down to a version it already spoke before.
  */
-static void
-do_test_group_protocol_version(const char *what, int16_t ApiKey, int16_t ApiVersion) {
+static void do_test_group_protocol_version(const char *what,
+                                           int16_t ApiKey,
+                                           int16_t ApiVersion) {
         rd_kafka_t *rk;
         rd_kafka_conf_t *conf;
         rd_kafka_mock_cluster_t *mcluster;
@@ -52,14 +53,13 @@ do_test_group_protocol_version(const char *what, int16_t ApiKey, int16_t ApiVers
         rd_kafka_topic_partition_list_t *topics;
 
         SUB_TEST_QUICK("%s (ApiKey %" PRId16 " pinned to v%" PRId16 ")", what,
-                      ApiKey, ApiVersion);
+                       ApiKey, ApiVersion);
 
         mcluster = test_mock_cluster_new(1, &bootstraps);
         rd_kafka_mock_topic_create(mcluster, "topic", 1, 1);
 
-        TEST_CALL_ERR__(
-            rd_kafka_mock_set_apiversion(mcluster, ApiKey, ApiVersion,
-                                         ApiVersion));
+        TEST_CALL_ERR__(rd_kafka_mock_set_apiversion(mcluster, ApiKey,
+                                                     ApiVersion, ApiVersion));
 
         test_conf_init(&conf, NULL, 60);
         test_conf_set(conf, "bootstrap.servers", bootstraps);

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -1,0 +1,95 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+#include "../src/rdkafka_proto.h"
+
+/**
+ * @name Verify that librdkafka can complete a classic consumer group
+ *       session (FindCoordinator, JoinGroup, SyncGroup, Heartbeat,
+ *       LeaveGroup) when the mock coordinator only accepts exactly the
+ *       raised protocol version ceiling for each of those APIs.
+ *
+ * These ceilings were raised to bring each API's max version up to the
+ * Apache Kafka Java client's max version, which has used KIP-482
+ * flexible-version framing for these APIs since the 2.8.0 release.
+ * Pinning the mock broker to accept only the new version (rather than the
+ * usual 0..max range) proves librdkafka actually emits, and correctly
+ * parses the response of, that exact version end-to-end rather than just
+ * negotiating down to a version it already spoke before.
+ */
+static void
+do_test_group_protocol_version(const char *what, int16_t ApiKey, int16_t ApiVersion) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_topic_partition_list_t *topics;
+
+        SUB_TEST_QUICK("%s (ApiKey %" PRId16 " pinned to v%" PRId16 ")", what,
+                      ApiKey, ApiVersion);
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, "topic", 1, 1);
+
+        TEST_CALL_ERR__(
+            rd_kafka_mock_set_apiversion(mcluster, ApiKey, ApiVersion,
+                                         ApiVersion));
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_set(conf, "session.timeout.ms", "6000");
+        test_conf_set(conf, "heartbeat.interval.ms", "1000");
+
+        rk = test_create_consumer(what, NULL, conf, NULL);
+
+        topics = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(topics, "topic",
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_subscribe(rk, topics));
+        rd_kafka_topic_partition_list_destroy(topics);
+
+        test_consumer_wait_assignment(rk, rd_true);
+
+        /* Let a couple of heartbeats go through before leaving. */
+        rd_sleep(2);
+
+        TEST_CALL_ERR__(rd_kafka_consumer_close(rk));
+        rd_kafka_destroy(rk);
+
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0192_flexver_group_protocol_mock(int argc, char **argv) {
+        do_test_group_protocol_version("Heartbeat flexible version",
+                                       RD_KAFKAP_Heartbeat, 4);
+        return 0;
+}

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -95,5 +95,7 @@ int main_0192_flexver_group_protocol_mock(int argc, char **argv) {
                                        RD_KAFKAP_FindCoordinator, 3);
         do_test_group_protocol_version("LeaveGroup flexible version",
                                        RD_KAFKAP_LeaveGroup, 4);
+        do_test_group_protocol_version("SyncGroup KIP-559 version",
+                                       RD_KAFKAP_SyncGroup, 5);
         return 0;
 }

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -97,5 +97,7 @@ int main_0192_flexver_group_protocol_mock(int argc, char **argv) {
                                        RD_KAFKAP_LeaveGroup, 4);
         do_test_group_protocol_version("SyncGroup KIP-559 version",
                                        RD_KAFKAP_SyncGroup, 5);
+        do_test_group_protocol_version("JoinGroup flexible version",
+                                       RD_KAFKAP_JoinGroup, 7);
         return 0;
 }

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -93,5 +93,7 @@ int main_0192_flexver_group_protocol_mock(int argc, char **argv) {
                                        RD_KAFKAP_Heartbeat, 4);
         do_test_group_protocol_version("FindCoordinator flexible version",
                                        RD_KAFKAP_FindCoordinator, 3);
+        do_test_group_protocol_version("LeaveGroup flexible version",
+                                       RD_KAFKAP_LeaveGroup, 4);
         return 0;
 }

--- a/tests/0192-flexver_group_protocol_mock.c
+++ b/tests/0192-flexver_group_protocol_mock.c
@@ -91,5 +91,7 @@ do_test_group_protocol_version(const char *what, int16_t ApiKey, int16_t ApiVers
 int main_0192_flexver_group_protocol_mock(int argc, char **argv) {
         do_test_group_protocol_version("Heartbeat flexible version",
                                        RD_KAFKAP_Heartbeat, 4);
+        do_test_group_protocol_version("FindCoordinator flexible version",
+                                       RD_KAFKAP_FindCoordinator, 3);
         return 0;
 }

--- a/tests/0193-sasl_authenticate_flexver.c
+++ b/tests/0193-sasl_authenticate_flexver.c
@@ -51,10 +51,10 @@ static void do_test_sasl_authenticate(void) {
 
         test_conf_init(&conf, NULL, 30);
 
-        if (rd_kafka_conf_get(conf, "sasl.username", username,
-                              &username_sz) != RD_KAFKA_CONF_OK ||
-            rd_kafka_conf_get(conf, "sasl.password", password,
-                              &password_sz) != RD_KAFKA_CONF_OK ||
+        if (rd_kafka_conf_get(conf, "sasl.username", username, &username_sz) !=
+                RD_KAFKA_CONF_OK ||
+            rd_kafka_conf_get(conf, "sasl.password", password, &password_sz) !=
+                RD_KAFKA_CONF_OK ||
             username_sz <= 1 || password_sz <= 1) {
                 rd_kafka_conf_destroy(conf);
                 SUB_TEST_SKIP(

--- a/tests/0193-sasl_authenticate_flexver.c
+++ b/tests/0193-sasl_authenticate_flexver.c
@@ -1,0 +1,79 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/**
+ * @name Verify that librdkafka can complete SASL authentication now that
+ *       the SaslAuthenticate ceiling has been raised to v2 (the first
+ *       KIP-482 flexible version), which brokers/proxies that enforce a
+ *       KIP-482 floor require.
+ *
+ * The mock broker does not implement SASL, so this test requires a real,
+ * SASL-configured broker (as already assumed by the sibling
+ * 0135-sasl_credentials.cpp test) and is skipped when one isn't
+ * configured, exactly like that test.
+ */
+static void do_test_sasl_authenticate(void) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        char username[128], password[128];
+        size_t username_sz = sizeof(username);
+        size_t password_sz = sizeof(password);
+        const struct rd_kafka_metadata *md;
+        rd_kafka_resp_err_t err;
+
+        SUB_TEST_QUICK();
+
+        test_conf_init(&conf, NULL, 30);
+
+        if (rd_kafka_conf_get(conf, "sasl.username", username,
+                              &username_sz) != RD_KAFKA_CONF_OK ||
+            rd_kafka_conf_get(conf, "sasl.password", password,
+                              &password_sz) != RD_KAFKA_CONF_OK ||
+            username_sz <= 1 || password_sz <= 1) {
+                rd_kafka_conf_destroy(conf);
+                SUB_TEST_SKIP(
+                    "sasl.username and/or sasl.password not configured\n");
+                return;
+        }
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        err = rd_kafka_metadata(rk, 0, NULL, &md, tmout_multip(10000));
+        TEST_ASSERT(!err, "metadata() failed: %s", rd_kafka_err2str(err));
+        rd_kafka_metadata_destroy(md);
+
+        rd_kafka_destroy(rk);
+
+        SUB_TEST_PASS();
+}
+
+int main_0193_sasl_authenticate_flexver(int argc, char **argv) {
+        do_test_sasl_authenticate();
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,6 +169,7 @@ set(
     0190-share_consumer_telemetry.c
     0191-ipv6_nodename_mock.c
     0192-flexver_group_protocol_mock.c
+    0193-sasl_authenticate_flexver.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,6 +168,7 @@ set(
     0187-legacy_msgset_fetch_mock.c
     0190-share_consumer_telemetry.c
     0191-ipv6_nodename_mock.c
+    0192-flexver_group_protocol_mock.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -316,6 +316,7 @@ _TEST_DECL(0186_share_consumer_fatal_error);
 _TEST_DECL(0187_legacy_msgset_fetch_mock);
 _TEST_DECL(0190_share_consumer_telemetry);
 _TEST_DECL(0191_ipv6_nodename_mock);
+_TEST_DECL(0192_flexver_group_protocol_mock);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -616,6 +617,7 @@ struct test tests[] = {
           TEST_F_MANUAL,
           TEST_BRKVER(4, 2, 0, 0)),
     _TEST(0191_ipv6_nodename_mock, TEST_F_LOCAL),
+    _TEST(0192_flexver_group_protocol_mock, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/tests/test.c
+++ b/tests/test.c
@@ -317,6 +317,7 @@ _TEST_DECL(0187_legacy_msgset_fetch_mock);
 _TEST_DECL(0190_share_consumer_telemetry);
 _TEST_DECL(0191_ipv6_nodename_mock);
 _TEST_DECL(0192_flexver_group_protocol_mock);
+_TEST_DECL(0193_sasl_authenticate_flexver);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -618,6 +619,7 @@ struct test tests[] = {
           TEST_BRKVER(4, 2, 0, 0)),
     _TEST(0191_ipv6_nodename_mock, TEST_F_LOCAL),
     _TEST(0192_flexver_group_protocol_mock, TEST_F_LOCAL),
+    _TEST(0193_sasl_authenticate_flexver, 0),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -262,6 +262,7 @@
     <ClCompile Include="..\..\tests\0190-share_consumer_telemetry.c" />
     <ClCompile Include="..\..\tests\0191-ipv6_nodename_mock.c" />
     <ClCompile Include="..\..\tests\0192-flexver_group_protocol_mock.c" />
+    <ClCompile Include="..\..\tests\0193-sasl_authenticate_flexver.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -261,6 +261,7 @@
     <ClCompile Include="..\..\tests\0187-legacy_msgset_fetch_mock.c" />
     <ClCompile Include="..\..\tests\0190-share_consumer_telemetry.c" />
     <ClCompile Include="..\..\tests\0191-ipv6_nodename_mock.c" />
+    <ClCompile Include="..\..\tests\0192-flexver_group_protocol_mock.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
librdkafka's protocol version ceilings on 14 client-facing APIs lag
behind the Apache Kafka 2.8.0 Java client (April 2021) — the gap is
visible in INTRODUCTION.md's own protocol version table. This raises
each ceiling to that client's max version for the API, or slightly
beyond where the jump was wire-compatible, bringing coverage up to a
long-established, still-conservative baseline rather than chasing the
current Kafka release.

| API                  | ApiKey | Before | After |
|----------------------|--------|--------|-------|
| SaslAuthenticate      | 36     | v1     | v2    |
| FindCoordinator       | 10     | v2     | v3    |
| JoinGroup             | 11     | v5     | v7    |
| SyncGroup             | 14     | v3     | v5    |
| Heartbeat             | 12     | v3     | v4    |
| LeaveGroup            | 13     | v1     | v4    |
| CreateTopics          | 19     | v4     | v7    |
| OffsetForLeaderEpoch  | 23     | v2     | v4    |
| DescribeConfigs       | 32     | v1     | v4    |
| AddPartitionsToTxn    | 24     | v0     | v3    |
| AddOffsetsToTxn       | 25     | v0     | v3    |
| EndTxn                | 26     | v1     | v3    |
| DeleteTopics          | 20     | v4     | v6    |
| CreatePartitions      | 37     | v2     | v3    |

Each API is its own commit, independently reviewable and bisectable.
Two pre-existing dormant bugs surfaced while implementing the later
versions and are fixed as part of the relevant commit: LeaveGroup's
response parser was skipping ThrottleTimeMs before ErrorCode on v1+
(could mask a non-zero error code), and SyncGroup's assignment bytes
write wasn't flexver-aware.

Testing:
 * Group-protocol APIs (FindCoordinator, JoinGroup, SyncGroup,
   Heartbeat, LeaveGroup) are covered end-to-end against the mock
   broker in tests/0192, pinning each API to exactly its new ceiling.
 * SaslAuthenticate is covered in tests/0193 against a real
   SASL-configured broker (skips cleanly without one, matching
   0135-sasl_credentials).
 * AddPartitionsToTxn/AddOffsetsToTxn/EndTxn and
   OffsetForLeaderEpoch extend the existing 0105/0139 mock suites.
 * CreateTopics, DescribeConfigs, DeleteTopics, and CreatePartitions
   have no mock broker support (the mock broker doesn't implement the
   Admin API), so they rely on the existing real-broker suites in
   tests/0081-admin.c, which are already version-agnostic and will
   exercise the new ceilings the next time they run in CI.

Out of scope: SaslHandshake, OffsetCommit, OffsetFetch, ListOffsets,
and InitProducerId were already at/above the required floor.

INTRODUCTION.md's protocol version table is updated to match.
CHANGELOG.md has a single Enhancements entry summarizing the change;
happy to adjust the wording or section if you'd prefer something
different.

Rebased onto current master; tests/0191 and tests/0192 were renumbered
to tests/0192 and tests/0193 respectively to avoid colliding with
tests/0191-ipv6_nodename_mock.c, added to master in the interim (#5544).
