### PR TITLE
Report the MessageSet end offset on batch errors

### DIFF
--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -262,6 +262,50 @@ static void rd_kafka_msgset_reader_init(rd_kafka_msgset_reader_t *msetr,
 
 
 /**
+ * @brief Propagate a MessageSet-level error, including the MessageSet's last
+ *        offset so the application can seek past the MessageSet.
+ *
+ * @param offset_verified rd_false if \p LastOffsetDelta may be corrupt.
+ * @remark Regular consumer only, see rd_kafka_share_msgset_err_ops().
+ */
+static void RD_FORMAT(printf, 6, 7)
+    rd_kafka_msgset_reader_batch_err(rd_kafka_msgset_reader_t *msetr,
+                                     rd_kafka_resp_err_t err,
+                                     int64_t BaseOffset,
+                                     int32_t LastOffsetDelta,
+                                     rd_bool_t offset_verified,
+                                     const char *fmt,
+                                     ...) {
+        char reason[512];
+        va_list ap;
+
+        va_start(ap, fmt);
+        rd_vsnprintf(reason, sizeof(reason), fmt, ap);
+        va_end(ap);
+
+        /* A corrupt LastOffsetDelta must not yield an end offset that
+         * overflows or precedes the start of the MessageSet. */
+        if (unlikely(LastOffsetDelta < 0 ||
+                     BaseOffset > INT64_MAX - LastOffsetDelta)) {
+                rd_kafka_consumer_err(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, NULL, msetr->msetr_rktp,
+                    BaseOffset,
+                    "%s: MessageSet end offset could not be determined",
+                    reason);
+                return;
+        }
+
+        rd_kafka_consumer_err(
+            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+            msetr->msetr_tver->version, NULL, msetr->msetr_rktp, BaseOffset,
+            "%s: MessageSet ends at offset %" PRId64 "%s", reason,
+            BaseOffset + LastOffsetDelta,
+            offset_verified ? "" : " (unverified)");
+}
+
+
+/**
  * @brief Decompress MessageSet, pass the uncompressed MessageSet to
  *        the MessageSet reader.
  */
@@ -519,12 +563,23 @@ err:
          * Create op and push on temporary queue. */
         if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
                 /* Regular consumer */
-                rd_kafka_consumer_err(
-                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
-                    msetr->msetr_tver->version, NULL, rktp, Offset,
-                    "Decompression (codec 0x%x) of message at %" PRIu64
-                    " of %" PRIusz " bytes failed: %s",
-                    codec, Offset, compressed_size, rd_kafka_err2str(err));
+                if (msetr->msetr_v2_hdr) {
+                        /* The entire MessageSet is compressed as one unit */
+                        rd_kafka_msgset_reader_batch_err(
+                            msetr, err, msetr->msetr_v2_hdr->BaseOffset,
+                            msetr->msetr_v2_hdr->LastOffsetDelta, rd_true,
+                            "Decompression (codec 0x%x) of MessageSet of "
+                            "%" PRIusz " bytes failed: %s",
+                            codec, compressed_size, rd_kafka_err2str(err));
+                } else {
+                        rd_kafka_consumer_err(
+                            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                            msetr->msetr_tver->version, NULL, rktp, Offset,
+                            "Decompression (codec 0x%x) of message at %" PRIu64
+                            " of %" PRIusz " bytes failed: %s",
+                            codec, Offset, compressed_size,
+                            rd_kafka_err2str(err));
+                }
                 return err;
         } else {
                 /**
@@ -1043,6 +1098,25 @@ err_parse:
 
 
 /**
+ * @brief Propagate a record-level parse failure within a MessageSet v2 as a
+ *        MessageSet-level error, the remaining records can't be parsed.
+ */
+static void rd_kafka_msgset_reader_records_err(rd_kafka_msgset_reader_t *msetr,
+                                               rd_kafka_resp_err_t err) {
+        /* Underflow is a partial response from the broker, not a corruption */
+        if (err == RD_KAFKA_RESP_ERR__UNDERFLOW || !msetr->msetr_v2_hdr ||
+            RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk))
+                return;
+
+        rd_kafka_msgset_reader_batch_err(
+            msetr, err, msetr->msetr_v2_hdr->BaseOffset,
+            msetr->msetr_v2_hdr->LastOffsetDelta, rd_true,
+            "Failed to parse messages in MessageSet: %s",
+            rd_kafka_err2str(err));
+}
+
+
+/**
  * @brief Read v2 messages from current buffer position.
  */
 static rd_kafka_resp_err_t
@@ -1091,8 +1165,10 @@ rd_kafka_msgset_reader_msgs_v2(rd_kafka_msgset_reader_t *msetr) {
         while (rd_kafka_buf_read_remain(msetr->msetr_rkbuf)) {
                 rd_kafka_resp_err_t err;
                 err = rd_kafka_msgset_reader_msg_v2(msetr);
-                if (unlikely(err))
+                if (unlikely(err)) {
+                        rd_kafka_msgset_reader_records_err(msetr, err);
                         return err;
+                }
         }
 
         return RD_KAFKA_RESP_ERR_NO_ERROR;
@@ -1100,6 +1176,7 @@ rd_kafka_msgset_reader_msgs_v2(rd_kafka_msgset_reader_t *msetr) {
 err_parse:
         /* Count all parse errors as partial message errors. */
         rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_partial, 1);
+        rd_kafka_msgset_reader_records_err(msetr, rkbuf->rkbuf_err);
         msetr->msetr_v2_hdr = NULL;
         return rkbuf->rkbuf_err;
 }
@@ -1163,19 +1240,25 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                          * continue with next message. */
                         if (!RD_KAFKA_IS_SHARE_CONSUMER(
                                 msetr->msetr_rkb->rkb_rk)) {
-                                rd_kafka_consumer_err(
-                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
-                                    RD_KAFKA_RESP_ERR__BAD_MSG,
-                                    msetr->msetr_tver->version, NULL, rktp,
-                                    hdr.BaseOffset,
-                                    "MessageSet at offset %" PRId64 " (%" PRId32
-                                    " bytes) "
-                                    "failed CRC32C check "
+                                int32_t LastOffsetDelta;
+
+                                /* LastOffsetDelta follows the Attributes
+                                 * (2 bytes) at the current read position.
+                                 * It is CRC-covered, hence unverified. */
+                                rd_kafka_buf_peek_i32(
+                                    rkbuf,
+                                    rd_slice_offset(&rkbuf->rkbuf_reader) + 2,
+                                    &LastOffsetDelta);
+
+                                rd_kafka_msgset_reader_batch_err(
+                                    msetr, RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    hdr.BaseOffset, LastOffsetDelta, rd_false,
+                                    "MessageSet (%" PRId32
+                                    " bytes) failed CRC32C check "
                                     "(original 0x%" PRIx32
                                     " != "
                                     "calculated 0x%" PRIx32 ")",
-                                    hdr.BaseOffset, hdr.Length, hdr.Crc,
-                                    calc_crc);
+                                    hdr.Length, hdr.Crc, calc_crc);
                                 /* Skip to end of MessageSet */
                                 /**
                                  * FIXME: `crc_len` is a byte *length*

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -198,7 +198,6 @@ static void ut_write_msgset_v2_header(char *buf,
         offset += 4;
 }
 
-#if WITH_ZSTD
 /**
  * @brief Calculate correct CRC32C for MessageSet v2
  *        CRC covers from Attributes to end of records
@@ -211,7 +210,6 @@ static uint32_t ut_calc_msgset_crc(const char *buf,
         size_t data_len  = total_len - offset_to_attributes;
         return rd_crc32c(0, data, data_len);
 }
-#endif /* WITH_ZSTD */
 
 /**
  * @brief Write a varint (used in Record format)
@@ -1493,6 +1491,231 @@ static int unittest_msgset_all_error_types_with_valid(void) {
 /**
  * @brief Run all MessageSet error handling unit tests
  */
+/**
+ * @name Regular consumer MessageSet v2 batch errors
+ * @{
+ *
+ * A failed MessageSet v2 can't be consumed and the fetch position is not
+ * advanced past it, so the error must carry the MessageSet's last offset for
+ * the application to be able to seek past it.
+ */
+
+/* Offset of the Crc and Attributes fields in a MessageSet v2 header */
+#define UT_MSGSET_V2_CRC_OFFSET  17
+#define UT_MSGSET_V2_ATTR_OFFSET 21
+
+/**
+ * @brief Create a minimal regular (non-share) consumer for testing
+ */
+static rd_kafka_t *ut_create_test_consumer(void) {
+        rd_kafka_conf_t *conf = rd_kafka_conf_new();
+        char errstr[512];
+
+        if (rd_kafka_conf_set(conf, "check.crcs", "true", errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
+                return NULL;
+        }
+
+        return rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+}
+
+/**
+ * @brief Pop the batch error op from \p rkq and verify its error code, offset
+ *        and that its error string contains \p exp_substr.
+ *
+ * @returns 0 on success, 1 on failure.
+ */
+static int ut_verify_batch_err(rd_kafka_q_t *rkq,
+                               rd_kafka_resp_err_t exp_err,
+                               int64_t exp_offset,
+                               const char *exp_substr) {
+        rd_kafka_op_t *rko = rd_kafka_q_pop(rkq, 1000, 0);
+
+        RD_UT_ASSERT(rko != NULL, "Expected an error op, got timeout");
+        RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                     "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+        RD_UT_ASSERT(rko->rko_err == exp_err, "Expected %s, got %s",
+                     rd_kafka_err2str(exp_err), rd_kafka_err2str(rko->rko_err));
+        RD_UT_ASSERT(rko->rko_u.err.offset == exp_offset,
+                     "Expected offset %" PRId64 ", got %" PRId64, exp_offset,
+                     rko->rko_u.err.offset);
+        RD_UT_ASSERT(rko->rko_u.err.errstr &&
+                         strstr(rko->rko_u.err.errstr, exp_substr),
+                     "Expected error string to contain \"%s\", got: %s",
+                     exp_substr, rko->rko_u.err.errstr);
+        rd_kafka_op_destroy(rko);
+
+        return 0;
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test that a decompression failure reports the MessageSet end offset
+ */
+static int unittest_msgset_decompression_error_end_offset(void) {
+        rd_kafka_t *rk;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        char *msgset_data;
+        size_t msgset_size               = 200;
+        int64_t BaseOffset               = 200;
+        int32_t LastOffsetDelta          = 2; /* Offsets 200-202 */
+        struct rd_kafka_toppar_ver tver  = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rk = ut_create_test_consumer();
+        RD_UT_ASSERT(rk, "Failed to create consumer");
+
+        rktp = ut_create_mock_toppar(rk, "test-topic-decompress-regular", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        /* MessageSet v2 with ZSTD compression but corrupted compressed data */
+        msgset_data = rd_calloc(1, msgset_size);
+        ut_write_msgset_v2_header(msgset_data, BaseOffset,
+                                  (int32_t)msgset_size - 12, -1, /* PLE */
+                                  2,                             /* MagicByte */
+                                  0, /* Crc, set below */
+                                  4, /* Attributes: ZSTD */
+                                  LastOffsetDelta, 0, 0, -1, -1, -1, 3);
+        memset(msgset_data + 61, 0xAB, msgset_size - 61);
+        ut_put_be32(msgset_data + UT_MSGSET_V2_CRC_OFFSET,
+                    ut_calc_msgset_crc(msgset_data, UT_MSGSET_V2_ATTR_OFFSET,
+                                       msgset_size));
+
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rk);
+
+        rd_kafka_msgset_parse(rkbuf, NULL, rktp, NULL, &tver);
+
+        if (ut_verify_batch_err(rktp->rktp_fetchq,
+                                RD_KAFKA_RESP_ERR__BAD_COMPRESSION, BaseOffset,
+                                "MessageSet ends at offset 202"))
+                return 1;
+
+        RD_UT_ASSERT(rd_kafka_q_pop(rktp->rktp_fetchq, 100, 0) == NULL,
+                     "Expected the MessageSet to be reported once");
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_toppar_destroy(rktp);
+        rd_kafka_destroy(rk);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Test that a CRC failure reports the MessageSet end offset, flagged
+ *        as unverified since it is read from the failed CRC region
+ */
+static int unittest_msgset_crc_error_end_offset(void) {
+        rd_kafka_t *rk;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        char *msgset_data;
+        size_t msgset_size              = 61;
+        int64_t BaseOffset              = 100;
+        int32_t LastOffsetDelta         = 4; /* Offsets 100-104 */
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rk = ut_create_test_consumer();
+        RD_UT_ASSERT(rk, "Failed to create consumer");
+
+        rktp = ut_create_mock_toppar(rk, "test-topic-crc-regular", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        /* MessageSet v2 with an intentionally wrong CRC */
+        msgset_data = rd_calloc(1, msgset_size);
+        ut_write_msgset_v2_header(msgset_data, BaseOffset,
+                                  (int32_t)msgset_size - 12, -1, /* PLE */
+                                  2,                             /* MagicByte */
+                                  0xDEADBEEF,                    /* Wrong Crc */
+                                  0, /* Attributes: no compression */
+                                  LastOffsetDelta, 0, 0, -1, -1, -1, 5);
+
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rk);
+
+        rd_kafka_msgset_parse(rkbuf, NULL, rktp, NULL, &tver);
+
+        if (ut_verify_batch_err(rktp->rktp_fetchq, RD_KAFKA_RESP_ERR__BAD_MSG,
+                                BaseOffset,
+                                "MessageSet ends at offset 104 (unverified)"))
+                return 1;
+
+        /* Not asserting a single op here: the CRC branch skips to the wrong
+         * position (see the FIXME on rd_kafka_buf_skip_to() in
+         * rd_kafka_msgset_reader_v2()) and parses the trailing bytes as
+         * another MessageSet, which emits a second, bogus error op. */
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_toppar_destroy(rktp);
+        rd_kafka_destroy(rk);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test that a record parse failure within a MessageSet reports the
+ *        MessageSet end offset
+ */
+static int unittest_msgset_record_error_end_offset(void) {
+        rd_kafka_t *rk;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset              = 300; /* Offsets 300-302 */
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rk = ut_create_test_consumer();
+        RD_UT_ASSERT(rk, "Failed to create consumer");
+
+        rktp = ut_create_mock_toppar(rk, "test-topic-record-regular", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        /* Valid MessageSet turned into a control batch: its records have no
+         * key, which the control message parser rejects as an invalid key
+         * size, failing the record parse with a valid CRC. */
+        msgset_data = rd_calloc(1, 8192);
+        msgset_size = ut_build_valid_msgset_v2(msgset_data, BaseOffset, 3, NULL,
+                                               NULL);
+        ut_put_be16(msgset_data + UT_MSGSET_V2_ATTR_OFFSET,
+                    RD_KAFKA_MSGSET_V2_ATTR_CONTROL);
+        ut_put_be32(msgset_data + UT_MSGSET_V2_CRC_OFFSET,
+                    ut_calc_msgset_crc(msgset_data, UT_MSGSET_V2_ATTR_OFFSET,
+                                       msgset_size));
+
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rk);
+
+        rd_kafka_msgset_parse(rkbuf, NULL, rktp, NULL, &tver);
+
+        if (ut_verify_batch_err(rktp->rktp_fetchq, RD_KAFKA_RESP_ERR__BAD_MSG,
+                                BaseOffset, "MessageSet ends at offset 302"))
+                return 1;
+
+        RD_UT_ASSERT(rd_kafka_q_pop(rktp->rktp_fetchq, 100, 0) == NULL,
+                     "Expected the MessageSet to be reported once");
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_toppar_destroy(rktp);
+        rd_kafka_destroy(rk);
+
+        RD_UT_PASS();
+}
+
+/**@}*/
+
+
 int rd_kafka_unittest_msgset_errors(void) {
         int fails = 0;
 
@@ -1516,6 +1739,13 @@ int rd_kafka_unittest_msgset_errors(void) {
 #if WITH_ZSTD
         fails += unittest_msgset_all_error_types_with_valid();
 #endif
+
+        /* Regular consumer: MessageSet end offset reporting */
+#if WITH_ZSTD
+        fails += unittest_msgset_decompression_error_end_offset();
+#endif
+        fails += unittest_msgset_crc_error_end_offset();
+        fails += unittest_msgset_record_error_end_offset();
 
         return fails;
 }


### PR DESCRIPTION
## Why

When a MessageSet v2 can't be read, the fetch position is not advanced past it, so the consumer keeps re-fetching the same batch. The error carried only the BaseOffset, and since a batch spans many offsets that isn't enough to seek past it — applications had no way to skip the bad batch.

## What

Report the MessageSet's last offset in the error, for three failures on the regular consumer:

- decompression failures
- CRC32C failures
- record parse failures within a batch, which previously produced no error op at all: the consumer stalled silently, visible only with `debug=protocol`

Errors now read `...: MessageSet ends at offset 202`. On the CRC path the offset is read from bytes covered by the CRC that just failed, so it is marked `(unverified)`; a delta that is negative or would overflow reports `MessageSet end offset could not be determined` instead.

Share consumer behaviour is unchanged — it already reports the offset range through `rd_kafka_share_msgset_err_ops()`.

## Verification

- Three unit tests added to the `msgset_errors` unit test, one per path, asserting the error code, the error's offset and the end offset in the message.
- Full unit test suite passes (336 tests).
- `make style-check` not run: no `clang-format` available in the dev environment.
