### PR TITLE
Fix left-shift-of-negative-value UB in the i64 varint zig-zag encoder

### DIFF
--- a/src/rdvarint.h
+++ b/src/rdvarint.h
@@ -68,7 +68,8 @@ static RD_INLINE RD_UNUSED size_t rd_uvarint_enc_u64(char *dst,
 static RD_INLINE RD_UNUSED size_t rd_uvarint_enc_i64(char *dst,
                                                      size_t dstsize,
                                                      int64_t num) {
-        return rd_uvarint_enc_u64(dst, dstsize, (num << 1) ^ (num >> 63));
+        return rd_uvarint_enc_u64(dst, dstsize,
+                                  ((uint64_t)num << 1) ^ (uint64_t)(num >> 63));
 }
 
 


### PR DESCRIPTION
Fixes GH-5395.

`rd_uvarint_enc_i64()` zig-zag encodes a signed `int64_t` by computing `(num << 1) ^ (num >> 63)`. When `num` is negative, that `num << 1` is a left shift of a negative value, which is undefined behavior in C. UBSan flags it every time a negative number gets varint-encoded, which happens on the regular message path (message header values, produce-batch offsets, timestamp deltas), so anyone building with `-fsanitize=undefined` hits it constantly.

The fix casts to `uint64_t` before the left shift, and casts the (still signed, arithmetic) right shift's result afterward. This is the same construct protobuf's `WireFormatLite::ZigZagEncode64` uses for the identical case, so it's a well-trodden fix rather than something novel.

Verified two ways:
- Built the whole project and ran the existing unit test suite (`TESTS=0000 ./test-runner`), which includes `rdvarint.c`'s `unittest_rdvarint()` covering both positive and negative values (0, 1, -1, 23, -23, 253, +/-1234567890101112) against exact expected byte output. All pass unchanged with the fix.
- Wrote a standalone harness reproducing just the two versions of the function and ran both under `-fsanitize=undefined -fno-sanitize-recover=all`: the original aborts immediately on the first negative test case with "left shift of negative value -1", the fixed version runs clean through the same vectors with byte-identical output.

No functional change for any input, this only removes the undefined behavior.
