### PR TITLE
Keep the member id assigned by the broker when a JoinGroup response is outdated

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2260,6 +2260,24 @@ err:
 
 
 /**
+ * @brief KIP-394 requires member.id on the initial JoinGroup request: adopt
+ *        the member id the broker assigned to us in its MEMBER_ID_REQUIRED
+ *        response and let the next join go out without a backoff.
+ *
+ * @locality rdkafka main thread
+ */
+static void
+rd_kafka_cgrp_set_required_member_id(rd_kafka_cgrp_t *rkcg,
+                                     const rd_kafkap_str_t *member_id) {
+        char *member_id_str;
+
+        RD_KAFKAP_STR_DUPA(&member_id_str, member_id);
+        rd_kafka_cgrp_set_member_id(rkcg, member_id_str);
+        rd_interval_reset(&rkcg->rkcg_join_intvl);
+}
+
+
+/**
  * @brief cgrp handler for JoinGroup responses
  * opaque must be the cgrp handle.
  *
@@ -2281,6 +2299,7 @@ static void rd_kafka_cgrp_handle_JoinGroup(rd_kafka_t *rk,
         int actions;
         int i_am_leader           = 0;
         rd_kafka_assignor_t *rkas = NULL;
+        rd_bool_t outdated        = rd_false;
 
         rd_kafka_cgrp_clear_wait_resp(rkcg, RD_KAFKAP_JoinGroup);
 
@@ -2294,7 +2313,14 @@ static void rd_kafka_cgrp_handle_JoinGroup(rd_kafka_t *rk,
                     "JoinGroup response: discarding outdated request "
                     "(now in join-state %s)",
                     rd_kafka_cgrp_join_state_names[rkcg->rkcg_join_state]);
-                return;
+
+                /* Still parse the response below: a MEMBER_ID_REQUIRED
+                 * response carries a member id assigned to us by the broker,
+                 * and this is the only place it is sent. */
+                if (err)
+                        return; /* Nothing to parse */
+
+                outdated = rd_true;
         }
 
         if (err) {
@@ -2311,6 +2337,18 @@ static void rd_kafka_cgrp_handle_JoinGroup(rd_kafka_t *rk,
         rd_kafka_buf_read_str(rkbuf, &LeaderId);
         rd_kafka_buf_read_str(rkbuf, &MyMemberId);
         rd_kafka_buf_read_i32(rkbuf, &member_cnt);
+
+        if (unlikely(outdated)) {
+                /* KIP-394: keep the member id assigned to us, if we don't
+                 * have one yet, so that the next JoinGroup reclaims it
+                 * instead of having the broker assign a second one and hold
+                 * this one until its session timeout expires. */
+                if (ErrorCode == RD_KAFKA_RESP_ERR_MEMBER_ID_REQUIRED &&
+                    !RD_KAFKAP_STR_LEN(rkcg->rkcg_member_id))
+                        rd_kafka_cgrp_set_required_member_id(rkcg, &MyMemberId);
+
+                return;
+        }
 
         if (!ErrorCode && RD_KAFKAP_STR_IS_NULL(&Protocol)) {
                 /* Protocol not set, we will not be able to find
@@ -2531,15 +2569,8 @@ err:
                         rd_kafka_cgrp_set_member_id(rkcg, "");
                 else if (ErrorCode == RD_KAFKA_RESP_ERR_ILLEGAL_GENERATION)
                         rkcg->rkcg_generation_id = -1;
-                else if (ErrorCode == RD_KAFKA_RESP_ERR_MEMBER_ID_REQUIRED) {
-                        /* KIP-394 requires member.id on initial join
-                         * group request */
-                        char *my_member_id;
-                        RD_KAFKAP_STR_DUPA(&my_member_id, &MyMemberId);
-                        rd_kafka_cgrp_set_member_id(rkcg, my_member_id);
-                        /* Skip the join backoff */
-                        rd_interval_reset(&rkcg->rkcg_join_intvl);
-                }
+                else if (ErrorCode == RD_KAFKA_RESP_ERR_MEMBER_ID_REQUIRED)
+                        rd_kafka_cgrp_set_required_member_id(rkcg, &MyMemberId);
 
                 if (rd_kafka_cgrp_rebalance_protocol(rkcg) ==
                         RD_KAFKA_REBALANCE_PROTOCOL_COOPERATIVE &&
@@ -2557,6 +2588,9 @@ err:
         return;
 
 err_parse:
+        if (unlikely(outdated))
+                return; /* Don't act on a response we are discarding */
+
         ErrorCode = rkbuf->rkbuf_err;
         goto err;
 }

--- a/src/rdkafka_mock_cgrp.c
+++ b/src/rdkafka_mock_cgrp.c
@@ -548,6 +548,21 @@ rd_kafka_mock_cgrp_classic_member_t *rd_kafka_mock_cgrp_classic_member_find(
 
 
 /**
+ * @brief Generate a MemberId for a member that joined without one (KIP-394).
+ *
+ * @returns \p dst.
+ */
+const char *rd_kafka_mock_cgrp_classic_member_id_generate(
+    rd_kafka_mock_cgrp_classic_t *mcgrp,
+    char *dst,
+    size_t dst_size) {
+        rd_snprintf(dst, dst_size, "mock-member-%" PRId32,
+                    ++mcgrp->member_id_seq);
+        return dst;
+}
+
+
+/**
  * @brief Update or add member to consumer group
  */
 rd_kafka_resp_err_t rd_kafka_mock_cgrp_classic_member_add(

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -1590,6 +1590,8 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
         rd_kafka_resp_err_t err;
         rd_kafka_mock_cgrp_classic_t *mcgrp;
         rd_kafka_mock_cgrp_classic_proto_t *protos = NULL;
+        const char *generated_member_id            = NULL;
+        char memberid[32];
 
         rd_kafka_buf_read_str(rkbuf, &GroupId);
         rd_kafka_buf_read_i32(rkbuf, &SessionTimeoutMs);
@@ -1646,16 +1648,32 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
                                                        &ProtocolType);
                 rd_assert(mcgrp);
 
-                /* This triggers an async rebalance, the response will be
-                 * sent later. */
-                err = rd_kafka_mock_cgrp_classic_member_add(
-                    mcgrp, mconn, resp, &MemberId, &ProtocolType,
-                    &GroupInstanceId, protos, ProtocolCnt, SessionTimeoutMs);
-                if (!err) {
-                        /* .._add() assumes ownership of resp and protos */
-                        protos = NULL;
-                        rd_kafka_mock_connection_set_blocking(mconn, rd_true);
-                        return 0;
+                if (rkbuf->rkbuf_reqhdr.ApiVersion >= 4 &&
+                    !RD_KAFKAP_STR_LEN(&MemberId) &&
+                    !RD_KAFKAP_STR_LEN(&GroupInstanceId)) {
+                        /* KIP-394: a dynamic member that joins without a
+                         * member id has one generated for it and is told to
+                         * rejoin with it. Static members are exempt. */
+                        generated_member_id =
+                            rd_kafka_mock_cgrp_classic_member_id_generate(
+                                mcgrp, memberid, sizeof(memberid));
+                        err = RD_KAFKA_RESP_ERR_MEMBER_ID_REQUIRED;
+
+                } else {
+                        /* This triggers an async rebalance, the response will
+                         * be sent later. */
+                        err = rd_kafka_mock_cgrp_classic_member_add(
+                            mcgrp, mconn, resp, &MemberId, &ProtocolType,
+                            &GroupInstanceId, protos, ProtocolCnt,
+                            SessionTimeoutMs);
+                        if (!err) {
+                                /* .._add() assumes ownership of resp and
+                                 * protos */
+                                protos = NULL;
+                                rd_kafka_mock_connection_set_blocking(mconn,
+                                                                      rd_true);
+                                return 0;
+                        }
                 }
         }
 
@@ -1665,9 +1683,13 @@ static int rd_kafka_mock_handle_JoinGroup(rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i16(resp, err);      /* ErrorCode */
         rd_kafka_buf_write_i32(resp, -1);       /* GenerationId */
         rd_kafka_buf_write_str(resp, NULL, -1); /* ProtocolName */
-        rd_kafka_buf_write_str(resp, NULL, -1); /* LeaderId */
-        rd_kafka_buf_write_kstr(resp, NULL);    /* MemberId */
-        rd_kafka_buf_write_i32(resp, 0);        /* MemberCnt */
+        /* LeaderId: empty, not NULL, when a MemberId is returned, as a real
+         * broker does. */
+        rd_kafka_buf_write_str(resp, generated_member_id ? "" : NULL, -1);
+        /* MemberId: the id generated for a KIP-394 MEMBER_ID_REQUIRED
+         * response, else NULL. */
+        rd_kafka_buf_write_str(resp, generated_member_id, -1);
+        rd_kafka_buf_write_i32(resp, 0); /* MemberCnt */
 
         rd_kafka_mock_connection_send_response(mconn, resp);
 

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -100,6 +100,7 @@ typedef struct rd_kafka_mock_cgrp_classic_s {
         char *protocol_type;                     /**< Protocol type */
         char *protocol_name;                     /**< Elected protocol name */
         int32_t generation_id;                   /**< Generation Id */
+        int32_t member_id_seq;                   /**< MemberId sequence */
         int session_timeout_ms;                  /**< Session timeout */
         enum {
                 RD_KAFKA_MOCK_CGRP_STATE_EMPTY,       /* No members */
@@ -892,6 +893,10 @@ rd_kafka_resp_err_t rd_kafka_mock_cgrp_classic_check_state(
 rd_kafka_mock_cgrp_classic_member_t *rd_kafka_mock_cgrp_classic_member_find(
     const rd_kafka_mock_cgrp_classic_t *mcgrp,
     const rd_kafkap_str_t *MemberId);
+const char *rd_kafka_mock_cgrp_classic_member_id_generate(
+    rd_kafka_mock_cgrp_classic_t *mcgrp,
+    char *dst,
+    size_t dst_size);
 void rd_kafka_mock_cgrp_classic_destroy(rd_kafka_mock_cgrp_classic_t *mcgrp);
 rd_kafka_mock_cgrp_classic_t *
 rd_kafka_mock_cgrp_classic_find(rd_kafka_mock_cluster_t *mcluster,

--- a/tests/0191-joingroup_member_id_mock.c
+++ b/tests/0191-joingroup_member_id_mock.c
@@ -1,0 +1,154 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#include "../src/rdkafka_proto.h"
+
+/**
+ * @name KIP-394: keep the member id assigned by the broker
+ *
+ * A JoinGroup response that arrives after the client has left the join state
+ * it was sent in is discarded. A MEMBER_ID_REQUIRED response carries the
+ * member id the broker assigned to us, so discarding it made the client join
+ * again without a member id and be assigned a second one, leaving the broker
+ * holding the first as a pending member that blocks the group's rebalance
+ * until its session timeout expires.
+ *
+ * The subscription is changed while the initial JoinGroup response is delayed
+ * by the mock broker, which is what makes that response outdated. What is
+ * verified is that the client asks the broker for a member id only once.
+ */
+
+#define JOINGROUP_RTT_MS 1000
+
+static size_t joingroup_request_cnt(rd_kafka_mock_cluster_t *mcluster) {
+        rd_kafka_mock_request_t **requests;
+        size_t request_cnt, i, cnt = 0;
+
+        requests = rd_kafka_mock_get_requests(mcluster, &request_cnt);
+        for (i = 0; i < request_cnt; i++) {
+                if (rd_kafka_mock_request_api_key(requests[i]) ==
+                    RD_KAFKAP_JoinGroup)
+                        cnt++;
+        }
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
+
+        return cnt;
+}
+
+static void do_test_member_id_required(const char *assignor) {
+        rd_kafka_mock_cluster_t *mcluster;
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+        const char *bootstraps;
+        const char *topic1 = "rdkafkatest_0191_first";
+        const char *topic2 = "rdkafkatest_0191_second";
+        rd_kafka_topic_partition_list_t *subscription, *expected;
+        size_t joingroup_cnt;
+
+        SUB_TEST_QUICK("%s", assignor);
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+
+        /* Elect as soon as the member has joined. */
+        rd_kafka_mock_group_initial_rebalance_delay_ms(mcluster, 0);
+
+        TEST_CALL_ERR__(rd_kafka_mock_topic_create(mcluster, topic1, 1, 1));
+        TEST_CALL_ERR__(rd_kafka_mock_topic_create(mcluster, topic2, 1, 1));
+
+        /* Delay the response to the initial JoinGroup, the one the broker
+         * answers with MEMBER_ID_REQUIRED and a new member id, so that the
+         * subscription can change while it is in flight. */
+        rd_kafka_mock_broker_push_request_error_rtts(
+            mcluster, 1, RD_KAFKAP_JoinGroup, 1, RD_KAFKA_RESP_ERR_NO_ERROR,
+            JOINGROUP_RTT_MS);
+
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", "0191_member_id_required");
+        test_conf_set(conf, "partition.assignment.strategy", assignor);
+
+        rk = test_create_consumer(NULL, NULL, conf, NULL);
+
+        rd_kafka_mock_start_request_tracking(mcluster);
+
+        test_consumer_subscribe(rk, topic1);
+
+        /* Wait for the JoinGroup to be in flight. */
+        while (joingroup_request_cnt(mcluster) < 1)
+                test_consumer_poll_no_msgs("wait JoinGroup", rk, 0, 100);
+
+        TEST_SAY("Changing the subscription while JoinGroup is in flight\n");
+        subscription = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subscription, topic1,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subscription, topic2,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_subscribe(rk, subscription));
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        expected = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(expected, topic1, 0);
+        rd_kafka_topic_partition_list_add(expected, topic2, 0);
+        test_consumer_wait_assignment_topic_partition_list(rk, rd_true,
+                                                           expected, 10000);
+        rd_kafka_topic_partition_list_destroy(expected);
+
+        /* One JoinGroup without a member id, and one with the member id the
+         * broker assigned in response to it. A third means the assigned
+         * member id was discarded along with the outdated response. */
+        joingroup_cnt = joingroup_request_cnt(mcluster);
+        TEST_ASSERT(joingroup_cnt == 2,
+                    "Expected 2 JoinGroup requests, not %" PRIusz
+                    ": the member id assigned by the broker was discarded "
+                    "with the outdated response",
+                    joingroup_cnt);
+
+        rd_kafka_mock_stop_request_tracking(mcluster);
+
+        test_consumer_close(rk);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0191_joingroup_member_id_mock(int argc, char **argv) {
+        TEST_SKIP_MOCK_CLUSTER(0);
+
+        if (!test_consumer_group_protocol_classic()) {
+                TEST_SKIP("Requires the classic group protocol\n");
+                return 0;
+        }
+
+        do_test_member_id_required("range");
+        do_test_member_id_required("cooperative-sticky");
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,7 @@ set(
     0185-share_consumer_max_poll_interval.c
     0186-share_consumer_fatal_error.c
     0190-share_consumer_telemetry.c
+    0191-joingroup_member_id_mock.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -314,6 +314,7 @@ _TEST_DECL(0184_share_consumer_topic_recreate_local);
 _TEST_DECL(0185_share_consumer_max_poll_interval);
 _TEST_DECL(0186_share_consumer_fatal_error);
 _TEST_DECL(0190_share_consumer_telemetry);
+_TEST_DECL(0191_joingroup_member_id_mock);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -612,6 +613,7 @@ struct test tests[] = {
     _TEST(0190_share_consumer_telemetry,
           TEST_F_MANUAL,
           TEST_BRKVER(4, 2, 0, 0)),
+    _TEST(0191_joingroup_member_id_mock, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -259,6 +259,7 @@
     <ClCompile Include="..\..\tests\0185-share_consumer_max_poll_interval.c" />
     <ClCompile Include="..\..\tests\0186-share_consumer_fatal_error.c" />
     <ClCompile Include="..\..\tests\0190-share_consumer_telemetry.c" />
+    <ClCompile Include="..\..\tests\0191-joingroup_member_id_mock.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
Fixes #5569

**Symptom**

A consumer using the classic group protocol sometimes performs the KIP-394 handshake twice within a few milliseconds, and uses only the second member id. The broker keeps the first one as a pending member and will not let the group finish rebalancing until it comes back, so the group sits in `PreparingRebalance` for the full `session.timeout.ms` (45s by default) with **no member of the group holding any partition**.

Coordinator log signature, for a single consumer starting up:

```
13:30:05,501  Dynamic member with unknown member id joins group G in Stable state.
              Created a new member id id:154b45 and request the member to rejoin with this id.
13:30:05,503  Dynamic member with unknown member id joins group G in Stable state.
              Created a new member id id:85bb1f and request the member to rejoin with this id.
13:30:05,504  Preparing to rebalance group G ... (reason: Adding new member id:85bb1f ...)
13:30:50,502  Pending member id:154b45 in group G has been removed after session timeout expiration.
13:30:50,502  Stabilized group G generation 2 with 2 members
```

Happening since v1.3.0. Affects the `classic` group protocol only: the `consumer` protocol (KIP-848) generates its member id client-side and never performs this handshake.

Found in production through node-rdkafka 3.0.1 (librdkafka 2.3.0), in a service whose consumer groups restart on every rollout. Across 20 CI runs there were 2377 `Pending member ... removed after session timeout expiration` events, and 2361 of them (99.3%) were the first of a pair of member ids created ≤200ms apart (median gap 6ms, p90 54ms) — the signature above, at scale. Per-group rate ranged 3–18% of joins. Beyond the latency, consumers with `auto.offset.reset=latest` and no committed offset skip everything produced during the window.

**Root cause**

`rd_kafka_cgrp_handle_JoinGroup()` discards a JoinGroup response when the cgrp is no longer in the join state the request was sent in, for instance because a metadata change triggered a rejoin while the JoinGroup was still in flight:

```
JOIN      Joining group "GROUP" with 1 subscribed topic(s) and member id ""
REJOIN    subscription updated from metadata change: rejoining group in state wait-join
JOINGROUP JoinGroup response: discarding outdated request (now in join-state init)
JOIN      Joining group "GROUP" with 1 subscribed topic(s) and member id ""
```

For a `MEMBER_ID_REQUIRED` response, the member id the broker assigned is that response's entire payload and nothing else records it, so discarding the response loses the id. The client then joins again with an empty member id and is assigned a second one, while the broker holds the first as a pending member.

The discard predates `MEMBER_ID_REQUIRED` handling: it was added in f428f516 (2017), when a JoinGroup response carried no state worth keeping, whereas KIP-394 handling arrived in a8ca2fbb and was first released in v1.3.0.

**Fix**

Parse an outdated response and adopt its member id when ours is still unset, so that the next JoinGroup reclaims the id the broker is already holding instead of asking for a second one. An outdated response is not acted upon in any other way, as before, and it is now discarded before being inspected any further, so it cannot touch assignor state.

**Testing**

- The mock broker did not implement KIP-394 at all, so this path was untestable: a first commit makes it answer a JoinGroup v4+ that arrives without a member id with `MEMBER_ID_REQUIRED` and a generated member id. Static members (`group.instance.id`) are exempt and injected errors still take precedence, so the handshake only happens where a real broker performs it.
- New regression test 0191 delays the initial JoinGroup response on the mock cluster and changes the subscription while it is in flight, then asserts that the client asks the broker for a member id exactly once — two JoinGroup requests, not three. Fails without the fix, passes with it, for both `range` (eager) and `cooperative-sticky`.
- Also exercised against Apache Kafka 3.9.0: under metadata churn the discard of an in-flight JoinGroup response reproduces on every consumer start (181/181), but the window between sending the empty-member-id JoinGroup and receiving `MEMBER_ID_REQUIRED` is only ~1.1ms locally, so landing a metadata change inside it needs the wider windows seen in CI and in production. The mock test is therefore what covers the race deterministically; the broker-side stall itself is not reproduced in-tree.
