### PR TITLE
Upgrade bundled OpenSSL and libcurl, refresh Windows build toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # librdkafka v2.15.1 (unreleased)
 
 * Update bundled OpenSSL and libcurl dependencies, and refresh the Windows
-  build toolchain (msys2, vcpkg) (#).
+  build toolchain (msys2, vcpkg) (#5578).
 
 ## Security considerations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+
+# librdkafka v2.15.1 (unreleased)
+
+* Update bundled OpenSSL and libcurl dependencies, and refresh the Windows
+  build toolchain (msys2, vcpkg) (#).
+
+## Security considerations
+
+Bundled dependencies were further upgraded as follows:
+OpenSSL 3.5.6 → 3.5.7 for source/autoconf builds, and 3.6.2 → 3.6.3 for
+vcpkg-based packages; libcurl 8.20.0 → 8.21.0, now used by both
+source/autoconf builds and vcpkg (previously pinned to 8.19.0 in vcpkg,
+so vcpkg-based packages also pick up the fixes below that source/autoconf
+builds already got from 8.20.0).
+
+ * OpenSSL upgrade (3.5.6 → 3.5.7 for source/autoconf, 3.6.2 → 3.6.3 for
+   vcpkg) addresses:
+   * Both branches: CVE-2026-34180, CVE-2026-34181, CVE-2026-34182,
+     CVE-2026-34183, CVE-2026-42764, CVE-2026-42766, CVE-2026-42767,
+     CVE-2026-42768, CVE-2026-42769, CVE-2026-42770, CVE-2026-45445,
+     CVE-2026-45446, CVE-2026-45447, CVE-2026-7383, CVE-2026-9076.
+   * Only the vcpkg 3.6.2 → 3.6.3 branch (3.5.6/3.5.7 were not affected):
+     CVE-2026-35188, CVE-2026-42765.
+
+ * libcurl upgrade (8.20.0 → 8.21.0) addresses: CVE-2026-8286,
+   CVE-2026-8458, CVE-2026-8924, CVE-2026-8925, CVE-2026-8926,
+   CVE-2026-8927, CVE-2026-8932, CVE-2026-9079, CVE-2026-9080,
+   CVE-2026-9545, CVE-2026-9546, CVE-2026-9547, CVE-2026-10536,
+   CVE-2026-11352, CVE-2026-11564, CVE-2026-11586, CVE-2026-11856,
+   CVE-2026-12064.
+   Since libcurl is now at the same version (8.21.0) for both
+   source/autoconf and vcpkg builds, this also closes the gap noted in
+   the previous release, where vcpkg-pinned 8.19.0 still contained
+   CVE-2026-4873, CVE-2026-5545, CVE-2026-5773, CVE-2026-6253,
+   CVE-2026-6276, CVE-2026-6429, CVE-2026-7168.
+
+ * zlib vcpkg port revision bump (1.3.2#0 → 1.3.2#1): no upstream version
+   change and no associated CVE; packaging-only update.
+
+
+
 # librdkafka v2.15.0
 
 librdkafka v2.15.0 is a feature release:

--- a/mklove/modules/configure.libcurl
+++ b/mklove/modules/configure.libcurl
@@ -45,8 +45,8 @@ void foo (void) {
 function install_source {
     local name=$1
     local destdir=$2
-    local ver=8.20.0
-    local checksum="fc5819cad3f9f5482669adcdc49a782c15f36d2a0715b395b06d9173593d2dc0"
+    local ver=8.21.0
+    local checksum="d9b327997999045a24cda50f3983e69e51c516bd8be6ef9842fc7f99135e33bb"
 
     echo "### Installing $name $ver from source to $destdir"
     if [[ ! -f Makefile ]]; then

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -91,8 +91,8 @@ function manual_checks {
 function libcrypto_install_source {
     local name=$1
     local destdir=$2
-    local ver=3.5.6
-    local checksum="deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736"
+    local ver=3.5.7
+    local checksum="a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8"
     local url=https://github.com/openssl/openssl/releases/download/openssl-${ver}/openssl-${ver}.tar.gz
 
     local conf_args="--prefix=/usr --openssldir=/usr/lib/ssl no-shared no-zlib"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,15 +8,15 @@
         },
         {
             "name": "zlib",
-            "version>=": "1.3.2#0"
+            "version>=": "1.3.2#1"
         },
         {
             "name": "openssl",
-            "version>=": "3.6.2#0"
+            "version>=": "3.6.3#0"
         },
         {
             "name": "curl",
-            "version>=": "8.19.0#0"
+            "version>=": "8.21.0#1"
         }
     ],
     "builtin-baseline": "56765209ec0e92c58a5fd91aa09c46a16d660026"

--- a/win32/setup-msys2.ps1
+++ b/win32/setup-msys2.ps1
@@ -17,7 +17,10 @@ if (!(Test-Path -Path "c:\msys64\usr\bin\bash.exe")) {
     (New-Object System.Net.WebClient).DownloadFile($url, './msys2-installer.exe')
 
     # Verify checksum
-    (Get-FileHash -Algorithm "SHA256" .\msys2-installer.exe).hash -eq $sha256
+    $actualSha256 = (Get-FileHash -Algorithm "SHA256" .\msys2-installer.exe).hash
+    if ($actualSha256 -ne $sha256) {
+        throw "msys2 installer checksum mismatch: expected $sha256, got $actualSha256"
+    }
 
     # Install msys2
     .\msys2-installer.exe -y -oc:\

--- a/win32/setup-msys2.ps1
+++ b/win32/setup-msys2.ps1
@@ -1,8 +1,8 @@
 # Install (if necessary) and set up msys2.
 $ErrorActionPreference = "Stop"
 
-$url="https://github.com/msys2/msys2-installer/releases/download/2025-12-13/msys2-base-x86_64-20251213.sfx.exe"
-$sha256="99f2fee9a7b1c344600ac97347e7be23a1f802d8d843b339ec7473a8ed8d49a6"
+$url="https://github.com/msys2/msys2-installer/releases/download/2026-06-11/msys2-base-x86_64-20260611.sfx.exe"
+$sha256="c105946e64e08f099ac0e4647461ce762b95333ad211777666476a9a41451d65"
 $cacheKey = "msys2-$sha256-$Env:CACHE_TAG"
 $librdkafkaPath = Get-Location;
 

--- a/win32/setup-vcpkg.ps1
+++ b/win32/setup-vcpkg.ps1
@@ -1,5 +1,5 @@
 # Set up vcpkg and install required packages.
-$version = "2026.04.27"
+$version = "2026.07.29"
 $vpkgHash=(Get-FileHash ".\librdkafka\vcpkg.json").Hash
 $cacheKey = "vcpkg-$version-$Env:triplet-$vpkgHash-$Env:CACHE_TAG"
 $librdkafkaPath = ".\librdkafka";


### PR DESCRIPTION
## Summary
- Bump bundled OpenSSL to 3.5.7 (source/autoconf builds) and 3.6.3 (vcpkg), and libcurl to 8.21.0 for both source/autoconf and vcpkg builds (previously vcpkg was pinned to an older 8.19.0, so this also closes that gap).
- Refresh the Windows build toolchain: msys2 installer (2025-12-13 → 2026-06-11) and vcpkg tool (2026.04.27 → 2026.07.29).
- Bump the vcpkg zlib port revision (1.3.2#0 → 1.3.2#1); no upstream version change, packaging-only.
- Document the fixed CVEs in a new "Security considerations" section in CHANGELOG.md:
  - OpenSSL: 15 CVEs fixed on both the 3.5.x and 3.6.x branches, plus 2 more (CVE-2026-35188, CVE-2026-42765) that only affected the vcpkg 3.6.x branch.
  - libcurl: 18 CVEs fixed in 8.21.0 (CVE-2026-8286 through CVE-2026-12064), the largest curl security release to date.

## Test plan
- [ ] CI build passes (source/autoconf and CMake/vcpkg configurations, including Windows)
- [ ] Verify `./configure` picks up libcurl 8.21.0 and OpenSSL 3.5.7 checksums correctly
- [ ] Verify vcpkg manifest resolves openssl 3.6.3, curl 8.21.0, zlib 1.3.2#1 on Windows CI