### PR TITLE
[FIX] Avoid duplicate FETCH_STOP for the same toppar during assignment removal

### DIFF
--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -387,11 +387,11 @@ static void rd_kafka_share_assignment_serve_removals(rd_kafka_t *rk) {
 static void rd_kafka_assignment_request_stop(rd_kafka_assignment_t *assignment,
                                              rd_kafka_toppar_t *rktp,
                                              rd_kafka_q_t *stop_replyq) {
-        if (!rktp->rktp_started || rktp->rktp_stop_pending)
+        if (!rktp->rktp_started || rktp->rktp_wait_stop)
                 return;
 
         rd_assert(assignment->started_cnt > 0);
-        rktp->rktp_stop_pending = rd_true;
+        rktp->rktp_wait_stop = rd_true;
         assignment->wait_stop_cnt++;
         rd_kafka_toppar_op_fetch_stop(rktp, RD_KAFKA_REPLYQ(stop_replyq, 0));
 }
@@ -405,8 +405,8 @@ static void rd_kafka_assignment_complete_stop(rd_kafka_assignment_t *assignment,
         rd_assert(assignment->wait_stop_cnt > 0);
         assignment->wait_stop_cnt--;
 
-        rd_assert(rktp->rktp_stop_pending);
-        rktp->rktp_stop_pending = rd_false;
+        rd_assert(rktp->rktp_wait_stop);
+        rktp->rktp_wait_stop = rd_false;
 
         rd_assert(rktp->rktp_started);
         rktp->rktp_started = rd_false;
@@ -486,10 +486,11 @@ static int rd_kafka_assignment_serve_removals0(rd_kafka_t *rk,
                 rd_kafka_dbg(rk, CGRP, "REMOVE",
                              "Removing %s [%" PRId32
                              "] from assignment "
-                             "(started=%s, pending=%s, queried=%s, "
-                             "stored offset=%s)",
+                             "(started=%s, wait_stop=%s, pending=%s, "
+                             "queried=%s, stored offset=%s)",
                              rktpar->topic, rktpar->partition,
                              RD_STR_ToF(rktp->rktp_started),
+                             RD_STR_ToF(rktp->rktp_wait_stop),
                              RD_STR_ToF(was_pending), RD_STR_ToF(was_queried),
                              rd_kafka_offset2str(rktpar->offset));
         }
@@ -585,7 +586,7 @@ static int rd_kafka_assignment_serve_pending(rd_kafka_t *rk) {
                     rd_kafka_topic_partition_ensure_toppar(rk, rktpar, rd_true);
 
                 rd_assert(!rktp->rktp_started);
-                rd_assert(!rktp->rktp_stop_pending);
+                rd_assert(!rktp->rktp_wait_stop);
 
                 if (!RD_KAFKA_OFFSET_IS_LOGICAL(rktpar->offset) ||
                     rktpar->offset == RD_KAFKA_OFFSET_BEGINNING ||
@@ -1254,7 +1255,9 @@ unittest_assignment_add_removed_partition(rd_kafka_t *rk,
                 rd_kafka_toppar_unlock(rktp);
         }
 
-        return rktp;
+        /* Return a test-owned reference that remains valid after
+         * serve_removals0() clears the removed assignment list. */
+        return rktp ? rd_kafka_toppar_keep(rktp) : NULL;
 }
 
 
@@ -1270,6 +1273,9 @@ static int unittest_assignment_stop_pending(void) {
         rd_kafka_conf_set(conf, "enable.auto.commit", "false", NULL, 0);
         rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
         RD_UT_ASSERT(rk, "failed to create consumer: %s", errstr);
+        /* Keep this fixture single-threaded and deterministic: no group.id
+         * means no consumer group, and FETCH_STOP replies go to a private
+         * test queue that is never polled. */
         test_ops = rd_kafka_q_new(rk);
 
         /* A removal for a partition that was never started must not request
@@ -1279,7 +1285,6 @@ static int unittest_assignment_stop_pending(void) {
         RD_UT_ASSERT(!RD_KAFKA_TOPPAR_IS_PAUSED(rktp),
                      "test requires an unpaused partition so only FETCH_STOP "
                      "bumps the version");
-        rk->rk_consumer.assignment.started_cnt = 1;
         version = rd_atomic32_get(&rktp->rktp_version);
         RD_UT_ASSERT(rd_kafka_assignment_serve_removals0(rk, test_ops) == 0,
                      "non-started removal should have no outstanding work");
@@ -1287,8 +1292,11 @@ static int unittest_assignment_stop_pending(void) {
                      "non-started removal must not request FETCH_STOP");
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
                      "non-started removal must not increment wait_stop_cnt");
-        RD_UT_ASSERT(!rktp->rktp_stop_pending,
+        RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
+                     "non-started removal must not alter started_cnt");
+        RD_UT_ASSERT(!rktp->rktp_wait_stop,
                      "non-started removal must not mark stop-pending");
+        rd_kafka_toppar_destroy(rktp);
 
         rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
         RD_UT_ASSERT(rktp, "failed to re-add toppar to removed list");
@@ -1304,8 +1312,9 @@ static int unittest_assignment_stop_pending(void) {
                      "FETCH_STOP");
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
                      "first stop should increment wait_stop_cnt once");
-        RD_UT_ASSERT(rktp->rktp_stop_pending,
+        RD_UT_ASSERT(rktp->rktp_wait_stop,
                      "first stop should mark the toppar stop-pending");
+        rd_kafka_toppar_destroy(rktp);
 
         rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
         RD_UT_ASSERT(rktp, "failed to re-add toppar to removed list");
@@ -1316,7 +1325,7 @@ static int unittest_assignment_stop_pending(void) {
         rk->rk_consumer.assignment.wait_stop_cnt = 1;
         rk->rk_consumer.assignment.started_cnt   = 1;
         rktp->rktp_started                       = rd_true;
-        rktp->rktp_stop_pending                  = rd_true;
+        rktp->rktp_wait_stop                     = rd_true;
         version = rd_atomic32_get(&rktp->rktp_version);
         rd_kafka_assignment_serve_removals0(rk, test_ops);
         RD_UT_ASSERT(rd_atomic32_get(&rktp->rktp_version) == version,
@@ -1325,7 +1334,7 @@ static int unittest_assignment_stop_pending(void) {
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
                      "duplicate removal must not increment wait_stop_cnt");
 
-        RD_UT_ASSERT(rktp->rktp_stop_pending,
+        RD_UT_ASSERT(rktp->rktp_wait_stop,
                      "completion fixture requires a pending stop");
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
                      "completion fixture requires one awaited stop");
@@ -1336,11 +1345,12 @@ static int unittest_assignment_stop_pending(void) {
         rd_kafka_assignment_complete_stop(&rk->rk_consumer.assignment, rktp);
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
                      "completion should clear wait_stop_cnt");
-        RD_UT_ASSERT(!rktp->rktp_stop_pending,
+        RD_UT_ASSERT(!rktp->rktp_wait_stop,
                      "completion should clear stop-pending");
         RD_UT_ASSERT(!rktp->rktp_started, "completion should clear started");
         RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
                      "completion should decrement started_cnt");
+        rd_kafka_toppar_destroy(rktp);
 
         {
                 rd_kafka_toppar_t *rktp0, *rktp1;
@@ -1375,11 +1385,15 @@ static int unittest_assignment_stop_pending(void) {
                 RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 2,
                              "same removal round should await both stop "
                              "replies");
-                RD_UT_ASSERT(rktp0->rktp_stop_pending &&
-                                 rktp1->rktp_stop_pending,
+                RD_UT_ASSERT(rktp0->rktp_wait_stop && rktp1->rktp_wait_stop,
                              "same removal round should mark both toppars "
                              "stop-pending");
 
+                /* In this no-cgrp fixture, consuming the final outstanding
+                 * stop through the production path would complete assignment
+                 * and dereference the absent cgrp. Consume only the first
+                 * production stop here; the final completion stays local to
+                 * the helper below. */
                 rd_kafka_assignment_partition_stopped(rk, rktp0);
                 RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
                              "production completion should clear exactly one "
@@ -1387,10 +1401,11 @@ static int unittest_assignment_stop_pending(void) {
                 RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 1,
                              "production completion should decrement started "
                              "count once");
-                RD_UT_ASSERT(!rktp0->rktp_stop_pending && !rktp0->rktp_started,
+                RD_UT_ASSERT(!rktp0->rktp_wait_stop && !rktp0->rktp_started,
                              "production completion should clear the first "
                              "toppar");
-                RD_UT_ASSERT(rktp1->rktp_stop_pending && rktp1->rktp_started,
+                rd_kafka_toppar_destroy(rktp0);
+                RD_UT_ASSERT(rktp1->rktp_wait_stop && rktp1->rktp_started,
                              "production completion should leave the second "
                              "toppar pending");
 
@@ -1402,9 +1417,10 @@ static int unittest_assignment_stop_pending(void) {
                 RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
                              "final helper completion should clear "
                              "started_cnt");
-                RD_UT_ASSERT(!rktp1->rktp_stop_pending && !rktp1->rktp_started,
+                RD_UT_ASSERT(!rktp1->rktp_wait_stop && !rktp1->rktp_started,
                              "final helper completion should clear the second "
                              "toppar");
+                rd_kafka_toppar_destroy(rktp1);
         }
 
         rd_kafka_q_destroy_owner(test_ops);

--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -1295,7 +1295,7 @@ static int unittest_assignment_stop_pending(void) {
         RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
                      "non-started removal must not alter started_cnt");
         RD_UT_ASSERT(!rktp->rktp_wait_stop,
-                     "non-started removal must not mark stop-pending");
+                     "non-started removal must not set wait_stop");
         rd_kafka_toppar_destroy(rktp);
 
         rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
@@ -1313,7 +1313,7 @@ static int unittest_assignment_stop_pending(void) {
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
                      "first stop should increment wait_stop_cnt once");
         RD_UT_ASSERT(rktp->rktp_wait_stop,
-                     "first stop should mark the toppar stop-pending");
+                     "first stop should set wait_stop on the toppar");
         rd_kafka_toppar_destroy(rktp);
 
         rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
@@ -1346,7 +1346,7 @@ static int unittest_assignment_stop_pending(void) {
         RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
                      "completion should clear wait_stop_cnt");
         RD_UT_ASSERT(!rktp->rktp_wait_stop,
-                     "completion should clear stop-pending");
+                     "completion should clear wait_stop");
         RD_UT_ASSERT(!rktp->rktp_started, "completion should clear started");
         RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
                      "completion should decrement started_cnt");
@@ -1386,8 +1386,8 @@ static int unittest_assignment_stop_pending(void) {
                              "same removal round should await both stop "
                              "replies");
                 RD_UT_ASSERT(rktp0->rktp_wait_stop && rktp1->rktp_wait_stop,
-                             "same removal round should mark both toppars "
-                             "stop-pending");
+                             "same removal round should set wait_stop on both "
+                             "toppars");
 
                 /* In this no-cgrp fixture, consuming the final outstanding
                  * stop through the production path would complete assignment

--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -99,6 +99,7 @@
 #include "rdkafka_cgrp.h"
 #include "rdkafka_offset.h"
 #include "rdkafka_request.h"
+#include "rdunittest.h"
 
 
 static void rd_kafka_assignment_dump(rd_kafka_t *rk) {
@@ -376,11 +377,56 @@ static void rd_kafka_share_assignment_serve_removals(rd_kafka_t *rk) {
 
 
 /**
+ * @brief Request a started partition stop and mark it as awaiting a stop reply.
+ *
+ * rktp_started is cleared only when the stop reply is served, so a second
+ * removal pass may see rktp_started while the first stop is still outstanding.
+ * Keep the outstanding-stop state on the assignment thread instead of peeking
+ * at the broker thread's fetch state.
+ */
+static void rd_kafka_assignment_request_stop(rd_kafka_assignment_t *assignment,
+                                             rd_kafka_toppar_t *rktp,
+                                             rd_kafka_q_t *stop_replyq) {
+        if (!rktp->rktp_started || rktp->rktp_stop_pending)
+                return;
+
+        rd_assert(assignment->started_cnt > 0);
+        rktp->rktp_stop_pending = rd_true;
+        assignment->wait_stop_cnt++;
+        rd_kafka_toppar_op_fetch_stop(rktp, RD_KAFKA_REPLYQ(stop_replyq, 0));
+}
+
+
+/**
+ * @brief Mark a stop reply as served for the partition.
+ */
+static void rd_kafka_assignment_complete_stop(rd_kafka_assignment_t *assignment,
+                                              rd_kafka_toppar_t *rktp) {
+        rd_assert(assignment->wait_stop_cnt > 0);
+        assignment->wait_stop_cnt--;
+
+        rd_assert(rktp->rktp_stop_pending);
+        rktp->rktp_stop_pending = rd_false;
+
+        rd_assert(rktp->rktp_started);
+        rktp->rktp_started = rd_false;
+
+        rd_assert(assignment->started_cnt > 0);
+        assignment->started_cnt--;
+}
+
+
+/**
  * @brief Decommission all partitions in the removed list.
+ *
+ * stop_replyq is a raw queue pointer owned by the caller. Build a fresh
+ * rd_kafka_replyq_t for each FETCH_STOP request so every op owns a separate
+ * queue reference.
  *
  * @returns >0 if there are removal operations in progress, else 0.
  */
-static int rd_kafka_assignment_serve_removals(rd_kafka_t *rk) {
+static int rd_kafka_assignment_serve_removals0(rd_kafka_t *rk,
+                                               rd_kafka_q_t *stop_replyq) {
         rd_kafka_topic_partition_t *rktpar;
         int valid_offsets = 0;
 
@@ -401,14 +447,9 @@ static int rd_kafka_assignment_serve_removals(rd_kafka_t *rk) {
                     rk->rk_consumer.assignment.queried, rktpar->topic,
                     rktpar->partition);
 
-                if (rktp->rktp_started) {
-                        /* Partition was started, stop the fetcher. */
-                        rd_assert(rk->rk_consumer.assignment.started_cnt > 0);
-
-                        rd_kafka_toppar_op_fetch_stop(
-                            rktp, RD_KAFKA_REPLYQ(rk->rk_ops, 0));
-                        rk->rk_consumer.assignment.wait_stop_cnt++;
-                }
+                /* If the partition was started, stop the fetcher. */
+                rd_kafka_assignment_request_stop(&rk->rk_consumer.assignment,
+                                                 rktp, stop_replyq);
 
                 /* Reset the (lib) pause flag which may have been set by
                  * the cgrp when scheduling the rebalance callback. */
@@ -476,6 +517,12 @@ static int rd_kafka_assignment_serve_removals(rd_kafka_t *rk) {
                rk->rk_consumer.wait_commit_cnt;
 }
 
+
+static int rd_kafka_assignment_serve_removals(rd_kafka_t *rk) {
+        return rd_kafka_assignment_serve_removals0(rk, rk->rk_ops);
+}
+
+
 static void rd_kafka_share_assignment_serve_pending(rd_kafka_t *rk) {
         int i;
 
@@ -538,6 +585,7 @@ static int rd_kafka_assignment_serve_pending(rd_kafka_t *rk) {
                     rd_kafka_topic_partition_ensure_toppar(rk, rktpar, rd_true);
 
                 rd_assert(!rktp->rktp_started);
+                rd_assert(!rktp->rktp_stop_pending);
 
                 if (!RD_KAFKA_OFFSET_IS_LOGICAL(rktpar->offset) ||
                     rktpar->offset == RD_KAFKA_OFFSET_BEGINNING ||
@@ -1176,14 +1224,7 @@ rd_kafka_assignment_subtract(rd_kafka_t *rk,
  */
 void rd_kafka_assignment_partition_stopped(rd_kafka_t *rk,
                                            rd_kafka_toppar_t *rktp) {
-        rd_assert(rk->rk_consumer.assignment.wait_stop_cnt > 0);
-        rk->rk_consumer.assignment.wait_stop_cnt--;
-
-        rd_assert(rktp->rktp_started);
-        rktp->rktp_started = rd_false;
-
-        rd_assert(rk->rk_consumer.assignment.started_cnt > 0);
-        rk->rk_consumer.assignment.started_cnt--;
+        rd_kafka_assignment_complete_stop(&rk->rk_consumer.assignment, rktp);
 
         /* If this was the last partition we awaited stop for, serve the
          * assignment to transition any existing assignment to the next state */
@@ -1193,6 +1234,192 @@ void rd_kafka_assignment_partition_stopped(rd_kafka_t *rk,
                              "stopped: serving assignment");
                 rd_kafka_assignment_serve(rk);
         }
+}
+
+
+static rd_kafka_toppar_t *
+unittest_assignment_add_removed_partition(rd_kafka_t *rk,
+                                          const char *topic,
+                                          int32_t partition) {
+        rd_kafka_topic_partition_t *rktpar;
+        rd_kafka_toppar_t *rktp;
+
+        rktpar = rd_kafka_topic_partition_list_add(
+            rk->rk_consumer.assignment.removed, topic, partition);
+        rktp = rd_kafka_topic_partition_ensure_toppar(rk, rktpar, rd_true);
+
+        if (rktp) {
+                rd_kafka_toppar_lock(rktp);
+                rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_ASSIGNED;
+                rd_kafka_toppar_unlock(rktp);
+        }
+
+        return rktp;
+}
+
+
+static int unittest_assignment_stop_pending(void) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        rd_kafka_q_t *test_ops;
+        rd_kafka_toppar_t *rktp;
+        int32_t version;
+        char errstr[512];
+
+        conf = rd_kafka_conf_new();
+        rd_kafka_conf_set(conf, "enable.auto.commit", "false", NULL, 0);
+        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        RD_UT_ASSERT(rk, "failed to create consumer: %s", errstr);
+        test_ops = rd_kafka_q_new(rk);
+
+        /* A removal for a partition that was never started must not request
+         * FETCH_STOP or alter the assignment stop counters. */
+        rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
+        RD_UT_ASSERT(rktp, "failed to create toppar");
+        RD_UT_ASSERT(!RD_KAFKA_TOPPAR_IS_PAUSED(rktp),
+                     "test requires an unpaused partition so only FETCH_STOP "
+                     "bumps the version");
+        rk->rk_consumer.assignment.started_cnt = 1;
+        version = rd_atomic32_get(&rktp->rktp_version);
+        RD_UT_ASSERT(rd_kafka_assignment_serve_removals0(rk, test_ops) == 0,
+                     "non-started removal should have no outstanding work");
+        RD_UT_ASSERT(rd_atomic32_get(&rktp->rktp_version) == version,
+                     "non-started removal must not request FETCH_STOP");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
+                     "non-started removal must not increment wait_stop_cnt");
+        RD_UT_ASSERT(!rktp->rktp_stop_pending,
+                     "non-started removal must not mark stop-pending");
+
+        rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
+        RD_UT_ASSERT(rktp, "failed to re-add toppar to removed list");
+        RD_UT_ASSERT(!RD_KAFKA_TOPPAR_IS_PAUSED(rktp),
+                     "test requires an unpaused partition so only FETCH_STOP "
+                     "bumps the version");
+        rk->rk_consumer.assignment.started_cnt = 1;
+        rktp->rktp_started                     = rd_true;
+        version = rd_atomic32_get(&rktp->rktp_version);
+        rd_kafka_assignment_serve_removals0(rk, test_ops);
+        RD_UT_ASSERT(rd_atomic32_get(&rktp->rktp_version) == version + 1,
+                     "first started removal should request exactly one "
+                     "FETCH_STOP");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
+                     "first stop should increment wait_stop_cnt once");
+        RD_UT_ASSERT(rktp->rktp_stop_pending,
+                     "first stop should mark the toppar stop-pending");
+
+        rktp = unittest_assignment_add_removed_partition(rk, "rdut", 0);
+        RD_UT_ASSERT(rktp, "failed to re-add toppar to removed list");
+        /* Re-arm the exact pre-reply state before the duplicate removal.  The
+         * first removal above proves the production call site reaches
+         * FETCH_STOP; this state keeps the duplicate predicate deterministic
+         * without depending on asynchronous reply timing. */
+        rk->rk_consumer.assignment.wait_stop_cnt = 1;
+        rk->rk_consumer.assignment.started_cnt   = 1;
+        rktp->rktp_started                       = rd_true;
+        rktp->rktp_stop_pending                  = rd_true;
+        version = rd_atomic32_get(&rktp->rktp_version);
+        rd_kafka_assignment_serve_removals0(rk, test_ops);
+        RD_UT_ASSERT(rd_atomic32_get(&rktp->rktp_version) == version,
+                     "second removal before reply consumption must not request "
+                     "FETCH_STOP");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
+                     "duplicate removal must not increment wait_stop_cnt");
+
+        RD_UT_ASSERT(rktp->rktp_stop_pending,
+                     "completion fixture requires a pending stop");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
+                     "completion fixture requires one awaited stop");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 1,
+                     "completion fixture requires one started partition");
+        RD_UT_ASSERT(rktp->rktp_started,
+                     "completion fixture requires a started toppar");
+        rd_kafka_assignment_complete_stop(&rk->rk_consumer.assignment, rktp);
+        RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
+                     "completion should clear wait_stop_cnt");
+        RD_UT_ASSERT(!rktp->rktp_stop_pending,
+                     "completion should clear stop-pending");
+        RD_UT_ASSERT(!rktp->rktp_started, "completion should clear started");
+        RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
+                     "completion should decrement started_cnt");
+
+        {
+                rd_kafka_toppar_t *rktp0, *rktp1;
+                int32_t version0, version1;
+
+                rktp0 =
+                    unittest_assignment_add_removed_partition(rk, "rdut", 0);
+                rktp1 =
+                    unittest_assignment_add_removed_partition(rk, "rdut", 1);
+                RD_UT_ASSERT(rktp0 && rktp1,
+                             "failed to create two removed toppars");
+                RD_UT_ASSERT(!RD_KAFKA_TOPPAR_IS_PAUSED(rktp0) &&
+                                 !RD_KAFKA_TOPPAR_IS_PAUSED(rktp1),
+                             "test requires unpaused partitions so only "
+                             "FETCH_STOP bumps the versions");
+
+                rk->rk_consumer.assignment.started_cnt = 2;
+                rktp0->rktp_started                    = rd_true;
+                rktp1->rktp_started                    = rd_true;
+                version0 = rd_atomic32_get(&rktp0->rktp_version);
+                version1 = rd_atomic32_get(&rktp1->rktp_version);
+
+                rd_kafka_assignment_serve_removals0(rk, test_ops);
+                RD_UT_ASSERT(rd_atomic32_get(&rktp0->rktp_version) ==
+                                 version0 + 1,
+                             "first started partition in the same removal "
+                             "round should request one FETCH_STOP");
+                RD_UT_ASSERT(rd_atomic32_get(&rktp1->rktp_version) ==
+                                 version1 + 1,
+                             "second started partition in the same removal "
+                             "round should request one FETCH_STOP");
+                RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 2,
+                             "same removal round should await both stop "
+                             "replies");
+                RD_UT_ASSERT(rktp0->rktp_stop_pending &&
+                                 rktp1->rktp_stop_pending,
+                             "same removal round should mark both toppars "
+                             "stop-pending");
+
+                rd_kafka_assignment_partition_stopped(rk, rktp0);
+                RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 1,
+                             "production completion should clear exactly one "
+                             "waited stop");
+                RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 1,
+                             "production completion should decrement started "
+                             "count once");
+                RD_UT_ASSERT(!rktp0->rktp_stop_pending && !rktp0->rktp_started,
+                             "production completion should clear the first "
+                             "toppar");
+                RD_UT_ASSERT(rktp1->rktp_stop_pending && rktp1->rktp_started,
+                             "production completion should leave the second "
+                             "toppar pending");
+
+                rd_kafka_assignment_complete_stop(&rk->rk_consumer.assignment,
+                                                  rktp1);
+                RD_UT_ASSERT(rk->rk_consumer.assignment.wait_stop_cnt == 0,
+                             "final helper completion should clear "
+                             "wait_stop_cnt");
+                RD_UT_ASSERT(rk->rk_consumer.assignment.started_cnt == 0,
+                             "final helper completion should clear "
+                             "started_cnt");
+                RD_UT_ASSERT(!rktp1->rktp_stop_pending && !rktp1->rktp_started,
+                             "final helper completion should clear the second "
+                             "toppar");
+        }
+
+        rd_kafka_q_destroy_owner(test_ops);
+        rd_kafka_destroy_flags(rk, RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
+
+        RD_UT_PASS();
+}
+
+
+int unittest_assignment(void) {
+        int fails = 0;
+
+        fails += unittest_assignment_stop_pending();
+
+        return fails;
 }
 
 

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -398,11 +398,16 @@ struct rd_kafka_toppar_s {                           /* rd_kafka_toppar_t */
 
         rd_kafka_cgrp_t *rktp_cgrp; /* Belongs to this cgrp */
 
-        rd_bool_t rktp_started; /**< Fetcher is instructured to
-                                 *   start.
-                                 *   This is used by cgrp to keep
-                                 *   track of whether the toppar has
-                                 *   been started or not. */
+        rd_bool_t rktp_started;      /**< Fetcher is instructured to
+                                      *   start.
+                                      *   This is used by cgrp to keep
+                                      *   track of whether the toppar has
+                                      *   been started or not. */
+        rd_bool_t rktp_stop_pending; /**< Assignment-owned FETCH_STOP reply is
+                                      *   outstanding. This is used by the
+                                      *   assignment code to avoid counting
+                                      *   more than one stop reply for the
+                                      *   toppar. */
 
         rd_kafka_replyq_t rktp_replyq; /* Current replyq+version
                                         * for propagating

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -398,16 +398,16 @@ struct rd_kafka_toppar_s {                           /* rd_kafka_toppar_t */
 
         rd_kafka_cgrp_t *rktp_cgrp; /* Belongs to this cgrp */
 
-        rd_bool_t rktp_started;      /**< Fetcher is instructured to
-                                      *   start.
-                                      *   This is used by cgrp to keep
-                                      *   track of whether the toppar has
-                                      *   been started or not. */
-        rd_bool_t rktp_stop_pending; /**< Assignment-owned FETCH_STOP reply is
-                                      *   outstanding. This is used by the
-                                      *   assignment code to avoid counting
-                                      *   more than one stop reply for the
-                                      *   toppar. */
+        rd_bool_t rktp_started;   /**< Fetcher is instructed to
+                                   *   start.
+                                   *   This is used by cgrp to keep
+                                   *   track of whether the toppar has
+                                   *   been started or not. */
+        rd_bool_t rktp_wait_stop; /**< Assignment-owned FETCH_STOP reply is
+                                   *   outstanding. This is used by the
+                                   *   assignment code to avoid counting
+                                   *   more than one stop reply for the
+                                   *   toppar. */
 
         rd_kafka_replyq_t rktp_replyq; /* Current replyq+version
                                         * for propagating

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -437,6 +437,7 @@ extern int unittest_sasl_oauthbearer_oidc_assertion(void);
 extern int unittest_admin(void);
 extern int unittest_telemetry(void);
 extern int unittest_telemetry_decode(void);
+extern int unittest_assignment(void);
 #if WITH_SSL
 extern int unittest_ssl(void);
 #endif
@@ -488,6 +489,7 @@ int rd_unittest(void) {
             {"admin", unittest_admin},
             {"telemetry", unittest_telemetry},
             {"telemetry_decode", unittest_telemetry_decode},
+            {"assignment", unittest_assignment},
             {"fetcher_share_filter_forward",
              unittest_fetcher_share_filter_forward},
             {"share_acknowledge", unittest_share_acknowledge},


### PR DESCRIPTION
Description
===========

Fixes #5573.

During assignment removal, `rktp_started` remains true until the FETCH_STOP reply is served. A later removal pass can therefore enqueue and count another FETCH_STOP for the same started toppar.

This change adds assignment-owned `rktp_wait_stop` state. A stop request now sets the flag, increments `assignment.wait_stop_cnt`, and enqueues FETCH_STOP in one place; later removal passes skip that toppar until `rd_kafka_assignment_partition_stopped()` clears the flag and the existing started/wait counters. Each actual request constructs a fresh `RD_KAFKA_REPLYQ(...)`, preserving one queue reference per op.

Correctness notes
=================

- Assignment removals send their stop replies to `rk->rk_ops`. The cgrp termination path uses `RD_KAFKA_NO_REPLYQ`, while the synchronous stop path waits on a local `tmpq`, so the new completion state applies only to assignment replies.
- `rktp_wait_stop` has the same owner and access points as `rktp_started`; no new lock domain is introduced.
- The native unit test runs the production removal and completion entry points. It checks version-barrier deltas of `+1` for the first request, `0` for a duplicate before completion, and `+1` for each of two partitions in one removal pass. It does not poll the asynchronous reply or reproduce the crash timing; per-request replyq ownership is preserved by code structure rather than a dynamic refcount assertion.

Tests
=====

- `make -j8`
- `cd tests && RD_UT_TEST=assignment TESTS=0000 ./run-test.sh -p1`
- `cd tests && TESTS=0000 ./run-test.sh -p1`
- `make style-check-changed` with clang-format 18
