### PR TITLE
headers: expose name size in all-header iterator

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1476,6 +1476,44 @@ rd_kafka_header_get_all(const rd_kafka_headers_t *hdrs,
                         size_t *sizep);
 
 
+/**
+ * @brief Iterator for all headers.
+ *
+ *        Same semantics as rd_kafka_header_get_all(), but also returns the
+ *        header name's size in \p name_sizep.
+ *
+ * @param hdrs       Headers to iterate.
+ * @param idx        Iterator index, start at 0 and increment by one for each
+ *                   call as long as RD_KAFKA_RESP_ERR_NO_ERROR is returned.
+ * @param namep      (out) Set to a const pointer to the header-name byte
+ *                   sequence. Its length is returned through \p name_sizep.
+ *                   The name bytes may contain embedded NUL bytes and are
+ *                   followed by a trailing NUL; callers must use
+ *                   \p name_sizep to read the name.
+ * @param name_sizep (out) Set to the header name's size (not including
+ *                   null-terminator).
+ * @param valuep     (out) Set to a (null-terminated) const pointer to the
+ *                   value (may be NULL).
+ * @param sizep      (out) Set to the value's size (not including
+ *                   null-terminator).
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR if an entry was found, else
+ *          RD_KAFKA_RESP_ERR__NOENT if \p idx is out of range.
+ *
+ * @remark The returned pointer in \p valuep includes a trailing
+ *         null-terminator that is not accounted for in \p sizep.
+ * @remark The returned pointers are only valid as long as the headers list and
+ *         the header item are valid.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_header_get_all_with_name_size(const rd_kafka_headers_t *hdrs,
+                                       size_t idx,
+                                       const char **namep,
+                                       size_t *name_sizep,
+                                       const void **valuep,
+                                       size_t *sizep);
+
+
 
 /**@}*/
 

--- a/src/rdkafka_header.c
+++ b/src/rdkafka_header.c
@@ -215,6 +215,30 @@ rd_kafka_resp_err_t rd_kafka_header_get_all(const rd_kafka_headers_t *hdrs,
 }
 
 
+rd_kafka_resp_err_t
+rd_kafka_header_get_all_with_name_size(const rd_kafka_headers_t *hdrs,
+                                       size_t idx,
+                                       const char **namep,
+                                       size_t *name_sizep,
+                                       const void **valuep,
+                                       size_t *sizep) {
+        const rd_kafka_header_t *hdr;
+
+        if (unlikely(idx >= (size_t)rd_list_cnt(&hdrs->rkhdrs_list)))
+                return RD_KAFKA_RESP_ERR__NOENT;
+
+        hdr = rd_list_elem(&hdrs->rkhdrs_list, (int)idx);
+        if (unlikely(!hdr))
+                return RD_KAFKA_RESP_ERR__NOENT;
+
+        *namep      = hdr->rkhdr_name;
+        *name_sizep = hdr->rkhdr_name_size;
+        *valuep     = hdr->rkhdr_value;
+        *sizep      = hdr->rkhdr_value_size;
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+
 size_t rd_kafka_header_cnt(const rd_kafka_headers_t *hdrs) {
         return (size_t)rd_list_cnt(&hdrs->rkhdrs_list);
 }

--- a/tests/0072-headers_ut.c
+++ b/tests/0072-headers_ut.c
@@ -233,6 +233,103 @@ static void expect_iter(const char *what,
 }
 
 
+static void do_test_embedded_nul_header_name_size(void) {
+        static const char name_nul[] = {'a', '\0', 'b'};
+        rd_kafka_headers_t *hdrs;
+        rd_kafka_resp_err_t err;
+        const char *name;
+        const char *value;
+        size_t name_size;
+        size_t value_size;
+
+        SUB_TEST_QUICK();
+
+        hdrs = rd_kafka_headers_new(2);
+
+        err =
+            rd_kafka_header_add(hdrs, name_nul, sizeof(name_nul), "v-nul", -1);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "failed to add embedded-NUL header: %s",
+                    rd_kafka_err2str(err));
+
+        err = rd_kafka_header_add(hdrs, "a", -1, "v-a", -1);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "failed to add plain header: %s", rd_kafka_err2str(err));
+
+        err = rd_kafka_header_get_all_with_name_size(
+            hdrs, 0, &name, &name_size, (const void **)&value, &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "failed to get embedded-NUL header: %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(name_size == sizeof(name_nul),
+                    "expected embedded-NUL name size %" PRIusz ", not %" PRIusz,
+                    sizeof(name_nul), name_size);
+        TEST_ASSERT(!memcmp(name, name_nul, name_size),
+                    "embedded-NUL header name bytes differ");
+        TEST_ASSERT(name[name_size] == '\0',
+                    "embedded-NUL header name is not NUL-terminated");
+        TEST_ASSERT(value_size == strlen("v-nul") && !strcmp(value, "v-nul"),
+                    "unexpected embedded-NUL header value");
+
+        err = rd_kafka_header_get_all_with_name_size(
+            hdrs, 1, &name, &name_size, (const void **)&value, &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "failed to get plain header: %s", rd_kafka_err2str(err));
+        TEST_ASSERT(name_size == 1, "expected plain name size 1, not %" PRIusz,
+                    name_size);
+        TEST_ASSERT(!memcmp(name, "a", name_size),
+                    "plain header name bytes differ");
+        TEST_ASSERT(name[name_size] == '\0',
+                    "plain header name is not NUL-terminated");
+        TEST_ASSERT(value_size == strlen("v-a") && !strcmp(value, "v-a"),
+                    "unexpected plain header value");
+
+        err = rd_kafka_header_get_all_with_name_size(
+            hdrs, 2, &name, &name_size, (const void **)&value, &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__NOENT,
+                    "expected NOENT at end of headers, got %s",
+                    rd_kafka_err2str(err));
+
+        err = rd_kafka_header_get_all_with_name_size(
+            hdrs, SIZE_MAX, &name, &name_size, (const void **)&value,
+            &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__NOENT,
+                    "expected NOENT for SIZE_MAX index, got %s",
+                    rd_kafka_err2str(err));
+
+        err = rd_kafka_header_get_all_with_name_size(
+            hdrs, (size_t)INT_MAX + 1, &name, &name_size, (const void **)&value,
+            &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__NOENT,
+                    "expected NOENT for INT_MAX + 1 index, got %s",
+                    rd_kafka_err2str(err));
+
+        err = rd_kafka_header_get_all(hdrs, 0, &name, (const void **)&value,
+                                      &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "old getter failed on embedded-NUL header: %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(!strcmp(name, "a"),
+                    "expected old getter C-string name 'a', not '%s'", name);
+        TEST_ASSERT(value_size == strlen("v-nul") && !strcmp(value, "v-nul"),
+                    "unexpected old getter embedded-NUL header value");
+
+        err = rd_kafka_header_get_all(hdrs, 1, &name, (const void **)&value,
+                                      &value_size);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "old getter failed on plain header: %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(!strcmp(name, "a"),
+                    "expected old getter plain name 'a', not '%s'", name);
+        TEST_ASSERT(value_size == strlen("v-a") && !strcmp(value, "v-a"),
+                    "unexpected old getter plain header value");
+
+        rd_kafka_headers_destroy(hdrs);
+
+        SUB_TEST_PASS();
+}
+
+
 
 /**
  * @brief First on_send() interceptor
@@ -346,6 +443,8 @@ int main_0072_headers_ut(int argc, char **argv) {
         size_t header_cnt;
         const int msgcnt = 10;
         rd_kafka_resp_err_t err;
+
+        do_test_embedded_nul_header_name_size();
 
         conf = rd_kafka_conf_new();
         test_conf_set(conf, "message.timeout.ms", "1");


### PR DESCRIPTION
## Summary

`rd_kafka_header_add()` accepts a header name size and librdkafka stores that
length internally, so header names may contain embedded NUL bytes. The public
all-header iterator only exposes the name as a C string, which prevents
callers from recovering the stored length and distinguishing names such as
`a\0b` from `a`.

This adds `rd_kafka_header_get_all_with_name_size()` to return the stored
header name size alongside the existing name, value, and value size. The
existing `rd_kafka_header_get_all()` API and behavior are unchanged.

## Testing

- `TESTS=0072 make -C tests`
- `make -C src`
- `make style-check-changed`
- `git diff --check`

The headers unit regression creates `a\0b` and `a` in the same headers list,
verifies the new accessor returns their byte lengths, and verifies the old
getter behavior remains unchanged. Temporarily returning `strlen(name)` from
the new accessor makes the test fail with the embedded-NUL name length
reported as 1 instead of 3. Removing the new accessor's pre-cast bounds guard
makes the 0072 test process fail on the large-index guard case.
